### PR TITLE
EPGデータを programs/broadcasts に分離し reextract の path_programs 連携を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ flowchart TD
     %% ── 前処理: EPG ──
     EPG_START(["EDCB .program.txt"])
     EPG_INGEST["video_pipeline_ingest_epg<br/>py/ingest_program_txt.py<br/>py/edcb_program_parser.py"]
-    EPG_DB[("path_metadata<br/>source='edcb_epg'")]
+    EPG_DB[("programs / broadcasts")]
     EPG_START --> EPG_INGEST --> EPG_DB
 
     %% ── Stage 1: Normalize ──
@@ -653,6 +653,33 @@ erDiagram
         TEXT updated_at
     }
 
+    programs {
+        TEXT program_id PK
+        TEXT program_key UK
+        TEXT canonical_title
+        TEXT created_at
+    }
+
+    broadcasts {
+        TEXT broadcast_id PK
+        TEXT program_id FK
+        TEXT air_date
+        TEXT start_time
+        TEXT end_time
+        TEXT broadcaster
+        TEXT match_key UK
+        TEXT data_json
+        TEXT created_at
+    }
+
+    path_programs {
+        TEXT path_id FK
+        TEXT program_id FK
+        TEXT broadcast_id FK
+        TEXT source
+        TEXT updated_at
+    }
+
     tags {
         INTEGER tag_id PK
         TEXT name
@@ -690,6 +717,10 @@ erDiagram
     runs ||--o{ events : "triggered"
     paths ||--o{ events : "src/dst"
     paths ||--|| path_metadata : "has metadata"
+    programs ||--o{ broadcasts : "has airings"
+    paths ||--o{ path_programs : "linked to programs"
+    programs ||--o{ path_programs : "linked from files"
+    broadcasts ||--o{ path_programs : "matched airing"
     paths ||--o{ path_tags : "tagged"
     tags ||--o{ path_tags : "applied to"
     broadcast_groups ||--o{ broadcast_group_members : "contains"
@@ -707,6 +738,8 @@ erDiagram
 | `observations`                                   | 実行時のファイル状態スナップショット (size/mtime)                  |
 | `events`                                         | 移動・リロケート等のアクション記録 (成否追跡)                      |
 | `path_metadata`                                  | 抽出メタデータ (source + data_json にJSONで格納)                   |
+| `programs` / `broadcasts`                      | ファイル非依存の番組マスタ + 放送履歴 (EPG)                        |
+| `path_programs`                                | ファイルと番組/放送履歴の紐付け (reextract由来)                    |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
 | `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
 
@@ -734,9 +767,9 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 | ---------------- | ----------------------- | ------------------------------------ |
 | `rule_based`   | ルールベース抽出        | `run_metadata_batches_promptv1.py` |
 | `llm_subagent` | LLMサブエージェント抽出 | `apply_llm_extract_output.py`      |
-| `edcb_epg`     | EPG取り込み             | `ingest_program_txt.py`            |
 
 > `source='rule_based'` はルールベース抽出の結果を示す。旧値 `llm` は移行スクリプトで `rule_based` に統一可能。
+> EPG取り込みデータは `path_metadata` ではなく `programs` / `broadcasts` に保存される。
 
 ### is_current 運用
 

--- a/py/ingest_program_txt.py
+++ b/py/ingest_program_txt.py
@@ -1,11 +1,7 @@
 """Ingest EDCB .program.txt files into mediaops.sqlite.
 
 Scans a TS recording directory for .program.txt companion files,
-parses them, and stores structured EPG metadata in the database.
-
-The metadata is stored in `path_metadata` with source='edcb_epg'.
-Match keys are stored in data_json so that encoded files (MP4) can
-be correlated with the original EPG data later.
+parses them, and stores EPG metadata in programs/broadcasts tables.
 
 Usage:
   cd <video-library-pipeline-dir>/py
@@ -21,15 +17,9 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from edcb_program_parser import (
-    datetime_key_from_epg,
-    match_key_from_epg,
-    match_key_from_filename,
-    parse_program_txt,
-)
+from edcb_program_parser import match_key_from_epg, parse_program_txt
 from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed, fetchone
-from pathscan_common import now_iso, path_id_for, split_win, wsl_to_windows_path
-from source_history import make_entry
+from pathscan_common import now_iso
 
 
 def find_program_txt_files(ts_root: Path) -> list[Path]:
@@ -37,92 +27,25 @@ def find_program_txt_files(ts_root: Path) -> list[Path]:
     return sorted(ts_root.rglob("*.program.txt"))
 
 
-def ts_path_from_program_txt(program_txt_path: Path) -> Path | None:
-    """Derive the .ts file path from its .program.txt companion.
-
-    EDCB naming: "title_date.ts.program.txt" → "title_date.ts"
-    """
-    name = program_txt_path.name
-    if name.endswith(".ts.program.txt"):
-        ts_name = name[: -len(".program.txt")]
-        return program_txt_path.parent / ts_name
-    return None
+def _normalize_program_key(title: str) -> str:
+    return " ".join(str(title or "").strip().lower().split())
 
 
-def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
-    """Re-generate match_keys for existing edcb_epg records (old→new format).
+def _program_id_for_key(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program:{program_key}"))
 
-    New format includes broadcaster: title::broadcaster::date::time
-    """
-    con = connect_db(db_path)
-    rows = con.execute(
-        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'",
-    ).fetchall()
 
-    updated = 0
-    skipped = 0
-    for path_id, data_json_str in rows:
-        try:
-            data = json.loads(data_json_str)
-        except Exception:
-            skipped += 1
-            continue
-        if not isinstance(data, dict):
-            skipped += 1
-            continue
-
-        title = data.get("official_title", "")
-        broadcaster = data.get("broadcaster", "")
-        air_date = data.get("air_date", "")
-        start_time = data.get("start_time", "")
-        if not title or not air_date or not start_time:
-            skipped += 1
-            continue
-
-        new_mk = match_key_from_epg({
-            "official_title": title,
-            "broadcaster": broadcaster,
-            "air_date": air_date,
-            "start_time": start_time,
-        })
-        old_mk = data.get("match_key")
-        if new_mk == old_mk:
-            skipped += 1
-            continue
-
-        data["match_key"] = new_mk
-        updated += 1
-
-        if not dry_run:
-            con.execute(
-                "UPDATE path_metadata SET data_json=?, updated_at=? WHERE path_id=? AND source='edcb_epg'",
-                (json.dumps(data, ensure_ascii=False), now_iso(), path_id),
-            )
-
-    if not dry_run:
-        con.commit()
-    con.close()
-
-    result = {"tool": "migrate_match_keys", "dry_run": dry_run, "total": len(rows), "updated": updated, "skipped": skipped}
-    print(json.dumps(result, ensure_ascii=False))
-    return 0
+def _broadcast_id_for_match_key(match_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast:{match_key}"))
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", required=True)
-    ap.add_argument("--ts-root", help="WSL path to TS recording directory (e.g. /mnt/j/TVFile)")
+    ap.add_argument("--ts-root", required=True, help="WSL path to TS recording directory (e.g. /mnt/j/TVFile)")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--limit", type=int, default=0)
-    ap.add_argument("--migrate-match-keys", action="store_true", help="Re-generate match_keys for existing edcb_epg records")
-    ap.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
     args = ap.parse_args()
-
-    if args.migrate_match_keys:
-        return _migrate_match_keys(args.db, dry_run=args.dry_run)
-
-    if not args.ts_root:
-        ap.error("--ts-root is required unless --migrate-match-keys is used")
 
     if not os.path.exists(args.db):
         raise SystemExit(f"DB not found: {args.db}")
@@ -153,7 +76,6 @@ def main() -> int:
             if args.limit and total > args.limit:
                 break
 
-            # Parse the program.txt
             epg = parse_program_txt(ptxt)
             if not epg:
                 skipped_parse_failed += 1
@@ -161,57 +83,50 @@ def main() -> int:
                 continue
             parsed += 1
 
-            # Derive TS file path and its Windows equivalent
-            ts_path = ts_path_from_program_txt(ptxt)
-            if not ts_path:
+            match_key = match_key_from_epg(epg)
+            if not match_key:
                 skipped_parse_failed += 1
-                errors.append(f"cannot_derive_ts_path: {ptxt.name}")
+                errors.append(f"missing_match_key: {ptxt.name}")
                 continue
 
-            ts_win_path = wsl_to_windows_path(str(ts_path))
-            pid = path_id_for(ts_win_path)
-
-            # Check if already ingested (idempotency)
             existing = fetchone(
                 con,
-                "SELECT path_id FROM path_metadata WHERE path_id = ? AND source = 'edcb_epg'",
-                (pid,),
+                "SELECT broadcast_id FROM broadcasts WHERE match_key = ?",
+                (match_key,),
             )
             if existing:
                 skipped_already_ingested += 1
                 continue
 
-            # Generate match keys for correlation with encoded files
-            match_key = match_key_from_epg(epg)
-            dt_key = datetime_key_from_epg(epg)
+            canonical_title = str(epg.get("official_title") or "").strip()
+            if not canonical_title:
+                skipped_parse_failed += 1
+                errors.append(f"missing_title: {ptxt.name}")
+                continue
 
-            # Build the data payload
-            data = {
-                "match_key": match_key,
-                "datetime_key": dt_key,
-                "air_date": epg["air_date"],
-                "start_time": epg["start_time"],
-                "end_time": epg["end_time"],
-                "broadcaster": epg["broadcaster"],
-                "broadcaster_raw": epg["broadcaster_raw"],
-                "official_title": epg["official_title"],
-                "title_raw": epg["title_raw"],
-                "annotations": epg["annotations"],
-                "is_rebroadcast_flag": epg["is_rebroadcast_flag"],
-                "description": epg["description"][:500] if epg["description"] else None,
-                "epg_genres": epg["epg_genres"],
-                "network_ids": epg["network_ids"],
-                "ts_path": ts_win_path,
-                "program_txt_path": str(ptxt),
-                "ingested_at": now_iso(),
-            }
-            data["source_history"] = [make_entry("edcb_epg", list(data.keys()))]
+            program_key = _normalize_program_key(canonical_title)
+            program_id = _program_id_for_key(program_key)
+            broadcast_id = _broadcast_id_for_match_key(match_key)
 
-            rows_to_insert.append({
-                "pid": pid,
-                "ts_win_path": ts_win_path,
-                "data": data,
-            })
+            payload = dict(epg)
+            payload["match_key"] = match_key
+            payload["ingested_at"] = now_iso()
+
+            rows_to_insert.append(
+                {
+                    "program_id": program_id,
+                    "program_key": program_key,
+                    "canonical_title": canonical_title,
+                    "broadcast_id": broadcast_id,
+                    "match_key": match_key,
+                    "air_date": epg.get("air_date"),
+                    "start_time": epg.get("start_time"),
+                    "end_time": epg.get("end_time"),
+                    "broadcaster": epg.get("broadcaster"),
+                    "data_json": json.dumps(payload, ensure_ascii=False),
+                    "created_at": now_iso(),
+                }
+            )
 
         if not args.apply:
             summary = {
@@ -229,7 +144,6 @@ def main() -> int:
             print(json.dumps(summary, ensure_ascii=False))
             return 0
 
-        # Apply: write to DB
         begin_immediate(con)
         con.execute(
             """
@@ -240,34 +154,38 @@ def main() -> int:
         )
 
         for row in rows_to_insert:
-            pid = row["pid"]
-            ts_win_path = row["ts_win_path"]
-            data = row["data"]
-            drive, dir_, name, ext = split_win(ts_win_path)
-            ts_now = now_iso()
-
-            # Ensure path exists in paths table
             con.execute(
                 """
-                INSERT INTO paths (path_id, path, drive, dir, name, ext, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET updated_at=excluded.updated_at
+                INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(program_id) DO UPDATE SET
+                  canonical_title=excluded.canonical_title
                 """,
-                (pid, ts_win_path, drive, dir_, name, ext, ts_now, ts_now),
+                (row["program_id"], row["program_key"], row["canonical_title"], row["created_at"]),
             )
-
-            # Insert EPG metadata
-            data_json = json.dumps(data, ensure_ascii=False)
             con.execute(
                 """
-                INSERT INTO path_metadata (path_id, source, data_json, updated_at)
-                VALUES (?, 'edcb_epg', ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET
-                  source='edcb_epg',
-                  data_json=excluded.data_json,
-                  updated_at=excluded.updated_at
+                INSERT INTO broadcasts (broadcast_id, program_id, air_date, start_time, end_time, broadcaster, match_key, data_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(broadcast_id) DO UPDATE SET
+                  air_date=excluded.air_date,
+                  start_time=excluded.start_time,
+                  end_time=excluded.end_time,
+                  broadcaster=excluded.broadcaster,
+                  match_key=excluded.match_key,
+                  data_json=excluded.data_json
                 """,
-                (pid, data_json, ts_now),
+                (
+                    row["broadcast_id"],
+                    row["program_id"],
+                    row["air_date"],
+                    row["start_time"],
+                    row["end_time"],
+                    row["broadcaster"],
+                    row["match_key"],
+                    row["data_json"],
+                    row["created_at"],
+                ),
             )
             ingested += 1
 

--- a/py/mediaops_schema.py
+++ b/py/mediaops_schema.py
@@ -130,6 +130,44 @@ DDL_STATEMENTS = [
     )
     """,
     """
+    CREATE TABLE IF NOT EXISTS programs (
+      program_id TEXT PRIMARY KEY,
+      program_key TEXT NOT NULL UNIQUE,
+      canonical_title TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS broadcasts (
+      broadcast_id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL,
+      air_date TEXT,
+      start_time TEXT,
+      end_time TEXT,
+      broadcaster TEXT,
+      match_key TEXT UNIQUE,
+      data_json TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (program_id) REFERENCES programs(program_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_program ON broadcasts(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_air ON broadcasts(air_date, start_time)",
+    """
+    CREATE TABLE IF NOT EXISTS path_programs (
+      path_id TEXT NOT NULL,
+      program_id TEXT NOT NULL,
+      broadcast_id TEXT,
+      source TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (path_id, program_id),
+      FOREIGN KEY (path_id) REFERENCES paths(path_id),
+      FOREIGN KEY (program_id) REFERENCES programs(program_id),
+      FOREIGN KEY (broadcast_id) REFERENCES broadcasts(broadcast_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_program ON path_programs(program_id)",
+    """
     CREATE TABLE IF NOT EXISTS broadcast_groups (
       group_id TEXT PRIMARY KEY,
       program_title TEXT NOT NULL,

--- a/py/migrate_epg_to_programs.py
+++ b/py/migrate_epg_to_programs.py
@@ -1,0 +1,155 @@
+"""Migrate legacy path_metadata(source='edcb_epg') into programs/broadcasts.
+
+Usage:
+  python migrate_epg_to_programs.py --db <db-path> [--apply] [--delete-source]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+from pathscan_common import now_iso
+
+
+def _normalize_program_key(title: str) -> str:
+    return " ".join(str(title or "").strip().lower().split())
+
+
+def _program_id_for_key(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program:{program_key}"))
+
+
+def _broadcast_id_for_match_key(match_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast:{match_key}"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--delete-source", action="store_true", help="Also delete migrated source rows from path_metadata")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.db):
+        raise SystemExit(f"DB not found: {args.db}")
+
+    con = connect_db(args.db)
+    create_schema_if_needed(con)
+
+    rows = con.execute(
+        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'"
+    ).fetchall()
+
+    migrated = 0
+    skipped = 0
+    invalid = 0
+    candidates: list[dict] = []
+
+    for path_id, data_json in rows:
+        try:
+            data = json.loads(data_json)
+        except Exception:
+            invalid += 1
+            continue
+        if not isinstance(data, dict):
+            invalid += 1
+            continue
+
+        title = str(data.get("official_title") or "").strip()
+        match_key = str(data.get("match_key") or "").strip()
+        if not title or not match_key:
+            skipped += 1
+            continue
+
+        program_key = _normalize_program_key(title)
+        candidates.append(
+            {
+                "path_id": path_id,
+                "program_id": _program_id_for_key(program_key),
+                "program_key": program_key,
+                "canonical_title": title,
+                "broadcast_id": _broadcast_id_for_match_key(match_key),
+                "match_key": match_key,
+                "air_date": data.get("air_date"),
+                "start_time": data.get("start_time"),
+                "end_time": data.get("end_time"),
+                "broadcaster": data.get("broadcaster"),
+                "data_json": json.dumps(data, ensure_ascii=False),
+                "created_at": now_iso(),
+            }
+        )
+
+    if not args.apply:
+        print(json.dumps({
+            "ok": True,
+            "tool": "migrate_epg_to_programs",
+            "apply": False,
+            "totalLegacyRows": len(rows),
+            "wouldMigrate": len(candidates),
+            "skipped": skipped,
+            "invalid": invalid,
+            "deleteSource": bool(args.delete_source),
+        }, ensure_ascii=False))
+        con.close()
+        return 0
+
+    begin_immediate(con)
+    try:
+        for row in candidates:
+            con.execute(
+                """
+                INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(program_id) DO UPDATE SET canonical_title=excluded.canonical_title
+                """,
+                (row["program_id"], row["program_key"], row["canonical_title"], row["created_at"]),
+            )
+            con.execute(
+                """
+                INSERT INTO broadcasts (broadcast_id, program_id, air_date, start_time, end_time, broadcaster, match_key, data_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(broadcast_id) DO UPDATE SET
+                  program_id=excluded.program_id,
+                  air_date=excluded.air_date,
+                  start_time=excluded.start_time,
+                  end_time=excluded.end_time,
+                  broadcaster=excluded.broadcaster,
+                  match_key=excluded.match_key,
+                  data_json=excluded.data_json
+                """,
+                (
+                    row["broadcast_id"], row["program_id"], row["air_date"], row["start_time"], row["end_time"],
+                    row["broadcaster"], row["match_key"], row["data_json"], row["created_at"],
+                ),
+            )
+            migrated += 1
+
+        if args.delete_source:
+            con.execute("DELETE FROM path_metadata WHERE source='edcb_epg'")
+
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    finally:
+        con.close()
+
+    print(json.dumps({
+        "ok": True,
+        "tool": "migrate_epg_to_programs",
+        "apply": True,
+        "totalLegacyRows": len(rows),
+        "migrated": migrated,
+        "skipped": skipped,
+        "invalid": invalid,
+        "deleteSource": bool(args.delete_source),
+    }, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
 import re
@@ -392,13 +393,7 @@ def extract_title_ai_primary(name: str, base: str, alias_hints: HintSet) -> dict
 
 
 class _EpgCache:
-    """Pre-loaded EPG metadata cache for fast lookup by match_key / datetime_key.
-
-    Indexes:
-    - _by_match_key: full key including broadcaster (no collision)
-    - _by_title_dt: title::date::time (old format) → list of EPG dicts
-    - _by_datetime_key: date::time → list of EPG dicts
-    """
+    """Pre-loaded EPG metadata cache for fast lookup by match_key / datetime_key."""
 
     def __init__(self, con: sqlite3.Connection):
         self._by_match_key: dict[str, dict] = {}
@@ -406,39 +401,42 @@ class _EpgCache:
         self._by_datetime_key: dict[str, list[dict]] = {}
         try:
             rows = con.execute(
-                "SELECT data_json FROM path_metadata WHERE source='edcb_epg'",
+                """
+                SELECT b.broadcast_id, b.program_id, b.match_key, b.air_date, b.start_time, b.data_json
+                FROM broadcasts b
+                """,
             ).fetchall()
         except sqlite3.Error:
             return
         for row in rows:
+            broadcast_id, program_id, mk, air_date, start_time, data_json = row
+            data: dict[str, Any] = {}
             try:
-                data = json.loads(row[0])
+                parsed = json.loads(data_json) if data_json else {}
+                if isinstance(parsed, dict):
+                    data = parsed
             except Exception:
-                continue
-            if not isinstance(data, dict):
-                continue
-            mk = data.get("match_key")
-            dk = data.get("datetime_key")
+                data = {}
+            if mk and not data.get("match_key"):
+                data["match_key"] = mk
+            item = {
+                "program_id": program_id,
+                "broadcast_id": broadcast_id,
+                "data": data,
+            }
             if mk:
-                self._by_match_key[mk] = data
-                # Build title::date::time key (strip broadcaster segment)
-                parts = mk.split("::")
+                self._by_match_key[mk] = item
+                parts = str(mk).split("::")
                 if len(parts) == 4:
                     title_dt = f"{parts[0]}::{parts[2]}::{parts[3]}"
-                    self._by_title_dt.setdefault(title_dt, []).append(data)
+                    self._by_title_dt.setdefault(title_dt, []).append(item)
                 elif len(parts) == 3:
-                    # Legacy format without broadcaster
-                    self._by_title_dt.setdefault(mk, []).append(data)
-            if dk:
-                self._by_datetime_key.setdefault(dk, []).append(data)
+                    self._by_title_dt.setdefault(mk, []).append(item)
+            if air_date and start_time:
+                dk = f"{air_date}::{start_time}"
+                self._by_datetime_key.setdefault(dk, []).append(item)
 
     def lookup(self, match_key: str | None, datetime_key: str | None) -> dict | None:
-        """Find EPG data by match_key, title_dt fallback, then datetime_key.
-
-        match_key from filename has no broadcaster segment (title::date::time),
-        so we try _by_match_key first (EPG-to-EPG exact), then _by_title_dt
-        (filename-to-EPG), then _by_datetime_key (date+time only).
-        """
         if match_key:
             if match_key in self._by_match_key:
                 return self._by_match_key[match_key]
@@ -449,9 +447,12 @@ class _EpgCache:
         return None
 
 
-def _enrich_with_epg(row: dict, epg: dict | None) -> None:
+def _enrich_with_epg(row: dict, epg_item: dict | None) -> None:
     """Add EPG-sourced fields to a metadata row (in-place)."""
-    if not epg:
+    if not epg_item:
+        return
+    epg = epg_item.get("data") if isinstance(epg_item, dict) else None
+    if not isinstance(epg, dict):
         return
     row["broadcaster"] = epg.get("broadcaster")
     row["epg_genre"] = None
@@ -589,6 +590,7 @@ def main() -> int:
         write_jsonl(bpath, batch)
 
         rows = []
+        path_program_links: list[tuple[str, str, str | None]] = []
         for rec in batch:
             pid = rec.get("path_id")
             if pid and not args.ignore_human_reviewed:
@@ -671,8 +673,16 @@ def main() -> int:
             # EPG enrichment: look up ingested program.txt data
             mk = match_key_from_filename(name)
             dk = datetime_key_from_filename(name)
-            epg = epg_cache.lookup(mk, dk)
-            _enrich_with_epg(row, epg)
+            epg_item = epg_cache.lookup(mk, dk)
+            _enrich_with_epg(row, epg_item)
+            if epg_item and row.get("path_id") and epg_item.get("program_id"):
+                path_program_links.append(
+                    (
+                        str(row["path_id"]),
+                        str(epg_item["program_id"]),
+                        str(epg_item.get("broadcast_id")) if epg_item.get("broadcast_id") else None,
+                    )
+                )
 
             row["genre"] = resolve_genre(row)
             row["franchise"] = resolve_franchise(row, args.franchise_rules or None)
@@ -696,6 +706,24 @@ def main() -> int:
             sys.argv += ["--franchise-rules", args.franchise_rules]
         if _upsert_main() != 0:
             raise SystemExit(f"upsert failed: {epath}")
+
+        if path_program_links:
+            ts_now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            try:
+                db_con.executemany(
+                    """
+                    INSERT INTO path_programs (path_id, program_id, broadcast_id, source, updated_at)
+                    VALUES (?, ?, ?, 'reextract', ?)
+                    ON CONFLICT(path_id, program_id) DO UPDATE SET
+                      broadcast_id=excluded.broadcast_id,
+                      source='reextract',
+                      updated_at=excluded.updated_at
+                    """,
+                    [(pid, pgid, bid, ts_now) for (pid, pgid, bid) in path_program_links],
+                )
+                db_con.commit()
+            except sqlite3.Error as e:
+                print(f"W path_programs upsert skipped: {e}")
 
         generated_input_jsonl_paths.append(str(bpath))
         generated_output_jsonl_paths.append(str(epath))


### PR DESCRIPTION
### Motivation
- 現在 `path_metadata` に入っている EPG（`source='edcb_epg'`）はファイル依存であり、TS が削除されると紐付けが失われるため、EPG をファイル非依存の番組テーブルへ移行して再利用性と安定性を高めることを目的としています。

### Description
- 追加したスキーマ: `py/mediaops_schema.py` に `programs` / `broadcasts` / `path_programs` のDDLと関連インデックスを追加して EPG を独立保存できるようにしました (`broadcasts.match_key` による一意判定を含む)。
- EPG取り込み変更: `py/ingest_program_txt.py` を更新して `.program.txt` の取り込み先を `programs` + `broadcasts` に変更し、`path_metadata` への `edcb_epg` 書き込みは廃止して `match_key` ベースの冪等性を `broadcasts` で判定するようにしました（`program_id`/`broadcast_id` は `uuid5` で生成）。
- reextract 連携: `py/run_metadata_batches_promptv1.py` を修正して EPG 参照元を `broadcasts` に切り替え、reextract 実行時に照合結果を `path_programs` へ `ON CONFLICT` で upsert する処理を追加しました（`source='reextract'` として保存）。
- マイグレーションスクリプト: `py/migrate_epg_to_programs.py` を新規追加し、既存 `path_metadata(source='edcb_epg')` を `programs`/`broadcasts` に移行するための `--apply` / `--delete-source` オプションを提供しました。
- ドキュメント更新: `README.md` のフロー図・ER図と `source` 説明を新しい保存先（`programs`/`broadcasts`/`path_programs`）に合わせて更新しました。

### Testing
- 自動構文チェックとして `python -m py_compile py/mediaops_schema.py py/ingest_program_txt.py py/run_metadata_batches_promptv1.py py/migrate_epg_to_programs.py` を実行し、構文エラーは検出されませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab989b61a08329a5a96b0799d1fa16)