### PR TITLE
refactor: rename source='llm' → 'rule_based' and add DB migration (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ relocateフロー専用の複合オーケストレーター。内部で relocate
 | `sourceJsonlPath`       | string  | レビュー済みJSONLのパス（生ファイル名は拒否される）        |
 | `markHumanReviewed`     | boolean | `human_reviewed=true` を付与 (default: true)             |
 | `allowNoContentChanges` | boolean | 内容未変更でも適用を許可 (default: false)                  |
-| `source`                | string  | `path_metadata.source` に記録する値 (default: `"llm"`) |
+| `source`                | string  | `path_metadata.source` に記録する値 (default: `"rule_based"`) |
 
 **安全機構:** apply前に自動DBバックアップ + ローテーション (最新10世代)。適用成功後、`program_aliases_review_*.yaml` をアーカイブに移動。
 
@@ -733,11 +733,11 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 
 | source値         | 意味                    | 生成元                               |
 | ---------------- | ----------------------- | ------------------------------------ |
-| `llm`          | ルールベース抽出        | `run_metadata_batches_promptv1.py` |
+| `rule_based`   | ルールベース抽出        | `run_metadata_batches_promptv1.py` |
 | `llm_subagent` | LLMサブエージェント抽出 | `apply_llm_extract_output.py`      |
 | `edcb_epg`     | EPG取り込み             | `ingest_program_txt.py`            |
 
-> **既知の問題:** `source='llm'` は歴史的命名の残滓。→ [#3](https://github.com/NEXTAltair/video-library-pipeline/issues/3)
+> `source='rule_based'` はルールベース抽出の結果を示す。旧値 `llm` は移行スクリプトで `rule_based` に統一可能。
 
 ### is_current 運用
 

--- a/py/migrate_source_llm_to_rule_based.py
+++ b/py/migrate_source_llm_to_rule_based.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Migrate source='llm' → 'rule_based' in path_metadata.
+
+Updates:
+1. path_metadata.source column: 'llm' → 'rule_based'
+2. data_json内のsource_history entries: "source":"llm" → "source":"rule_based"
+
+Usage:
+  python migrate_source_llm_to_rule_based.py --db mediaops.sqlite --dry-run
+  python migrate_source_llm_to_rule_based.py --db mediaops.sqlite
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from mediaops_schema import begin_immediate, connect_db
+
+
+FROM_SOURCE = "llm"
+TO_SOURCE = "rule_based"
+
+
+def _rewrite_source_history(data: object) -> tuple[object, bool]:
+    if not isinstance(data, dict):
+        return data, False
+
+    source_history = data.get("source_history")
+    if not isinstance(source_history, list):
+        return data, False
+
+    changed = False
+    for entry in source_history:
+        if isinstance(entry, dict) and entry.get("source") == FROM_SOURCE:
+            entry["source"] = TO_SOURCE
+            changed = True
+
+    return data, changed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    con = connect_db(args.db)
+    col_count = con.execute(
+        "SELECT COUNT(*) AS c FROM path_metadata WHERE source=?",
+        (FROM_SOURCE,),
+    ).fetchone()["c"]
+
+    rows = con.execute(
+        "SELECT path_id, data_json FROM path_metadata WHERE data_json IS NOT NULL"
+    ).fetchall()
+
+    json_updates: list[tuple[str, str]] = []
+    for r in rows:
+        raw = r["data_json"]
+        try:
+            data = json.loads(str(raw))
+        except Exception:
+            continue
+
+        data, changed = _rewrite_source_history(data)
+        if changed:
+            json_updates.append((json.dumps(data, ensure_ascii=False), str(r["path_id"])))
+
+    report = {
+        "ok": True,
+        "dryRun": args.dry_run,
+        "sourceColumnRows": int(col_count),
+        "sourceHistoryRows": len(json_updates),
+    }
+
+    if args.dry_run:
+        print(json.dumps(report, ensure_ascii=False))
+        con.close()
+        return 0
+
+    begin_immediate(con)
+    if col_count:
+        con.execute(
+            "UPDATE path_metadata SET source=? WHERE source=?",
+            (TO_SOURCE, FROM_SOURCE),
+        )
+    if json_updates:
+        con.executemany(
+            "UPDATE path_metadata SET data_json=? WHERE path_id=?",
+            json_updates,
+        )
+    con.commit()
+    con.close()
+
+    print(json.dumps(report, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -653,7 +653,7 @@ def main() -> int:
 
             row["genre"] = resolve_genre(row)
             row["franchise"] = resolve_franchise(row, args.franchise_rules or None)
-            row["source_history"] = [make_entry("llm", [k for k, v in row.items() if v is not None and k not in {"path_id", "path"}])]
+            row["source_history"] = [make_entry("rule_based", [k for k, v in row.items() if v is not None and k not in {"path_id", "path"}])]
 
             enforce_db_contract(row)
             rows.append(row)
@@ -668,7 +668,7 @@ def main() -> int:
         from upsert_path_metadata_jsonl import main as _upsert_main  # type: ignore
         import sys
 
-        sys.argv = ["upsert", "--db", args.db, "--in", str(epath), "--source", "llm"]
+        sys.argv = ["upsert", "--db", args.db, "--in", str(epath), "--source", "rule_based"]
         if args.franchise_rules:
             sys.argv += ["--franchise-rules", args.franchise_rules]
         if _upsert_main() != 0:

--- a/py/upsert_path_metadata_jsonl.py
+++ b/py/upsert_path_metadata_jsonl.py
@@ -10,7 +10,7 @@ We also stamp:
 
 Usage:
   cd <video-library-pipeline-dir>/py
-  python upsert_path_metadata_jsonl.py --in extracted.jsonl --source llm
+  python upsert_path_metadata_jsonl.py --in extracted.jsonl --source rule_based
 
 Safety:
 - DB write only. No file operations.
@@ -44,7 +44,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", default="")
     ap.add_argument("--in", dest="inp", required=True)
-    ap.add_argument("--source", default="llm")
+    ap.add_argument("--source", default="rule_based")
     ap.add_argument("--franchise-rules", default="")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()

--- a/src/tool-apply-reviewed-metadata.ts
+++ b/src/tool-apply-reviewed-metadata.ts
@@ -166,7 +166,7 @@ export function registerToolApplyReviewedMetadata(api: any, getCfg: (api: any) =
           markHumanReviewed: { type: "boolean", default: true },
           allowNoContentChanges: { type: "boolean", default: false },
           reviewedBy: { type: "string" },
-          source: { type: "string", default: "llm" },
+          source: { type: "string", default: "rule_based" },
         },
       },
       async execute(_id: string, params: AnyObj) {
@@ -301,7 +301,7 @@ export function registerToolApplyReviewedMetadata(api: any, getCfg: (api: any) =
           "--in",
           outputStampedJsonlPath,
           "--source",
-          String(params.source || "llm"),
+          String(params.source || "rule_based"),
           "--drive-routes",
           driveRoutesPath,
           "--franchise-rules",


### PR DESCRIPTION
### Motivation

- `source='llm'` はルールベース抽出を意味する歴史的な命名の残滓で誤解を招くため、明示的に `rule_based` に統一するための変更です。
- DB内の既存データ（`path_metadata.source` と `data_json.source_history[].source`）も一貫性のために移行する必要があるため、移行スクリプトを追加しました。

### Description

- Python: changed default and docs in `py/upsert_path_metadata_jsonl.py` so `--source` default is `rule_based` and example usage reflects it. 
- Python: changed `py/run_metadata_batches_promptv1.py` to emit `source_history` entries with `rule_based` and to call the upsert logic with `--source rule_based`.
- TypeScript: changed the `video_pipeline_apply_reviewed_metadata` tool in `src/tool-apply-reviewed-metadata.ts` to default/fallback `source` to `rule_based` and pass that to the upsert script.
- Docs: updated `README.md` to list `rule_based` as the canonical rule-based extractor value and replaced the old note about `llm` with migration guidance.
- Migration script: added `py/migrate_source_llm_to_rule_based.py` which (a) updates `path_metadata.source` rows from `llm` → `rule_based` and (b) rewrites `source_history[].source` values inside `data_json` from `llm` → `rule_based`, with a `--dry-run` mode.

### Testing

- Ran a repository search (`rg`) to confirm occurrences were updated and review remaining `llm` usages, which showed only `llm_subagent` left untouched, and the intended files updated. 
- Verified importing the patched module with `python3 -c "import sys; sys.path.insert(0, 'py'); import upsert_path_metadata_jsonl; print('ok')"` succeeded. 
- Executed the new migration script against a temporary sqlite DB (both `--dry-run` and actual apply) and confirmed that only rows with `source='llm'` were updated to `rule_based` and only `source_history` entries with `"source":"llm"` were rewritten while `llm_subagent` entries remained unchanged. 
- All automated checks and the migration verification ran and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a942c2ee5c8329a320e72126585752)