### PR TITLE
EPGをprograms/broadcastsへ分離しreextractでのpath_programs連携を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,33 @@ erDiagram
         TEXT updated_at
     }
 
+    programs {
+        TEXT program_id PK
+        TEXT program_key UNIQUE
+        TEXT canonical_title
+        TEXT created_at
+    }
+
+    broadcasts {
+        TEXT broadcast_id PK
+        TEXT program_id FK
+        TEXT air_date
+        TEXT start_time
+        TEXT end_time
+        TEXT broadcaster
+        TEXT match_key UNIQUE
+        TEXT data_json
+        TEXT created_at
+    }
+
+    path_programs {
+        TEXT path_id FK
+        TEXT program_id FK
+        TEXT broadcast_id FK
+        TEXT source
+        TEXT updated_at
+    }
+
     tags {
         INTEGER tag_id PK
         TEXT name
@@ -690,6 +717,10 @@ erDiagram
     runs ||--o{ events : "triggered"
     paths ||--o{ events : "src/dst"
     paths ||--|| path_metadata : "has metadata"
+    programs ||--o{ broadcasts : "has airings"
+    paths ||--o{ path_programs : "linked programs"
+    programs ||--o{ path_programs : "linked to paths"
+    broadcasts ||--o{ path_programs : "optional matched airing"
     paths ||--o{ path_tags : "tagged"
     tags ||--o{ path_tags : "applied to"
     broadcast_groups ||--o{ broadcast_group_members : "contains"
@@ -707,6 +738,8 @@ erDiagram
 | `observations`                                   | 実行時のファイル状態スナップショット (size/mtime)                  |
 | `events`                                         | 移動・リロケート等のアクション記録 (成否追跡)                      |
 | `path_metadata`                                  | 抽出メタデータ (source + data_json にJSONで格納)                   |
+| `programs` / `broadcasts`                       | EPG由来の番組マスタ/放送履歴（ファイル非依存）                    |
+| `path_programs`                                 | ファイルと番組の紐付け（主に reextract 時に更新）                 |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
 | `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
 
@@ -734,7 +767,7 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 | ---------------- | ----------------------- | ------------------------------------ |
 | `rule_based`   | ルールベース抽出        | `run_metadata_batches_promptv1.py` |
 | `llm_subagent` | LLMサブエージェント抽出 | `apply_llm_extract_output.py`      |
-| `edcb_epg`     | EPG取り込み             | `ingest_program_txt.py`            |
+| `reextract`    | ファイルと番組の紐付け   | `run_metadata_batches_promptv1.py` |
 
 > `source='rule_based'` はルールベース抽出の結果を示す。旧値 `llm` は移行スクリプトで `rule_based` に統一可能。
 

--- a/py/ingest_program_txt.py
+++ b/py/ingest_program_txt.py
@@ -1,11 +1,7 @@
-"""Ingest EDCB .program.txt files into mediaops.sqlite.
+"""Ingest EDCB .program.txt files into programs/broadcasts tables.
 
 Scans a TS recording directory for .program.txt companion files,
-parses them, and stores structured EPG metadata in the database.
-
-The metadata is stored in `path_metadata` with source='edcb_epg'.
-Match keys are stored in data_json so that encoded files (MP4) can
-be correlated with the original EPG data later.
+parses them, and stores EPG metadata as file-independent program/broadcast data.
 
 Usage:
   cd <video-library-pipeline-dir>/py
@@ -17,19 +13,44 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import uuid
+import unicodedata
 from pathlib import Path
 from typing import Any
 
-from edcb_program_parser import (
-    datetime_key_from_epg,
-    match_key_from_epg,
-    match_key_from_filename,
-    parse_program_txt,
-)
-from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed, fetchone
-from pathscan_common import now_iso, path_id_for, split_win, wsl_to_windows_path
-from source_history import make_entry
+from edcb_program_parser import datetime_key_from_epg, match_key_from_epg, parse_program_txt
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+from pathscan_common import now_iso
+
+_WS = re.compile(r"[\s\u3000]+")
+
+
+def normalize_program_key(title: str) -> str:
+    """Normalize title for stable program_key (NFKC + lowercase + compact ws)."""
+    t = unicodedata.normalize("NFKC", str(title or "")).strip().lower()
+    return _WS.sub(" ", t)
+
+
+def _program_id_for_key(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program:{program_key}"))
+
+
+def _broadcast_id_for_match_key(match_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast:{match_key}"))
+
+
+def _fallback_broadcast_identity(program_id: str, epg: dict[str, Any], source_path: Path) -> str:
+    token = "::".join(
+        [
+            program_id,
+            str(epg.get("air_date") or ""),
+            str(epg.get("start_time") or ""),
+            str(epg.get("broadcaster") or ""),
+            str(source_path),
+        ]
+    )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast-fallback:{token}"))
 
 
 def find_program_txt_files(ts_root: Path) -> list[Path]:
@@ -37,33 +58,20 @@ def find_program_txt_files(ts_root: Path) -> list[Path]:
     return sorted(ts_root.rglob("*.program.txt"))
 
 
-def ts_path_from_program_txt(program_txt_path: Path) -> Path | None:
-    """Derive the .ts file path from its .program.txt companion.
-
-    EDCB naming: "title_date.ts.program.txt" → "title_date.ts"
-    """
-    name = program_txt_path.name
-    if name.endswith(".ts.program.txt"):
-        ts_name = name[: -len(".program.txt")]
-        return program_txt_path.parent / ts_name
-    return None
-
-
 def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
-    """Re-generate match_keys for existing edcb_epg records (old→new format).
-
-    New format includes broadcaster: title::broadcaster::date::time
-    """
+    """Re-generate match_keys in broadcasts.data_json (old→new format)."""
     con = connect_db(db_path)
+    create_schema_if_needed(con)
+
     rows = con.execute(
-        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'",
+        "SELECT broadcast_id, data_json FROM broadcasts",
     ).fetchall()
 
     updated = 0
     skipped = 0
-    for path_id, data_json_str in rows:
+    for broadcast_id, data_json_str in rows:
         try:
-            data = json.loads(data_json_str)
+            data = json.loads(data_json_str or "{}")
         except Exception:
             skipped += 1
             continue
@@ -79,14 +87,16 @@ def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
             skipped += 1
             continue
 
-        new_mk = match_key_from_epg({
-            "official_title": title,
-            "broadcaster": broadcaster,
-            "air_date": air_date,
-            "start_time": start_time,
-        })
+        new_mk = match_key_from_epg(
+            {
+                "official_title": title,
+                "broadcaster": broadcaster,
+                "air_date": air_date,
+                "start_time": start_time,
+            }
+        )
         old_mk = data.get("match_key")
-        if new_mk == old_mk:
+        if not new_mk or new_mk == old_mk:
             skipped += 1
             continue
 
@@ -95,15 +105,21 @@ def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
 
         if not dry_run:
             con.execute(
-                "UPDATE path_metadata SET data_json=?, updated_at=? WHERE path_id=? AND source='edcb_epg'",
-                (json.dumps(data, ensure_ascii=False), now_iso(), path_id),
+                "UPDATE broadcasts SET match_key=?, data_json=? WHERE broadcast_id=?",
+                (new_mk, json.dumps(data, ensure_ascii=False), broadcast_id),
             )
 
     if not dry_run:
         con.commit()
     con.close()
 
-    result = {"tool": "migrate_match_keys", "dry_run": dry_run, "total": len(rows), "updated": updated, "skipped": skipped}
+    result = {
+        "tool": "migrate_match_keys",
+        "dry_run": dry_run,
+        "total": len(rows),
+        "updated": updated,
+        "skipped": skipped,
+    }
     print(json.dumps(result, ensure_ascii=False))
     return 0
 
@@ -114,7 +130,7 @@ def main() -> int:
     ap.add_argument("--ts-root", help="WSL path to TS recording directory (e.g. /mnt/j/TVFile)")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--limit", type=int, default=0)
-    ap.add_argument("--migrate-match-keys", action="store_true", help="Re-generate match_keys for existing edcb_epg records")
+    ap.add_argument("--migrate-match-keys", action="store_true", help="Re-generate match_keys in broadcasts data_json")
     ap.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
     args = ap.parse_args()
 
@@ -140,9 +156,9 @@ def main() -> int:
 
     total = 0
     parsed = 0
-    skipped_already_ingested = 0
     skipped_parse_failed = 0
-    ingested = 0
+    ingested_programs = 0
+    ingested_broadcasts = 0
     errors: list[str] = []
 
     rows_to_insert: list[dict[str, Any]] = []
@@ -153,7 +169,6 @@ def main() -> int:
             if args.limit and total > args.limit:
                 break
 
-            # Parse the program.txt
             epg = parse_program_txt(ptxt)
             if not epg:
                 skipped_parse_failed += 1
@@ -161,57 +176,39 @@ def main() -> int:
                 continue
             parsed += 1
 
-            # Derive TS file path and its Windows equivalent
-            ts_path = ts_path_from_program_txt(ptxt)
-            if not ts_path:
+            title = str(epg.get("official_title") or "").strip()
+            if not title:
                 skipped_parse_failed += 1
-                errors.append(f"cannot_derive_ts_path: {ptxt.name}")
+                errors.append(f"missing_title: {ptxt.name}")
                 continue
 
-            ts_win_path = wsl_to_windows_path(str(ts_path))
-            pid = path_id_for(ts_win_path)
-
-            # Check if already ingested (idempotency)
-            existing = fetchone(
-                con,
-                "SELECT path_id FROM path_metadata WHERE path_id = ? AND source = 'edcb_epg'",
-                (pid,),
-            )
-            if existing:
-                skipped_already_ingested += 1
-                continue
-
-            # Generate match keys for correlation with encoded files
+            program_key = normalize_program_key(title)
+            program_id = _program_id_for_key(program_key)
             match_key = match_key_from_epg(epg)
             dt_key = datetime_key_from_epg(epg)
+            broadcast_id = _broadcast_id_for_match_key(match_key) if match_key else _fallback_broadcast_identity(program_id, epg, ptxt)
 
-            # Build the data payload
-            data = {
-                "match_key": match_key,
-                "datetime_key": dt_key,
-                "air_date": epg["air_date"],
-                "start_time": epg["start_time"],
-                "end_time": epg["end_time"],
-                "broadcaster": epg["broadcaster"],
-                "broadcaster_raw": epg["broadcaster_raw"],
-                "official_title": epg["official_title"],
-                "title_raw": epg["title_raw"],
-                "annotations": epg["annotations"],
-                "is_rebroadcast_flag": epg["is_rebroadcast_flag"],
-                "description": epg["description"][:500] if epg["description"] else None,
-                "epg_genres": epg["epg_genres"],
-                "network_ids": epg["network_ids"],
-                "ts_path": ts_win_path,
-                "program_txt_path": str(ptxt),
-                "ingested_at": now_iso(),
-            }
-            data["source_history"] = [make_entry("edcb_epg", list(data.keys()))]
+            data = dict(epg)
+            data["match_key"] = match_key
+            data["datetime_key"] = dt_key
+            data["program_txt_path"] = str(ptxt)
+            data["ingested_at"] = now_iso()
 
-            rows_to_insert.append({
-                "pid": pid,
-                "ts_win_path": ts_win_path,
-                "data": data,
-            })
+            rows_to_insert.append(
+                {
+                    "program_id": program_id,
+                    "program_key": program_key,
+                    "canonical_title": title,
+                    "broadcast_id": broadcast_id,
+                    "air_date": epg.get("air_date"),
+                    "start_time": epg.get("start_time"),
+                    "end_time": epg.get("end_time"),
+                    "broadcaster": epg.get("broadcaster"),
+                    "match_key": match_key,
+                    "data_json": json.dumps(data, ensure_ascii=False),
+                    "created_at": now_iso(),
+                }
+            )
 
         if not args.apply:
             summary = {
@@ -221,15 +218,13 @@ def main() -> int:
                 "tsRoot": str(ts_root),
                 "total": total,
                 "parsed": parsed,
-                "alreadyIngested": skipped_already_ingested,
                 "parseFailed": skipped_parse_failed,
-                "wouldIngest": len(rows_to_insert),
+                "wouldIngestBroadcasts": len(rows_to_insert),
                 "errors": errors[:20],
             }
             print(json.dumps(summary, ensure_ascii=False))
             return 0
 
-        # Apply: write to DB
         begin_immediate(con)
         con.execute(
             """
@@ -240,36 +235,45 @@ def main() -> int:
         )
 
         for row in rows_to_insert:
-            pid = row["pid"]
-            ts_win_path = row["ts_win_path"]
-            data = row["data"]
-            drive, dir_, name, ext = split_win(ts_win_path)
-            ts_now = now_iso()
-
-            # Ensure path exists in paths table
             con.execute(
                 """
-                INSERT INTO paths (path_id, path, drive, dir, name, ext, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET updated_at=excluded.updated_at
+                INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(program_key) DO UPDATE SET
+                  canonical_title=excluded.canonical_title
                 """,
-                (pid, ts_win_path, drive, dir_, name, ext, ts_now, ts_now),
+                (row["program_id"], row["program_key"], row["canonical_title"], row["created_at"]),
             )
+            ingested_programs += con.execute("SELECT changes()").fetchone()[0]
 
-            # Insert EPG metadata
-            data_json = json.dumps(data, ensure_ascii=False)
             con.execute(
                 """
-                INSERT INTO path_metadata (path_id, source, data_json, updated_at)
-                VALUES (?, 'edcb_epg', ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET
-                  source='edcb_epg',
-                  data_json=excluded.data_json,
-                  updated_at=excluded.updated_at
+                INSERT INTO broadcasts (
+                  broadcast_id, program_id, air_date, start_time, end_time,
+                  broadcaster, match_key, data_json, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(match_key) DO UPDATE SET
+                  program_id=excluded.program_id,
+                  air_date=excluded.air_date,
+                  start_time=excluded.start_time,
+                  end_time=excluded.end_time,
+                  broadcaster=excluded.broadcaster,
+                  data_json=excluded.data_json
                 """,
-                (pid, data_json, ts_now),
+                (
+                    row["broadcast_id"],
+                    row["program_id"],
+                    row["air_date"],
+                    row["start_time"],
+                    row["end_time"],
+                    row["broadcaster"],
+                    row["match_key"],
+                    row["data_json"],
+                    row["created_at"],
+                ),
             )
-            ingested += 1
+            ingested_broadcasts += con.execute("SELECT changes()").fetchone()[0]
 
         con.execute("UPDATE runs SET finished_at=? WHERE run_id=?", (now_iso(), run_id))
         con.commit()
@@ -281,16 +285,16 @@ def main() -> int:
         con.close()
 
     summary = {
-        "ok": len(errors) == 0 or ingested > 0,
+        "ok": len(errors) == 0 or ingested_broadcasts > 0,
         "tool": "ingest_program_txt",
         "apply": True,
         "runId": run_id,
         "tsRoot": str(ts_root),
         "total": total,
         "parsed": parsed,
-        "alreadyIngested": skipped_already_ingested,
         "parseFailed": skipped_parse_failed,
-        "ingested": ingested,
+        "ingestedPrograms": ingested_programs,
+        "ingestedBroadcasts": ingested_broadcasts,
         "errors": errors[:20],
     }
     print(json.dumps(summary, ensure_ascii=False))

--- a/py/mediaops_schema.py
+++ b/py/mediaops_schema.py
@@ -130,6 +130,45 @@ DDL_STATEMENTS = [
     )
     """,
     """
+    CREATE TABLE IF NOT EXISTS programs (
+      program_id TEXT PRIMARY KEY,
+      program_key TEXT NOT NULL UNIQUE,
+      canonical_title TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS broadcasts (
+      broadcast_id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL,
+      air_date TEXT,
+      start_time TEXT,
+      end_time TEXT,
+      broadcaster TEXT,
+      match_key TEXT UNIQUE,
+      data_json TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (program_id) REFERENCES programs(program_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_program ON broadcasts(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_datetime ON broadcasts(air_date, start_time)",
+    """
+    CREATE TABLE IF NOT EXISTS path_programs (
+      path_id TEXT NOT NULL,
+      program_id TEXT NOT NULL,
+      broadcast_id TEXT,
+      source TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (path_id, program_id),
+      FOREIGN KEY (path_id) REFERENCES paths(path_id),
+      FOREIGN KEY (program_id) REFERENCES programs(program_id),
+      FOREIGN KEY (broadcast_id) REFERENCES broadcasts(broadcast_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_program ON path_programs(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_broadcast ON path_programs(broadcast_id)",
+    """
     CREATE TABLE IF NOT EXISTS broadcast_groups (
       group_id TEXT PRIMARY KEY,
       program_title TEXT NOT NULL,

--- a/py/migrate_epg_to_programs.py
+++ b/py/migrate_epg_to_programs.py
@@ -1,0 +1,183 @@
+"""Migrate legacy EPG rows from path_metadata(source='edcb_epg') to programs/broadcasts.
+
+Usage:
+  python migrate_epg_to_programs.py --db /path/to/mediaops.sqlite [--apply] [--delete-source]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import unicodedata
+import uuid
+
+from edcb_program_parser import datetime_key_from_epg, match_key_from_epg
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+
+_WS = re.compile(r"[\s\u3000]+")
+
+
+def normalize_program_key(title: str) -> str:
+    t = unicodedata.normalize("NFKC", str(title or "")).strip().lower()
+    return _WS.sub(" ", t)
+
+
+def program_id_for_key(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program:{program_key}"))
+
+
+def broadcast_id_for(match_key: str, fallback: str) -> str:
+    token = match_key or fallback
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast:{token}"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--delete-source", action="store_true", help="Delete migrated source rows from path_metadata.")
+    args = ap.parse_args()
+
+    con = connect_db(args.db)
+    create_schema_if_needed(con)
+
+    rows = con.execute(
+        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'"
+    ).fetchall()
+
+    planned = []
+    parse_failed = 0
+    for row in rows:
+        try:
+            data = json.loads(row["data_json"])
+        except Exception:
+            parse_failed += 1
+            continue
+        if not isinstance(data, dict):
+            parse_failed += 1
+            continue
+
+        title = str(data.get("official_title") or "").strip()
+        if not title:
+            parse_failed += 1
+            continue
+
+        program_key = normalize_program_key(title)
+        program_id = program_id_for_key(program_key)
+
+        mk = str(data.get("match_key") or "").strip() or match_key_from_epg(data) or ""
+        dk = str(data.get("datetime_key") or "").strip() or datetime_key_from_epg(data)
+        if dk and "datetime_key" not in data:
+            data["datetime_key"] = dk
+        if mk and "match_key" not in data:
+            data["match_key"] = mk
+
+        fallback = "::".join(
+            [
+                row["path_id"],
+                str(data.get("air_date") or ""),
+                str(data.get("start_time") or ""),
+                str(data.get("broadcaster") or ""),
+            ]
+        )
+        broadcast_id = broadcast_id_for(mk, fallback)
+
+        planned.append(
+            {
+                "path_id": row["path_id"],
+                "program_id": program_id,
+                "program_key": program_key,
+                "canonical_title": title,
+                "broadcast_id": broadcast_id,
+                "air_date": data.get("air_date"),
+                "start_time": data.get("start_time"),
+                "end_time": data.get("end_time"),
+                "broadcaster": data.get("broadcaster"),
+                "match_key": mk or None,
+                "data_json": json.dumps(data, ensure_ascii=False),
+            }
+        )
+
+    if not args.apply:
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "tool": "migrate_epg_to_programs",
+                    "apply": False,
+                    "sourceRows": len(rows),
+                    "parseFailed": parse_failed,
+                    "wouldMigrate": len(planned),
+                    "deleteSource": bool(args.delete_source),
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 0
+
+    inserted_or_updated = 0
+    deleted = 0
+    begin_immediate(con)
+    for x in planned:
+        con.execute(
+            """
+            INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+            VALUES (?, ?, ?, datetime('now'))
+            ON CONFLICT(program_key) DO UPDATE SET canonical_title=excluded.canonical_title
+            """,
+            (x["program_id"], x["program_key"], x["canonical_title"]),
+        )
+        con.execute(
+            """
+            INSERT INTO broadcasts (
+              broadcast_id, program_id, air_date, start_time, end_time,
+              broadcaster, match_key, data_json, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+            ON CONFLICT(match_key) DO UPDATE SET
+              program_id=excluded.program_id,
+              air_date=excluded.air_date,
+              start_time=excluded.start_time,
+              end_time=excluded.end_time,
+              broadcaster=excluded.broadcaster,
+              data_json=excluded.data_json
+            """,
+            (
+                x["broadcast_id"],
+                x["program_id"],
+                x["air_date"],
+                x["start_time"],
+                x["end_time"],
+                x["broadcaster"],
+                x["match_key"],
+                x["data_json"],
+            ),
+        )
+        inserted_or_updated += 1
+
+    if args.delete_source:
+        deleted = con.execute("DELETE FROM path_metadata WHERE source='edcb_epg'").rowcount
+
+    con.commit()
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "tool": "migrate_epg_to_programs",
+                "apply": True,
+                "sourceRows": len(rows),
+                "parseFailed": parse_failed,
+                "migrated": inserted_or_updated,
+                "deletedSourceRows": deleted,
+                "deleteSource": bool(args.delete_source),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime, timezone
 import os
 import re
 import sqlite3
@@ -15,6 +16,7 @@ from edcb_program_parser import match_key_from_filename, datetime_key_from_filen
 from franchise_resolver import resolve_franchise
 from genre_resolver import resolve_genre
 from source_history import make_entry
+from mediaops_schema import create_schema_if_needed
 
 WS = re.compile(r"[\s\u3000]+")
 BAD = re.compile(r"[<>:\"/\\\\|?*]")
@@ -406,19 +408,46 @@ class _EpgCache:
         self._by_datetime_key: dict[str, list[dict]] = {}
         try:
             rows = con.execute(
-                "SELECT data_json FROM path_metadata WHERE source='edcb_epg'",
+                """
+                SELECT
+                  b.broadcast_id,
+                  b.program_id,
+                  p.canonical_title,
+                  b.air_date,
+                  b.start_time,
+                  b.end_time,
+                  b.broadcaster,
+                  b.match_key,
+                  b.data_json
+                FROM broadcasts b
+                JOIN programs p ON p.program_id = b.program_id
+                """,
             ).fetchall()
         except sqlite3.Error:
             return
         for row in rows:
             try:
-                data = json.loads(row[0])
+                payload = json.loads(row["data_json"] or "{}")
             except Exception:
-                continue
-            if not isinstance(data, dict):
-                continue
+                payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+
+            data = dict(payload)
+            data.setdefault("broadcast_id", row["broadcast_id"])
+            data.setdefault("program_id", row["program_id"])
+            data.setdefault("official_title", row["canonical_title"])
+            data.setdefault("air_date", row["air_date"])
+            data.setdefault("start_time", row["start_time"])
+            data.setdefault("end_time", row["end_time"])
+            data.setdefault("broadcaster", row["broadcaster"])
+            data.setdefault("match_key", row["match_key"])
             mk = data.get("match_key")
-            dk = data.get("datetime_key")
+            dk = data.get("datetime_key") or (
+                f"{data.get('air_date')}::{data.get('start_time')}"
+                if data.get("air_date") and data.get("start_time")
+                else None
+            )
             if mk:
                 self._by_match_key[mk] = data
                 # Build title::date::time key (strip broadcaster segment)
@@ -575,6 +604,8 @@ def main() -> int:
     generated_input_jsonl_paths: list[str] = []
     generated_output_jsonl_paths: list[str] = []
     db_con = sqlite3.connect(args.db)
+    db_con.row_factory = sqlite3.Row
+    create_schema_if_needed(db_con)
     epg_cache = _EpgCache(db_con)
 
     def flush():
@@ -589,6 +620,7 @@ def main() -> int:
         write_jsonl(bpath, batch)
 
         rows = []
+        path_program_links: dict[tuple[str, str], tuple[str | None, str]] = {}
         for rec in batch:
             pid = rec.get("path_id")
             if pid and not args.ignore_human_reviewed:
@@ -673,6 +705,11 @@ def main() -> int:
             dk = datetime_key_from_filename(name)
             epg = epg_cache.lookup(mk, dk)
             _enrich_with_epg(row, epg)
+            if epg and rec.get("path_id") and epg.get("program_id"):
+                path_program_links[(str(rec["path_id"]), str(epg["program_id"]))] = (
+                    str(epg.get("broadcast_id")) if epg.get("broadcast_id") else None,
+                    "reextract",
+                )
 
             row["genre"] = resolve_genre(row)
             row["franchise"] = resolve_franchise(row, args.franchise_rules or None)
@@ -696,6 +733,22 @@ def main() -> int:
             sys.argv += ["--franchise-rules", args.franchise_rules]
         if _upsert_main() != 0:
             raise SystemExit(f"upsert failed: {epath}")
+
+        if path_program_links:
+            ts_now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            for (path_id, program_id), (broadcast_id, source) in path_program_links.items():
+                db_con.execute(
+                    """
+                    INSERT INTO path_programs (path_id, program_id, broadcast_id, source, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(path_id, program_id) DO UPDATE SET
+                      broadcast_id=excluded.broadcast_id,
+                      source=excluded.source,
+                      updated_at=excluded.updated_at
+                    """,
+                    (path_id, program_id, broadcast_id, source, ts_now),
+                )
+            db_con.commit()
 
         generated_input_jsonl_paths.append(str(bpath))
         generated_output_jsonl_paths.append(str(epath))


### PR DESCRIPTION
### Motivation
- EPG（`.program.txt` 由来）をファイル（`path_metadata`）に紐付けたままにするとファイル削除で情報が失われるため、番組情報をファイル非依存で保持する設計に移行するための変更です。
- reextract 時にエンコード後ファイルと放送履歴を照合して紐付ける仕組みを整備する必要がありました。

### Description
- スキーマ変更: `py/mediaops_schema.py` に新テーブルを追加して、`programs` / `broadcasts` / `path_programs` と関連インデックスを導入しました。
- ingest 更新: `py/ingest_program_txt.py` を書き換え、EPG取り込みは `path_metadata(source='edcb_epg')` ではなく `programs` + `broadcasts` に保存するように変更しました（`program_key` 正規化、決定論的ID生成、`data_json` にEPG全体を保存、`ON CONFLICT` の upsert 対応）。
- reextract 連携: `py/run_metadata_batches_promptv1.py` の EPG キャッシュ参照を `broadcasts JOIN programs` に切り替え、reextract 実行時に照合できた場合 `path_programs` に `source='reextract'` で UPSERT する処理を追加しました（`path_programs` によるファイル→番組紐付け）。
- マイグレーション: 新規スクリプト `py/migrate_epg_to_programs.py` を追加し、既存の `path_metadata (source='edcb_epg')` レコードを `programs`/`broadcasts` へ移行する dry-run/apply フローと `--delete-source` オプションを提供します。 
- ドキュメント: `README.md` のスキーマ図・テーブル概要・`source` 列挙を新構成に合わせて更新しました。

### Testing
- 型チェック／構文チェックとして `python -m py_compile py/mediaops_schema.py py/ingest_program_txt.py py/run_metadata_batches_promptv1.py py/migrate_epg_to_programs.py` を実行し成功しました. 
- 各スクリプトのヘルプ表示を確認するために `python py/ingest_program_txt.py --help`, `python py/migrate_epg_to_programs.py --help`, `python py/run_metadata_batches_promptv1.py --help` を実行し正常に起動（ヘルプ出力）することを確認しました (出力: `ok`)。 

補足: 実際のデータベースマイグレーション（`py/migrate_epg_to_programs.py --apply` の実行）は依頼どおりここでは行っておらず、実運用DBへの適用は別途実行してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab989b61a08329a5a96b0799d1fa16)