### PR TITLE
EPGデータを programs/broadcasts に分離し reextract 連携を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ flowchart TD
     %% ── 前処理: EPG ──
     EPG_START(["EDCB .program.txt"])
     EPG_INGEST["video_pipeline_ingest_epg<br/>py/ingest_program_txt.py<br/>py/edcb_program_parser.py"]
-    EPG_DB[("path_metadata<br/>source='edcb_epg'")]
+    EPG_DB[("programs + broadcasts")]
     EPG_START --> EPG_INGEST --> EPG_DB
 
     %% ── Stage 1: Normalize ──
@@ -653,6 +653,33 @@ erDiagram
         TEXT updated_at
     }
 
+    programs {
+        TEXT program_id PK
+        TEXT program_key UNIQUE
+        TEXT canonical_title
+        TEXT created_at
+    }
+
+    broadcasts {
+        TEXT broadcast_id PK
+        TEXT program_id FK
+        TEXT air_date
+        TEXT start_time
+        TEXT end_time
+        TEXT broadcaster
+        TEXT match_key UNIQUE
+        TEXT data_json
+        TEXT created_at
+    }
+
+    path_programs {
+        TEXT path_id FK
+        TEXT program_id FK
+        TEXT broadcast_id FK
+        TEXT source
+        TEXT updated_at
+    }
+
     tags {
         INTEGER tag_id PK
         TEXT name
@@ -690,6 +717,10 @@ erDiagram
     runs ||--o{ events : "triggered"
     paths ||--o{ events : "src/dst"
     paths ||--|| path_metadata : "has metadata"
+    programs ||--o{ broadcasts : "has airings"
+    paths ||--o{ path_programs : "linked"
+    programs ||--o{ path_programs : "linked"
+    broadcasts ||--o{ path_programs : "matched"
     paths ||--o{ path_tags : "tagged"
     tags ||--o{ path_tags : "applied to"
     broadcast_groups ||--o{ broadcast_group_members : "contains"
@@ -707,6 +738,9 @@ erDiagram
 | `observations`                                   | 実行時のファイル状態スナップショット (size/mtime)                  |
 | `events`                                         | 移動・リロケート等のアクション記録 (成否追跡)                      |
 | `path_metadata`                                  | 抽出メタデータ (source + data_json にJSONで格納)                   |
+| `programs`                                       | 番組シリーズの正規化キー管理 (`program_key`)                        |
+| `broadcasts`                                     | EPG放送履歴 (air_date/start_time/broadcaster + data_json)           |
+| `path_programs`                                  | ファイルと番組/放送履歴の紐付け (`reextract` 等で更新)              |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
 | `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
 
@@ -734,9 +768,10 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 | ---------------- | ----------------------- | ------------------------------------ |
 | `rule_based`   | ルールベース抽出        | `run_metadata_batches_promptv1.py` |
 | `llm_subagent` | LLMサブエージェント抽出 | `apply_llm_extract_output.py`      |
-| `edcb_epg`     | EPG取り込み             | `ingest_program_txt.py`            |
 
 > `source='rule_based'` はルールベース抽出の結果を示す。旧値 `llm` は移行スクリプトで `rule_based` に統一可能。
+
+> EPG取り込みは `path_metadata` ではなく `programs` / `broadcasts` に保存される。
 
 ### is_current 運用
 

--- a/py/ingest_program_txt.py
+++ b/py/ingest_program_txt.py
@@ -1,11 +1,9 @@
 """Ingest EDCB .program.txt files into mediaops.sqlite.
 
 Scans a TS recording directory for .program.txt companion files,
-parses them, and stores structured EPG metadata in the database.
-
-The metadata is stored in `path_metadata` with source='edcb_epg'.
-Match keys are stored in data_json so that encoded files (MP4) can
-be correlated with the original EPG data later.
+parses them, and stores EPG metadata into file-independent tables:
+- programs
+- broadcasts
 
 Usage:
   cd <video-library-pipeline-dir>/py
@@ -17,19 +15,19 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import unicodedata
 import uuid
 from pathlib import Path
 from typing import Any
 
-from edcb_program_parser import (
-    datetime_key_from_epg,
-    match_key_from_epg,
-    match_key_from_filename,
-    parse_program_txt,
-)
-from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed, fetchone
-from pathscan_common import now_iso, path_id_for, split_win, wsl_to_windows_path
+from edcb_program_parser import datetime_key_from_epg, match_key_from_epg, parse_program_txt
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+from pathscan_common import now_iso
 from source_history import make_entry
+
+_WS = re.compile(r"[\s\u3000]+")
+_BAD = re.compile(r"[<>:\"/\\\\|?*]")
 
 
 def find_program_txt_files(ts_root: Path) -> list[Path]:
@@ -37,92 +35,41 @@ def find_program_txt_files(ts_root: Path) -> list[Path]:
     return sorted(ts_root.rglob("*.program.txt"))
 
 
-def ts_path_from_program_txt(program_txt_path: Path) -> Path | None:
-    """Derive the .ts file path from its .program.txt companion.
-
-    EDCB naming: "title_date.ts.program.txt" → "title_date.ts"
-    """
-    name = program_txt_path.name
-    if name.endswith(".ts.program.txt"):
-        ts_name = name[: -len(".program.txt")]
-        return program_txt_path.parent / ts_name
-    return None
+def _program_key_from_title(title: str) -> str:
+    normalized = unicodedata.normalize("NFKC", str(title or "")).lower()
+    normalized = _BAD.sub("", normalized)
+    normalized = _WS.sub("_", normalized).strip("_")
+    return normalized or "unknown"
 
 
-def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
-    """Re-generate match_keys for existing edcb_epg records (old→new format).
+def _program_id_from_key(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program:{program_key}"))
 
-    New format includes broadcaster: title::broadcaster::date::time
-    """
-    con = connect_db(db_path)
-    rows = con.execute(
-        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'",
-    ).fetchall()
 
-    updated = 0
-    skipped = 0
-    for path_id, data_json_str in rows:
-        try:
-            data = json.loads(data_json_str)
-        except Exception:
-            skipped += 1
-            continue
-        if not isinstance(data, dict):
-            skipped += 1
-            continue
-
-        title = data.get("official_title", "")
-        broadcaster = data.get("broadcaster", "")
-        air_date = data.get("air_date", "")
-        start_time = data.get("start_time", "")
-        if not title or not air_date or not start_time:
-            skipped += 1
-            continue
-
-        new_mk = match_key_from_epg({
-            "official_title": title,
-            "broadcaster": broadcaster,
-            "air_date": air_date,
-            "start_time": start_time,
-        })
-        old_mk = data.get("match_key")
-        if new_mk == old_mk:
-            skipped += 1
-            continue
-
-        data["match_key"] = new_mk
-        updated += 1
-
-        if not dry_run:
-            con.execute(
-                "UPDATE path_metadata SET data_json=?, updated_at=? WHERE path_id=? AND source='edcb_epg'",
-                (json.dumps(data, ensure_ascii=False), now_iso(), path_id),
-            )
-
-    if not dry_run:
-        con.commit()
-    con.close()
-
-    result = {"tool": "migrate_match_keys", "dry_run": dry_run, "total": len(rows), "updated": updated, "skipped": skipped}
-    print(json.dumps(result, ensure_ascii=False))
-    return 0
+def _broadcast_id(program_id: str, epg: dict[str, Any], match_key: str | None) -> str:
+    if match_key:
+        seed = f"broadcast:{match_key}"
+    else:
+        seed = "::".join(
+            [
+                "broadcast",
+                program_id,
+                str(epg.get("air_date") or ""),
+                str(epg.get("start_time") or ""),
+                str(epg.get("end_time") or ""),
+                str(epg.get("broadcaster") or ""),
+            ]
+        )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", required=True)
-    ap.add_argument("--ts-root", help="WSL path to TS recording directory (e.g. /mnt/j/TVFile)")
+    ap.add_argument("--ts-root", required=True, help="WSL path to TS recording directory (e.g. /mnt/j/TVFile)")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--limit", type=int, default=0)
-    ap.add_argument("--migrate-match-keys", action="store_true", help="Re-generate match_keys for existing edcb_epg records")
-    ap.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
     args = ap.parse_args()
-
-    if args.migrate_match_keys:
-        return _migrate_match_keys(args.db, dry_run=args.dry_run)
-
-    if not args.ts_root:
-        ap.error("--ts-root is required unless --migrate-match-keys is used")
 
     if not os.path.exists(args.db):
         raise SystemExit(f"DB not found: {args.db}")
@@ -140,9 +87,9 @@ def main() -> int:
 
     total = 0
     parsed = 0
-    skipped_already_ingested = 0
     skipped_parse_failed = 0
-    ingested = 0
+    ingested_programs = 0
+    ingested_broadcasts = 0
     errors: list[str] = []
 
     rows_to_insert: list[dict[str, Any]] = []
@@ -153,7 +100,6 @@ def main() -> int:
             if args.limit and total > args.limit:
                 break
 
-            # Parse the program.txt
             epg = parse_program_txt(ptxt)
             if not epg:
                 skipped_parse_failed += 1
@@ -161,57 +107,47 @@ def main() -> int:
                 continue
             parsed += 1
 
-            # Derive TS file path and its Windows equivalent
-            ts_path = ts_path_from_program_txt(ptxt)
-            if not ts_path:
-                skipped_parse_failed += 1
-                errors.append(f"cannot_derive_ts_path: {ptxt.name}")
-                continue
+            title = str(epg.get("official_title") or "")
+            program_key = _program_key_from_title(title)
+            program_id = _program_id_from_key(program_key)
 
-            ts_win_path = wsl_to_windows_path(str(ts_path))
-            pid = path_id_for(ts_win_path)
-
-            # Check if already ingested (idempotency)
-            existing = fetchone(
-                con,
-                "SELECT path_id FROM path_metadata WHERE path_id = ? AND source = 'edcb_epg'",
-                (pid,),
-            )
-            if existing:
-                skipped_already_ingested += 1
-                continue
-
-            # Generate match keys for correlation with encoded files
             match_key = match_key_from_epg(epg)
             dt_key = datetime_key_from_epg(epg)
-
-            # Build the data payload
             data = {
                 "match_key": match_key,
                 "datetime_key": dt_key,
-                "air_date": epg["air_date"],
-                "start_time": epg["start_time"],
-                "end_time": epg["end_time"],
-                "broadcaster": epg["broadcaster"],
-                "broadcaster_raw": epg["broadcaster_raw"],
-                "official_title": epg["official_title"],
-                "title_raw": epg["title_raw"],
-                "annotations": epg["annotations"],
-                "is_rebroadcast_flag": epg["is_rebroadcast_flag"],
-                "description": epg["description"][:500] if epg["description"] else None,
-                "epg_genres": epg["epg_genres"],
-                "network_ids": epg["network_ids"],
-                "ts_path": ts_win_path,
+                "air_date": epg.get("air_date"),
+                "start_time": epg.get("start_time"),
+                "end_time": epg.get("end_time"),
+                "broadcaster": epg.get("broadcaster"),
+                "broadcaster_raw": epg.get("broadcaster_raw"),
+                "official_title": epg.get("official_title"),
+                "title_raw": epg.get("title_raw"),
+                "annotations": epg.get("annotations"),
+                "is_rebroadcast_flag": epg.get("is_rebroadcast_flag"),
+                "description": (epg.get("description") or "")[:500] or None,
+                "epg_genres": epg.get("epg_genres"),
+                "detail_sections": epg.get("detail_sections"),
+                "network_ids": epg.get("network_ids"),
                 "program_txt_path": str(ptxt),
                 "ingested_at": now_iso(),
             }
             data["source_history"] = [make_entry("edcb_epg", list(data.keys()))]
 
-            rows_to_insert.append({
-                "pid": pid,
-                "ts_win_path": ts_win_path,
-                "data": data,
-            })
+            rows_to_insert.append(
+                {
+                    "program_id": program_id,
+                    "program_key": program_key,
+                    "canonical_title": title or "UNKNOWN",
+                    "broadcast_id": _broadcast_id(program_id, epg, match_key),
+                    "air_date": epg.get("air_date"),
+                    "start_time": epg.get("start_time"),
+                    "end_time": epg.get("end_time"),
+                    "broadcaster": epg.get("broadcaster"),
+                    "match_key": match_key,
+                    "data_json": json.dumps(data, ensure_ascii=False),
+                }
+            )
 
         if not args.apply:
             summary = {
@@ -221,15 +157,13 @@ def main() -> int:
                 "tsRoot": str(ts_root),
                 "total": total,
                 "parsed": parsed,
-                "alreadyIngested": skipped_already_ingested,
                 "parseFailed": skipped_parse_failed,
-                "wouldIngest": len(rows_to_insert),
+                "wouldIngestBroadcasts": len(rows_to_insert),
                 "errors": errors[:20],
             }
             print(json.dumps(summary, ensure_ascii=False))
             return 0
 
-        # Apply: write to DB
         begin_immediate(con)
         con.execute(
             """
@@ -239,37 +173,49 @@ def main() -> int:
             (run_id, "epg_ingest", str(ts_root), started_at, None, "ingest_program_txt.py", None),
         )
 
+        seen_program_ids: set[str] = set()
         for row in rows_to_insert:
-            pid = row["pid"]
-            ts_win_path = row["ts_win_path"]
-            data = row["data"]
-            drive, dir_, name, ext = split_win(ts_win_path)
             ts_now = now_iso()
-
-            # Ensure path exists in paths table
             con.execute(
                 """
-                INSERT INTO paths (path_id, path, drive, dir, name, ext, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET updated_at=excluded.updated_at
+                INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(program_id) DO UPDATE SET
+                  canonical_title=excluded.canonical_title
                 """,
-                (pid, ts_win_path, drive, dir_, name, ext, ts_now, ts_now),
+                (row["program_id"], row["program_key"], row["canonical_title"], ts_now),
             )
+            if row["program_id"] not in seen_program_ids:
+                seen_program_ids.add(row["program_id"])
+                ingested_programs += 1
 
-            # Insert EPG metadata
-            data_json = json.dumps(data, ensure_ascii=False)
             con.execute(
                 """
-                INSERT INTO path_metadata (path_id, source, data_json, updated_at)
-                VALUES (?, 'edcb_epg', ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET
-                  source='edcb_epg',
-                  data_json=excluded.data_json,
-                  updated_at=excluded.updated_at
+                INSERT INTO broadcasts (
+                  broadcast_id, program_id, air_date, start_time, end_time, broadcaster, match_key, data_json, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(match_key) DO UPDATE SET
+                  program_id=excluded.program_id,
+                  air_date=excluded.air_date,
+                  start_time=excluded.start_time,
+                  end_time=excluded.end_time,
+                  broadcaster=excluded.broadcaster,
+                  data_json=excluded.data_json
                 """,
-                (pid, data_json, ts_now),
+                (
+                    row["broadcast_id"],
+                    row["program_id"],
+                    row["air_date"],
+                    row["start_time"],
+                    row["end_time"],
+                    row["broadcaster"],
+                    row["match_key"],
+                    row["data_json"],
+                    ts_now,
+                ),
             )
-            ingested += 1
+            ingested_broadcasts += 1
 
         con.execute("UPDATE runs SET finished_at=? WHERE run_id=?", (now_iso(), run_id))
         con.commit()
@@ -281,16 +227,16 @@ def main() -> int:
         con.close()
 
     summary = {
-        "ok": len(errors) == 0 or ingested > 0,
+        "ok": len(errors) == 0 or ingested_broadcasts > 0,
         "tool": "ingest_program_txt",
         "apply": True,
         "runId": run_id,
         "tsRoot": str(ts_root),
         "total": total,
         "parsed": parsed,
-        "alreadyIngested": skipped_already_ingested,
         "parseFailed": skipped_parse_failed,
-        "ingested": ingested,
+        "ingestedPrograms": ingested_programs,
+        "ingestedBroadcasts": ingested_broadcasts,
         "errors": errors[:20],
     }
     print(json.dumps(summary, ensure_ascii=False))

--- a/py/mediaops_schema.py
+++ b/py/mediaops_schema.py
@@ -152,6 +152,46 @@ DDL_STATEMENTS = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_bgm_group ON broadcast_group_members(group_id)",
     "CREATE INDEX IF NOT EXISTS idx_bgm_path ON broadcast_group_members(path_id)",
+    """
+    CREATE TABLE IF NOT EXISTS programs (
+      program_id TEXT PRIMARY KEY,
+      program_key TEXT NOT NULL UNIQUE,
+      canonical_title TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_programs_key ON programs(program_key)",
+    """
+    CREATE TABLE IF NOT EXISTS broadcasts (
+      broadcast_id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL,
+      air_date TEXT,
+      start_time TEXT,
+      end_time TEXT,
+      broadcaster TEXT,
+      match_key TEXT UNIQUE,
+      data_json TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (program_id) REFERENCES programs(program_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_program ON broadcasts(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_air_start ON broadcasts(air_date, start_time)",
+    """
+    CREATE TABLE IF NOT EXISTS path_programs (
+      path_id TEXT NOT NULL,
+      program_id TEXT NOT NULL,
+      broadcast_id TEXT,
+      source TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (path_id, program_id),
+      FOREIGN KEY (path_id) REFERENCES paths(path_id),
+      FOREIGN KEY (program_id) REFERENCES programs(program_id),
+      FOREIGN KEY (broadcast_id) REFERENCES broadcasts(broadcast_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_program ON path_programs(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_broadcast ON path_programs(broadcast_id)",
 ]
 
 _FILES_NEW_COLUMNS: list[tuple[str, str]] = [

--- a/py/migrate_epg_to_programs.py
+++ b/py/migrate_epg_to_programs.py
@@ -1,0 +1,181 @@
+"""Migrate legacy EPG records from path_metadata(source='edcb_epg') to programs/broadcasts.
+
+Default is dry-run. Use --apply to write.
+Optionally use --delete-legacy to remove old path_metadata rows after migration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import unicodedata
+import uuid
+from typing import Any
+
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+from pathscan_common import now_iso
+
+_WS = re.compile(r"[\s\u3000]+")
+_BAD = re.compile(r"[<>:\"/\\\\|?*]")
+
+
+def _program_key_from_title(title: str) -> str:
+    normalized = unicodedata.normalize("NFKC", str(title or "")).lower()
+    normalized = _BAD.sub("", normalized)
+    normalized = _WS.sub("_", normalized).strip("_")
+    return normalized or "unknown"
+
+
+def _program_id_from_key(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program:{program_key}"))
+
+
+def _broadcast_id(program_id: str, data: dict[str, Any], match_key: str | None) -> str:
+    if match_key:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast:{match_key}"))
+    seed = "::".join(
+        [
+            "broadcast",
+            program_id,
+            str(data.get("air_date") or ""),
+            str(data.get("start_time") or ""),
+            str(data.get("end_time") or ""),
+            str(data.get("broadcaster") or ""),
+        ]
+    )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--delete-legacy", action="store_true")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.db):
+        raise SystemExit(f"DB not found: {args.db}")
+
+    con = connect_db(args.db)
+    create_schema_if_needed(con)
+
+    rows = con.execute(
+        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'"
+    ).fetchall()
+
+    parsed = 0
+    parse_failed = 0
+    prepared = 0
+    programs: dict[str, tuple[str, str]] = {}
+    broadcasts: list[dict[str, Any]] = []
+
+    for row in rows:
+        try:
+            data = json.loads(row[1])
+        except Exception:
+            parse_failed += 1
+            continue
+        if not isinstance(data, dict):
+            parse_failed += 1
+            continue
+
+        parsed += 1
+        title = str(data.get("official_title") or "")
+        program_key = _program_key_from_title(title)
+        program_id = _program_id_from_key(program_key)
+        programs[program_id] = (program_key, title or "UNKNOWN")
+
+        match_key = data.get("match_key")
+        if not isinstance(match_key, str):
+            match_key = None
+
+        broadcasts.append(
+            {
+                "broadcast_id": _broadcast_id(program_id, data, match_key),
+                "program_id": program_id,
+                "air_date": data.get("air_date"),
+                "start_time": data.get("start_time"),
+                "end_time": data.get("end_time"),
+                "broadcaster": data.get("broadcaster"),
+                "match_key": match_key,
+                "data_json": json.dumps(data, ensure_ascii=False),
+            }
+        )
+        prepared += 1
+
+    if args.apply:
+        try:
+            begin_immediate(con)
+            ts_now = now_iso()
+            for program_id, (program_key, canonical_title) in programs.items():
+                con.execute(
+                    """
+                    INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(program_id) DO UPDATE SET
+                      canonical_title=excluded.canonical_title
+                    """,
+                    (program_id, program_key, canonical_title, ts_now),
+                )
+
+            for b in broadcasts:
+                con.execute(
+                    """
+                    INSERT INTO broadcasts (
+                      broadcast_id, program_id, air_date, start_time, end_time, broadcaster, match_key, data_json, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(match_key) DO UPDATE SET
+                      program_id=excluded.program_id,
+                      air_date=excluded.air_date,
+                      start_time=excluded.start_time,
+                      end_time=excluded.end_time,
+                      broadcaster=excluded.broadcaster,
+                      data_json=excluded.data_json
+                    """,
+                    (
+                        b["broadcast_id"],
+                        b["program_id"],
+                        b["air_date"],
+                        b["start_time"],
+                        b["end_time"],
+                        b["broadcaster"],
+                        b["match_key"],
+                        b["data_json"],
+                        ts_now,
+                    ),
+                )
+
+            deleted_legacy = 0
+            if args.delete_legacy:
+                cur = con.execute("DELETE FROM path_metadata WHERE source='edcb_epg'")
+                deleted_legacy = int(cur.rowcount or 0)
+
+            con.commit()
+        except Exception:
+            con.rollback()
+            raise
+    else:
+        deleted_legacy = 0
+
+    summary = {
+        "ok": True,
+        "tool": "migrate_epg_to_programs",
+        "apply": bool(args.apply),
+        "deleteLegacy": bool(args.delete_legacy),
+        "legacyRows": len(rows),
+        "parsed": parsed,
+        "parseFailed": parse_failed,
+        "programsPrepared": len(programs),
+        "broadcastsPrepared": prepared,
+        "deletedLegacyRows": deleted_legacy,
+    }
+    print(json.dumps(summary, ensure_ascii=False))
+    con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -15,6 +15,7 @@ from edcb_program_parser import match_key_from_filename, datetime_key_from_filen
 from franchise_resolver import resolve_franchise
 from genre_resolver import resolve_genre
 from source_history import make_entry
+from pathscan_common import now_iso
 
 WS = re.compile(r"[\s\u3000]+")
 BAD = re.compile(r"[<>:\"/\\\\|?*]")
@@ -394,6 +395,7 @@ def extract_title_ai_primary(name: str, base: str, alias_hints: HintSet) -> dict
 class _EpgCache:
     """Pre-loaded EPG metadata cache for fast lookup by match_key / datetime_key.
 
+    Source: broadcasts table (file-independent EPG store).
     Indexes:
     - _by_match_key: full key including broadcaster (no collision)
     - _by_title_dt: title::date::time (old format) → list of EPG dicts
@@ -406,31 +408,38 @@ class _EpgCache:
         self._by_datetime_key: dict[str, list[dict]] = {}
         try:
             rows = con.execute(
-                "SELECT data_json FROM path_metadata WHERE source='edcb_epg'",
+                "SELECT broadcast_id, program_id, match_key, air_date, start_time, data_json FROM broadcasts",
             ).fetchall()
         except sqlite3.Error:
             return
         for row in rows:
             try:
-                data = json.loads(row[0])
+                data = json.loads(row[5]) if row[5] else {}
             except Exception:
-                continue
+                data = {}
             if not isinstance(data, dict):
-                continue
+                data = {}
+            data.setdefault("broadcast_id", row[0])
+            data.setdefault("program_id", row[1])
+            if row[2]:
+                data.setdefault("match_key", row[2])
+            if row[3] and row[4]:
+                data.setdefault("datetime_key", f"{row[3]}::{row[4]}")
+
             mk = data.get("match_key")
             dk = data.get("datetime_key")
             if mk:
                 self._by_match_key[mk] = data
                 # Build title::date::time key (strip broadcaster segment)
-                parts = mk.split("::")
+                parts = str(mk).split("::")
                 if len(parts) == 4:
                     title_dt = f"{parts[0]}::{parts[2]}::{parts[3]}"
                     self._by_title_dt.setdefault(title_dt, []).append(data)
                 elif len(parts) == 3:
                     # Legacy format without broadcaster
-                    self._by_title_dt.setdefault(mk, []).append(data)
+                    self._by_title_dt.setdefault(str(mk), []).append(data)
             if dk:
-                self._by_datetime_key.setdefault(dk, []).append(data)
+                self._by_datetime_key.setdefault(str(dk), []).append(data)
 
     def lookup(self, match_key: str | None, datetime_key: str | None) -> dict | None:
         """Find EPG data by match_key, title_dt fallback, then datetime_key.
@@ -453,6 +462,10 @@ def _enrich_with_epg(row: dict, epg: dict | None) -> None:
     """Add EPG-sourced fields to a metadata row (in-place)."""
     if not epg:
         return
+    if epg.get("program_id"):
+        row["program_id"] = epg.get("program_id")
+    if epg.get("broadcast_id"):
+        row["broadcast_id"] = epg.get("broadcast_id")
     row["broadcaster"] = epg.get("broadcaster")
     row["epg_genre"] = None
     genres = epg.get("epg_genres")
@@ -696,6 +709,35 @@ def main() -> int:
             sys.argv += ["--franchise-rules", args.franchise_rules]
         if _upsert_main() != 0:
             raise SystemExit(f"upsert failed: {epath}")
+
+        # Link extracted file metadata to file-independent EPG program/broadcast entities.
+        links: dict[tuple[str, str], tuple[str | None, str]] = {}
+        for linked in rows:
+            path_id = linked.get("path_id")
+            program_id = linked.get("program_id")
+            if not path_id or not program_id:
+                continue
+            links[(str(path_id), str(program_id))] = (
+                str(linked.get("broadcast_id")) if linked.get("broadcast_id") else None,
+                now_iso(),
+            )
+        if links:
+            try:
+                db_con.executemany(
+                    """
+                    INSERT INTO path_programs (path_id, program_id, broadcast_id, source, updated_at)
+                    VALUES (?, ?, ?, 'reextract', ?)
+                    ON CONFLICT(path_id, program_id) DO UPDATE SET
+                      broadcast_id=excluded.broadcast_id,
+                      source=excluded.source,
+                      updated_at=excluded.updated_at
+                    """,
+                    [(pid, pgid, bid, ts) for (pid, pgid), (bid, ts) in links.items()],
+                )
+                db_con.commit()
+            except sqlite3.Error:
+                # path_programs may not exist before schema migration is applied.
+                pass
 
         generated_input_jsonl_paths.append(str(bpath))
         generated_output_jsonl_paths.append(str(epath))

--- a/src/tool-ingest-epg.ts
+++ b/src/tool-ingest-epg.ts
@@ -6,8 +6,8 @@ export function registerToolIngestEpg(api: any, getCfg: (api: any) => any) {
     {
       name: "video_pipeline_ingest_epg",
       description:
-        "Scan a TS recording directory for EDCB .program.txt files and ingest EPG metadata (broadcaster, genre, description) into DB. " +
-        "Run this before deleting program.txt files so that encoded files can be matched to their EPG data.",
+        "Scan a TS recording directory for EDCB .program.txt files and ingest EPG metadata into programs/broadcasts tables. " +
+        "Run this before deleting program.txt files so that encoded files can be matched to broadcast history.",
       parameters: {
         type: "object",
         additionalProperties: false,


### PR DESCRIPTION
### Motivation

- EDCB の `.program.txt` に由来する EPG をファイル (`path_metadata.path_id`) に紐づけたまま保持するのは不適切で、エンコード後に参照先が消えるためファイル非依存の番組/放送履歴ストアへ移行する必要がある。 
- `reextract` / ルールベース照合が放送履歴を参照できるようにして、エンコード後のファイルと放送履歴を正しく結び付けられるようにするため。 

### Description

- スキーマを拡張して `programs`, `broadcasts`, `path_programs` テーブルと関連インデックスを追加した (`py/mediaops_schema.py`)。 
- EPG取り込みを `path_metadata(source='edcb_epg')` ではなく `programs` + `broadcasts` に書き込むように `py/ingest_program_txt.py` を書き換え、`program_key`/`program_id`/`broadcast_id` の決定ロジックを実装した。 
- 既存のレガシー EPG を移行する新スクリプト `py/migrate_epg_to_programs.py` を追加し、`--apply` と `--delete-legacy` オプションをサポートした。 
- ルールベース再抽出ツール `py/run_metadata_batches_promptv1.py` を修正して EPG ヒントの参照元を `broadcasts` に切り替え、照合時に `program_id` / `broadcast_id` を抽出行に付与し、upsert 後に `path_programs` へ `source='reextract'` で紐付けを書き込む処理を追加した。 
- 外部ツール説明とドキュメントを更新して新スキーマを反映した (`src/tool-ingest-epg.ts`, `README.md`)。 

### Testing

- Python 構文チェックを実行して `py` スクリプト群をコンパイル可能であることを確認 (`python -m py_compile py/mediaops_schema.py py/ingest_program_txt.py py/run_metadata_batches_promptv1.py py/migrate_epg_to_programs.py`) and it succeeded. 
- 一時データベースで `create_schema_if_needed()` を呼び出して `programs`, `broadcasts`, `path_programs` テーブルが作成されることを確認（テーブル一覧検査）。 
- 一時データベース上で `py/migrate_epg_to_programs.py --db <tmp> --apply` を実行し、サンプルの legacy `path_metadata(source='edcb_epg')` 1 件が `programs=1` / `broadcasts=1` に移行されることを確認した (出力 JSON に成功を返しました)。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab989b61a08329a5a96b0799d1fa16)