### PR TITLE
Separate EPG into programs/broadcasts and add path_programs linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,33 @@ erDiagram
         TEXT updated_at
     }
 
+    programs {
+        TEXT program_id PK
+        TEXT program_key UK
+        TEXT canonical_title
+        TEXT created_at
+    }
+
+    broadcasts {
+        TEXT broadcast_id PK
+        TEXT program_id FK
+        TEXT air_date
+        TEXT start_time
+        TEXT end_time
+        TEXT broadcaster
+        TEXT match_key UK
+        TEXT data_json
+        TEXT created_at
+    }
+
+    path_programs {
+        TEXT path_id FK
+        TEXT program_id FK
+        TEXT broadcast_id FK
+        TEXT source
+        TEXT updated_at
+    }
+
     tags {
         INTEGER tag_id PK
         TEXT name
@@ -690,6 +717,10 @@ erDiagram
     runs ||--o{ events : "triggered"
     paths ||--o{ events : "src/dst"
     paths ||--|| path_metadata : "has metadata"
+    programs ||--o{ broadcasts : "has airings"
+    paths ||--o{ path_programs : "linked"
+    programs ||--o{ path_programs : "linked"
+    broadcasts ||--o{ path_programs : "matched"
     paths ||--o{ path_tags : "tagged"
     tags ||--o{ path_tags : "applied to"
     broadcast_groups ||--o{ broadcast_group_members : "contains"
@@ -707,6 +738,8 @@ erDiagram
 | `observations`                                   | 実行時のファイル状態スナップショット (size/mtime)                  |
 | `events`                                         | 移動・リロケート等のアクション記録 (成否追跡)                      |
 | `path_metadata`                                  | 抽出メタデータ (source + data_json にJSONで格納)                   |
+| `programs` / `broadcasts`                      | ファイル非依存の番組シリーズ・放送履歴 (EPG由来の正規テーブル)      |
+| `path_programs`                                | ファイルと番組シリーズの紐付け (reextract等で更新)                 |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
 | `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
 
@@ -734,7 +767,6 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 | ---------------- | ----------------------- | ------------------------------------ |
 | `rule_based`   | ルールベース抽出        | `run_metadata_batches_promptv1.py` |
 | `llm_subagent` | LLMサブエージェント抽出 | `apply_llm_extract_output.py`      |
-| `edcb_epg`     | EPG取り込み             | `ingest_program_txt.py`            |
 
 > `source='rule_based'` はルールベース抽出の結果を示す。旧値 `llm` は移行スクリプトで `rule_based` に統一可能。
 

--- a/py/ingest_program_txt.py
+++ b/py/ingest_program_txt.py
@@ -1,11 +1,7 @@
-"""Ingest EDCB .program.txt files into mediaops.sqlite.
+"""Ingest EDCB .program.txt files into program/broadcast tables.
 
 Scans a TS recording directory for .program.txt companion files,
-parses them, and stores structured EPG metadata in the database.
-
-The metadata is stored in `path_metadata` with source='edcb_epg'.
-Match keys are stored in data_json so that encoded files (MP4) can
-be correlated with the original EPG data later.
+parses them, and stores EPG metadata in `programs` + `broadcasts`.
 
 Usage:
   cd <video-library-pipeline-dir>/py
@@ -17,19 +13,35 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import unicodedata
 import uuid
 from pathlib import Path
 from typing import Any
 
-from edcb_program_parser import (
-    datetime_key_from_epg,
-    match_key_from_epg,
-    match_key_from_filename,
-    parse_program_txt,
-)
-from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed, fetchone
-from pathscan_common import now_iso, path_id_for, split_win, wsl_to_windows_path
-from source_history import make_entry
+from edcb_program_parser import datetime_key_from_epg, match_key_from_epg, parse_program_txt
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+from pathscan_common import now_iso
+
+WS = re.compile(r"[\s\u3000]+")
+BAD = re.compile(r"[<>:\"/\\|?*]")
+UND = re.compile(r"_+")
+
+
+def normalize_program_key(title: str) -> str:
+    t = unicodedata.normalize("NFKC", str(title or "")).strip().lower()
+    t = WS.sub("_", t)
+    t = BAD.sub("", t)
+    t = UND.sub("_", t).strip("_")
+    return t or "unknown"
+
+
+def program_id_for(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program_key:{program_key}"))
+
+
+def broadcast_id_for(match_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast_match_key:{match_key}"))
 
 
 def find_program_txt_files(ts_root: Path) -> list[Path]:
@@ -37,31 +49,14 @@ def find_program_txt_files(ts_root: Path) -> list[Path]:
     return sorted(ts_root.rglob("*.program.txt"))
 
 
-def ts_path_from_program_txt(program_txt_path: Path) -> Path | None:
-    """Derive the .ts file path from its .program.txt companion.
-
-    EDCB naming: "title_date.ts.program.txt" → "title_date.ts"
-    """
-    name = program_txt_path.name
-    if name.endswith(".ts.program.txt"):
-        ts_name = name[: -len(".program.txt")]
-        return program_txt_path.parent / ts_name
-    return None
-
-
 def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
-    """Re-generate match_keys for existing edcb_epg records (old→new format).
-
-    New format includes broadcaster: title::broadcaster::date::time
-    """
+    """Re-generate match_keys for existing broadcasts (old→new format)."""
     con = connect_db(db_path)
-    rows = con.execute(
-        "SELECT path_id, data_json FROM path_metadata WHERE source='edcb_epg'",
-    ).fetchall()
+    rows = con.execute("SELECT broadcast_id, data_json FROM broadcasts").fetchall()
 
     updated = 0
     skipped = 0
-    for path_id, data_json_str in rows:
+    for broadcast_id, data_json_str in rows:
         try:
             data = json.loads(data_json_str)
         except Exception:
@@ -95,8 +90,8 @@ def _migrate_match_keys(db_path: str, *, dry_run: bool = False) -> int:
 
         if not dry_run:
             con.execute(
-                "UPDATE path_metadata SET data_json=?, updated_at=? WHERE path_id=? AND source='edcb_epg'",
-                (json.dumps(data, ensure_ascii=False), now_iso(), path_id),
+                "UPDATE broadcasts SET match_key=?, data_json=? WHERE broadcast_id=?",
+                (new_mk, json.dumps(data, ensure_ascii=False), broadcast_id),
             )
 
     if not dry_run:
@@ -114,7 +109,7 @@ def main() -> int:
     ap.add_argument("--ts-root", help="WSL path to TS recording directory (e.g. /mnt/j/TVFile)")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--limit", type=int, default=0)
-    ap.add_argument("--migrate-match-keys", action="store_true", help="Re-generate match_keys for existing edcb_epg records")
+    ap.add_argument("--migrate-match-keys", action="store_true", help="Re-generate match_keys for existing broadcast records")
     ap.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
     args = ap.parse_args()
 
@@ -153,7 +148,6 @@ def main() -> int:
             if args.limit and total > args.limit:
                 break
 
-            # Parse the program.txt
             epg = parse_program_txt(ptxt)
             if not epg:
                 skipped_parse_failed += 1
@@ -161,31 +155,20 @@ def main() -> int:
                 continue
             parsed += 1
 
-            # Derive TS file path and its Windows equivalent
-            ts_path = ts_path_from_program_txt(ptxt)
-            if not ts_path:
-                skipped_parse_failed += 1
-                errors.append(f"cannot_derive_ts_path: {ptxt.name}")
-                continue
+            match_key = match_key_from_epg(epg)
+            dt_key = datetime_key_from_epg(epg)
+            program_key = normalize_program_key(str(epg.get("official_title") or ""))
+            program_id = program_id_for(program_key)
+            broadcast_id = broadcast_id_for(match_key)
 
-            ts_win_path = wsl_to_windows_path(str(ts_path))
-            pid = path_id_for(ts_win_path)
-
-            # Check if already ingested (idempotency)
-            existing = fetchone(
-                con,
-                "SELECT path_id FROM path_metadata WHERE path_id = ? AND source = 'edcb_epg'",
-                (pid,),
-            )
+            existing = con.execute(
+                "SELECT broadcast_id FROM broadcasts WHERE match_key = ?",
+                (match_key,),
+            ).fetchone()
             if existing:
                 skipped_already_ingested += 1
                 continue
 
-            # Generate match keys for correlation with encoded files
-            match_key = match_key_from_epg(epg)
-            dt_key = datetime_key_from_epg(epg)
-
-            # Build the data payload
             data = {
                 "match_key": match_key,
                 "datetime_key": dt_key,
@@ -200,16 +183,22 @@ def main() -> int:
                 "is_rebroadcast_flag": epg["is_rebroadcast_flag"],
                 "description": epg["description"][:500] if epg["description"] else None,
                 "epg_genres": epg["epg_genres"],
+                "detail_sections": epg.get("detail_sections"),
                 "network_ids": epg["network_ids"],
-                "ts_path": ts_win_path,
                 "program_txt_path": str(ptxt),
                 "ingested_at": now_iso(),
             }
-            data["source_history"] = [make_entry("edcb_epg", list(data.keys()))]
 
             rows_to_insert.append({
-                "pid": pid,
-                "ts_win_path": ts_win_path,
+                "program_id": program_id,
+                "program_key": program_key,
+                "canonical_title": str(epg.get("official_title") or "").strip() or "UNKNOWN",
+                "broadcast_id": broadcast_id,
+                "match_key": match_key,
+                "air_date": epg.get("air_date"),
+                "start_time": epg.get("start_time"),
+                "end_time": epg.get("end_time"),
+                "broadcaster": epg.get("broadcaster"),
                 "data": data,
             })
 
@@ -229,7 +218,6 @@ def main() -> int:
             print(json.dumps(summary, ensure_ascii=False))
             return 0
 
-        # Apply: write to DB
         begin_immediate(con)
         con.execute(
             """
@@ -240,34 +228,41 @@ def main() -> int:
         )
 
         for row in rows_to_insert:
-            pid = row["pid"]
-            ts_win_path = row["ts_win_path"]
-            data = row["data"]
-            drive, dir_, name, ext = split_win(ts_win_path)
             ts_now = now_iso()
-
-            # Ensure path exists in paths table
             con.execute(
                 """
-                INSERT INTO paths (path_id, path, drive, dir, name, ext, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET updated_at=excluded.updated_at
+                INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(program_id) DO UPDATE SET
+                  canonical_title=excluded.canonical_title
                 """,
-                (pid, ts_win_path, drive, dir_, name, ext, ts_now, ts_now),
+                (row["program_id"], row["program_key"], row["canonical_title"], ts_now),
             )
 
-            # Insert EPG metadata
-            data_json = json.dumps(data, ensure_ascii=False)
             con.execute(
                 """
-                INSERT INTO path_metadata (path_id, source, data_json, updated_at)
-                VALUES (?, 'edcb_epg', ?, ?)
-                ON CONFLICT(path_id) DO UPDATE SET
-                  source='edcb_epg',
-                  data_json=excluded.data_json,
-                  updated_at=excluded.updated_at
+                INSERT INTO broadcasts (broadcast_id, program_id, air_date, start_time, end_time, broadcaster, match_key, data_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(broadcast_id) DO UPDATE SET
+                  program_id=excluded.program_id,
+                  air_date=excluded.air_date,
+                  start_time=excluded.start_time,
+                  end_time=excluded.end_time,
+                  broadcaster=excluded.broadcaster,
+                  match_key=excluded.match_key,
+                  data_json=excluded.data_json
                 """,
-                (pid, data_json, ts_now),
+                (
+                    row["broadcast_id"],
+                    row["program_id"],
+                    row["air_date"],
+                    row["start_time"],
+                    row["end_time"],
+                    row["broadcaster"],
+                    row["match_key"],
+                    json.dumps(row["data"], ensure_ascii=False),
+                    ts_now,
+                ),
             )
             ingested += 1
 

--- a/py/mediaops_schema.py
+++ b/py/mediaops_schema.py
@@ -130,6 +130,45 @@ DDL_STATEMENTS = [
     )
     """,
     """
+    CREATE TABLE IF NOT EXISTS programs (
+      program_id TEXT PRIMARY KEY,
+      program_key TEXT NOT NULL UNIQUE,
+      canonical_title TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS broadcasts (
+      broadcast_id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL,
+      air_date TEXT,
+      start_time TEXT,
+      end_time TEXT,
+      broadcaster TEXT,
+      match_key TEXT UNIQUE,
+      data_json TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (program_id) REFERENCES programs(program_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_program ON broadcasts(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_broadcasts_air_date ON broadcasts(air_date)",
+    """
+    CREATE TABLE IF NOT EXISTS path_programs (
+      path_id TEXT NOT NULL,
+      program_id TEXT NOT NULL,
+      broadcast_id TEXT,
+      source TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (path_id, program_id),
+      FOREIGN KEY (path_id) REFERENCES paths(path_id),
+      FOREIGN KEY (program_id) REFERENCES programs(program_id),
+      FOREIGN KEY (broadcast_id) REFERENCES broadcasts(broadcast_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_program ON path_programs(program_id)",
+    "CREATE INDEX IF NOT EXISTS idx_path_programs_broadcast ON path_programs(broadcast_id)",
+    """
     CREATE TABLE IF NOT EXISTS broadcast_groups (
       group_id TEXT PRIMARY KEY,
       program_title TEXT NOT NULL,

--- a/py/migrate_epg_to_programs.py
+++ b/py/migrate_epg_to_programs.py
@@ -1,0 +1,151 @@
+"""Migrate legacy EPG rows from path_metadata(source='edcb_epg') to programs/broadcasts.
+
+This script is idempotent. It does not run automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import unicodedata
+import uuid
+
+from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed
+from pathscan_common import now_iso
+
+WS = re.compile(r"[\s\u3000]+")
+BAD = re.compile(r"[<>:\"/\\|?*]")
+UND = re.compile(r"_+")
+
+
+def normalize_program_key(title: str) -> str:
+    t = unicodedata.normalize("NFKC", str(title or "")).strip().lower()
+    t = WS.sub("_", t)
+    t = BAD.sub("", t)
+    t = UND.sub("_", t).strip("_")
+    return t or "unknown"
+
+
+def program_id_for(program_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"program_key:{program_key}"))
+
+
+def broadcast_id_for(match_key: str, fallback_seed: str) -> str:
+    if match_key:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast_match_key:{match_key}"))
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"broadcast_fallback:{fallback_seed}"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--delete-legacy", action="store_true", help="Delete migrated source='edcb_epg' rows from path_metadata")
+    args = ap.parse_args()
+
+    con = connect_db(args.db)
+    create_schema_if_needed(con)
+
+    rows = con.execute(
+        """
+        SELECT path_id, data_json
+        FROM path_metadata
+        WHERE source='edcb_epg'
+        """
+    ).fetchall()
+
+    migrated = 0
+    skipped = 0
+    deleted = 0
+
+    try:
+        if args.apply:
+            begin_immediate(con)
+
+        for path_id, data_json in rows:
+            try:
+                data = json.loads(data_json)
+            except Exception:
+                skipped += 1
+                continue
+            if not isinstance(data, dict):
+                skipped += 1
+                continue
+
+            title = str(data.get("official_title") or data.get("program_title") or "").strip()
+            if not title:
+                skipped += 1
+                continue
+
+            match_key = str(data.get("match_key") or "").strip()
+            program_key = normalize_program_key(title)
+            program_id = program_id_for(program_key)
+            b_seed = f"{path_id}:{data.get('air_date')}:{data.get('start_time')}:{title}"
+            broadcast_id = broadcast_id_for(match_key, b_seed)
+            ts = now_iso()
+
+            if args.apply:
+                con.execute(
+                    """
+                    INSERT INTO programs (program_id, program_key, canonical_title, created_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(program_id) DO UPDATE SET
+                      canonical_title=excluded.canonical_title
+                    """,
+                    (program_id, program_key, title, ts),
+                )
+                con.execute(
+                    """
+                    INSERT INTO broadcasts (broadcast_id, program_id, air_date, start_time, end_time, broadcaster, match_key, data_json, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(broadcast_id) DO UPDATE SET
+                      program_id=excluded.program_id,
+                      air_date=excluded.air_date,
+                      start_time=excluded.start_time,
+                      end_time=excluded.end_time,
+                      broadcaster=excluded.broadcaster,
+                      match_key=excluded.match_key,
+                      data_json=excluded.data_json
+                    """,
+                    (
+                        broadcast_id,
+                        program_id,
+                        data.get("air_date"),
+                        data.get("start_time"),
+                        data.get("end_time"),
+                        data.get("broadcaster"),
+                        match_key or None,
+                        json.dumps(data, ensure_ascii=False),
+                        ts,
+                    ),
+                )
+            migrated += 1
+
+        if args.apply and args.delete_legacy:
+            deleted = con.execute("DELETE FROM path_metadata WHERE source='edcb_epg'").rowcount
+
+        if args.apply:
+            con.commit()
+    except Exception:
+        if args.apply:
+            con.rollback()
+        raise
+    finally:
+        con.close()
+
+    print(json.dumps({
+        "ok": True,
+        "tool": "migrate_epg_to_programs",
+        "apply": bool(args.apply),
+        "deleteLegacy": bool(args.delete_legacy),
+        "legacyRows": len(rows),
+        "migrated": migrated,
+        "skipped": skipped,
+        "deletedLegacy": deleted,
+    }, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -15,6 +15,7 @@ from edcb_program_parser import match_key_from_filename, datetime_key_from_filen
 from franchise_resolver import resolve_franchise
 from genre_resolver import resolve_genre
 from source_history import make_entry
+from pathscan_common import now_iso
 
 WS = re.compile(r"[\s\u3000]+")
 BAD = re.compile(r"[<>:\"/\\\\|?*]")
@@ -392,13 +393,7 @@ def extract_title_ai_primary(name: str, base: str, alias_hints: HintSet) -> dict
 
 
 class _EpgCache:
-    """Pre-loaded EPG metadata cache for fast lookup by match_key / datetime_key.
-
-    Indexes:
-    - _by_match_key: full key including broadcaster (no collision)
-    - _by_title_dt: title::date::time (old format) → list of EPG dicts
-    - _by_datetime_key: date::time → list of EPG dicts
-    """
+    """Pre-loaded EPG metadata cache for fast lookup by match_key / datetime_key."""
 
     def __init__(self, con: sqlite3.Connection):
         self._by_match_key: dict[str, dict] = {}
@@ -406,39 +401,36 @@ class _EpgCache:
         self._by_datetime_key: dict[str, list[dict]] = {}
         try:
             rows = con.execute(
-                "SELECT data_json FROM path_metadata WHERE source='edcb_epg'",
+                """
+                SELECT b.broadcast_id, b.program_id, b.match_key, b.data_json
+                FROM broadcasts b
+                """,
             ).fetchall()
         except sqlite3.Error:
             return
         for row in rows:
             try:
-                data = json.loads(row[0])
+                data = json.loads(row[3] or "{}")
             except Exception:
                 continue
             if not isinstance(data, dict):
                 continue
-            mk = data.get("match_key")
+            data["broadcast_id"] = row[0]
+            data["program_id"] = row[1]
+            mk = row[2] or data.get("match_key")
             dk = data.get("datetime_key")
             if mk:
                 self._by_match_key[mk] = data
-                # Build title::date::time key (strip broadcaster segment)
-                parts = mk.split("::")
+                parts = str(mk).split("::")
                 if len(parts) == 4:
                     title_dt = f"{parts[0]}::{parts[2]}::{parts[3]}"
                     self._by_title_dt.setdefault(title_dt, []).append(data)
                 elif len(parts) == 3:
-                    # Legacy format without broadcaster
-                    self._by_title_dt.setdefault(mk, []).append(data)
+                    self._by_title_dt.setdefault(str(mk), []).append(data)
             if dk:
-                self._by_datetime_key.setdefault(dk, []).append(data)
+                self._by_datetime_key.setdefault(str(dk), []).append(data)
 
     def lookup(self, match_key: str | None, datetime_key: str | None) -> dict | None:
-        """Find EPG data by match_key, title_dt fallback, then datetime_key.
-
-        match_key from filename has no broadcaster segment (title::date::time),
-        so we try _by_match_key first (EPG-to-EPG exact), then _by_title_dt
-        (filename-to-EPG), then _by_datetime_key (date+time only).
-        """
         if match_key:
             if match_key in self._by_match_key:
                 return self._by_match_key[match_key]
@@ -589,6 +581,7 @@ def main() -> int:
         write_jsonl(bpath, batch)
 
         rows = []
+        path_program_links: list[tuple[str, str, str | None, str, str]] = []
         for rec in batch:
             pid = rec.get("path_id")
             if pid and not args.ignore_human_reviewed:
@@ -673,6 +666,14 @@ def main() -> int:
             dk = datetime_key_from_filename(name)
             epg = epg_cache.lookup(mk, dk)
             _enrich_with_epg(row, epg)
+            if epg and rec.get("path_id") and epg.get("program_id"):
+                path_program_links.append((
+                    str(rec["path_id"]),
+                    str(epg["program_id"]),
+                    str(epg.get("broadcast_id")) if epg.get("broadcast_id") else None,
+                    "reextract",
+                    now_iso(),
+                ))
 
             row["genre"] = resolve_genre(row)
             row["franchise"] = resolve_franchise(row, args.franchise_rules or None)
@@ -696,6 +697,20 @@ def main() -> int:
             sys.argv += ["--franchise-rules", args.franchise_rules]
         if _upsert_main() != 0:
             raise SystemExit(f"upsert failed: {epath}")
+
+        if path_program_links:
+            db_con.executemany(
+                """
+                INSERT INTO path_programs (path_id, program_id, broadcast_id, source, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(path_id, program_id) DO UPDATE SET
+                  broadcast_id=excluded.broadcast_id,
+                  source=excluded.source,
+                  updated_at=excluded.updated_at
+                """,
+                path_program_links,
+            )
+            db_con.commit()
 
         generated_input_jsonl_paths.append(str(bpath))
         generated_output_jsonl_paths.append(str(epath))


### PR DESCRIPTION
### Motivation
- EPG records previously stored in `path_metadata` as `source='edcb_epg'` are file-tied and can disappear when `.ts` files are removed, so EPG should be represented as file-independent program/broadcast entities. 
- Decouple ingest/reextract workflows so `ingest_epg` writes canonical program/broadcast rows and `reextract` links files to those records.

### Description
- Added new schema objects in `py/mediaops_schema.py`: `programs`, `broadcasts`, and `path_programs` plus related indexes to store series, airings, and file↔program links. 
- Reworked EPG ingest in `py/ingest_program_txt.py` to write to `programs` and `broadcasts` (idempotent on `broadcasts.match_key`) and stop writing `path_metadata` for `edcb_epg`. 
- Updated `py/run_metadata_batches_promptv1.py` to read EPG from `broadcasts.data_json` via a new `_EpgCache` and to upsert `path_programs` (with `source='reextract'`) when reextract correlates a path to a program/broadcast. 
- Added migration script `py/migrate_epg_to_programs.py` that migrates existing `path_metadata` rows where `source='edcb_epg'` into `programs` + `broadcasts` and optionally deletes legacy rows with `--delete-legacy`. 
- Updated README §9 to include `programs`, `broadcasts`, and `path_programs` in the ER diagram and table overview.

### Testing
- Ran static syntax checks with `python -m py_compile py/mediaops_schema.py py/ingest_program_txt.py py/run_metadata_batches_promptv1.py py/migrate_epg_to_programs.py` and it completed successfully. 
- Created a temporary SQLite DB, populated a `paths` + `path_metadata(source='edcb_epg')` test row, ran `py/migrate_epg_to_programs.py --db <tmpdb> --apply --delete-legacy`, and verified the migration produced `programs=1`, `broadcasts=1`, and removed the legacy `path_metadata` row (legacy=0). 
- Confirmed the reextract path-linking logic inserts into `path_programs` by running a small end-to-end test against a temp DB, and observed expected `path_programs` upsert behavior; all steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab989b61a08329a5a96b0799d1fa16)