### PR TITLE
feat: rename layout `by_series` → `by_title` with legacy alias normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,17 +751,17 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 
 | ジャンル               | 振り分け先                     | レイアウト                |
 | ---------------------- | ------------------------------ | ------------------------- |
-| 特撮                   | `N:\`                        | `by_series`             |
-| アニメ                 | `D:\Anime`                   | `by_series` [※](#5)    |
+| 特撮                   | `N:\`                        | `by_title`              |
+| アニメ                 | `D:\Anime`                   | `by_title` [※](#5)      |
 | 映画                   | `L:\`                        | `by_syllabary`          |
-| ドラマ                 | `E:\Dドラマ`                 | `by_series` [※](#5)    |
+| ドラマ                 | `E:\Dドラマ`                 | `by_title` [※](#5)      |
 | ドキュメンタリー・情報 | `E:\Dドキュメンタリー･情報` | `by_program_year_month` |
 | バラエティ             | `E:\Bバラエティ`             | `by_program_year_month` |
 | ニュース・報道         | `E:\Nニュース・報道`         | `by_program_year_month` |
 | 放送大学               | `B:\放送大学`                | `by_program_year_month` |
 | (デフォルト)           | `B:\VideoLibrary`            | `by_program_year_month` |
 
-> **※** アニメ・ドラマのレイアウト移行 → [#5](https://github.com/NEXTAltair/video-library-pipeline/issues/5)。レイアウト名のリネーム → [#2](https://github.com/NEXTAltair/video-library-pipeline/issues/2)
+> **※** アニメ・ドラマのレイアウト移行 → [#5](https://github.com/NEXTAltair/video-library-pipeline/issues/5)。`by_series` は後方互換エイリアスとして `by_title` に正規化される。
 
 ### レイアウトタイプ
 
@@ -769,10 +769,10 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 | ------------------------- | ------------------------------------------------ | ----------------------------------- |
 | `by_program_year_month` | `<root>/<program_title>/<year>/<month>/<file>` | 大部分のジャンルで使用              |
 | `by_syllabary`          | `<root>/<五十音フォルダ(ア,カ,サ…)>/<file>`   | 映画                                |
-| `by_series`             | `<root>/<program_title>/<file>` (年月なし)     | 特撮 (既存シリーズフォルダにマッチ) |
+| `by_title`              | `<root>/<program_title>/<file>` (年月なし)     | 特撮 (既存シリーズフォルダにマッチ) |
 | `flat`                  | `<root>/<file>`                                | (現在未使用)                        |
 
-> `by_series` と `by_syllabary` はシンプルな実装済み。改善計画 → [#2](https://github.com/NEXTAltair/video-library-pipeline/issues/2), [#5](https://github.com/NEXTAltair/video-library-pipeline/issues/5)
+> `by_syllabary` はシンプルな実装済み。`by_series` は後方互換名として受け付けつつ内部で `by_title` に正規化する。
 
 ---
 

--- a/py/path_placement_rules.py
+++ b/py/path_placement_rules.py
@@ -94,7 +94,7 @@ class DriveRoute:
     def __init__(self, data: dict[str, Any]):
         self.genre: str = str(data.get("genre") or "")
         self.dest_root: str = str(data.get("dest_root") or "").rstrip("\\")
-        self.layout: str = str(data.get("layout") or "by_program_year_month")
+        self.layout: str = normalize_layout_name(str(data.get("layout") or "by_program_year_month"))
         self.epg_genre_match: list[str] = data.get("epg_genre_match") or []
         self.title_patterns: list[str] = data.get("title_patterns") or []
 
@@ -172,7 +172,7 @@ def load_drive_routes(yaml_path: str | Path) -> DriveRoutes:
     data = _load_yaml_file(p)
 
     default_dest = str(data.get("default_dest") or "")
-    default_layout = str(data.get("default_layout") or "by_program_year_month")
+    default_layout = normalize_layout_name(str(data.get("default_layout") or "by_program_year_month"))
     routes = [DriveRoute(r) for r in data.get("routes", []) if r.get("genre")]
 
     return DriveRoutes(default_dest=default_dest, default_layout=default_layout, routes=routes)
@@ -193,6 +193,13 @@ _SYLLABARY_RANGES = [
     ("ラ", "ラ", "ロ"),  # ラ行
     ("ワ", "ワ", "ン"),  # ワ行
 ]
+
+
+def normalize_layout_name(layout: str) -> str:
+    """Normalize layout aliases to canonical names."""
+    if layout == "by_series":
+        return "by_title"
+    return layout
 
 
 def _title_to_syllabary_folder(title: str) -> str:
@@ -258,8 +265,8 @@ def build_routed_dest_path(
         folder = _title_to_syllabary_folder(prog_title)
         dst = f"{dest_root}\\{folder}\\{filename}"
 
-    elif layout == "by_series":
-        # Use program_title as series folder name
+    elif layout == "by_title":
+        # Use program_title as title folder name (legacy alias: by_series)
         series_dir = safe_dir_name(prog_title, maxlen=80)
         dst = f"{dest_root}\\{series_dir}\\{filename}"
 


### PR DESCRIPTION
### Motivation
- Standardize layout naming by introducing a canonical `by_title` layout for title-folder placement while preserving backward compatibility with existing `by_series` routes.

### Description
- Add `normalize_layout_name(layout)` to map the legacy `by_series` alias to `by_title` and apply it to `DriveRoute.layout` and loaded `default_layout` in `py/path_placement_rules.py`.
- Change the routed destination builder to handle the canonical `by_title` branch (previously named `by_series`) and document the behavior in a comment.
- Update `README.md` routing table and layout documentation to use `by_title` and note that `by_series` is accepted as a backward-compatible alias.

### Testing
- Ran `python -m py_compile py/path_placement_rules.py` and it succeeded.
- Executed an inline Python script that imports the module, verifies `normalize_layout_name('by_series') == 'by_title'`, constructs a `DriveRoutes`/`DriveRoute` with legacy `by_series`, and asserts `build_routed_dest_path` produces the expected title-folder destination; the script completed successfully and printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92f764280832987f4e2749c33a824)