### PR TITLE
Fix franchise overwrite on upsert when no resolver match

### DIFF
--- a/py/upsert_path_metadata_jsonl.py
+++ b/py/upsert_path_metadata_jsonl.py
@@ -95,7 +95,9 @@ def main() -> int:
 
             merged = merge_data(existing, rec, args.source)
             merged["genre"] = resolve_genre(merged)
-            merged["franchise"] = resolve_franchise(merged, args.franchise_rules or None)
+            resolved_franchise = resolve_franchise(merged, args.franchise_rules or None)
+            if resolved_franchise is not None:
+                merged["franchise"] = resolved_franchise
             data_json = json.dumps(merged, ensure_ascii=False)
             to_upsert.append((path_id, args.source, data_json, updated_at))
 


### PR DESCRIPTION
### Motivation
- Prevent data loss where an unresolved franchise lookup (`None`) could silently erase an existing or reviewer-provided `franchise` value during upsert, which violated the intended merge/preserve semantics.

### Description
- Updated `py/upsert_path_metadata_jsonl.py` to store the resolver result in `resolved_franchise` and only set `merged["franchise"]` when `resolved_franchise` is not `None`, preserving prior `franchise` values when no rule/path match is found.

### Testing
- Ran `python -m compileall py/upsert_path_metadata_jsonl.py` which completed successfully.
- Executed a short Python simulation (with `sys.path.append('py')`) that calls `merge_data`, `resolve_genre`, and `resolve_franchise`, and confirmed an existing `franchise` value remains unchanged when the resolver returns `None`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a925247cac83298f9229139b171baf)