### PR TITLE
EPGフラグ起点で再放送判定を改修し `unknown` フォールバックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ video-library-pipeline (本プラグイン)
 | `video_pipeline_status`                     | パイプラインの最新状態サマリ (各ステージの最新JSONL等)   | `includeRawPaths`                  |
 | `video_pipeline_export_program_yaml`        | 抽出結果からヒントYAML生成                               | `sourceJsonlPath`                  |
 | `video_pipeline_ingest_epg`                 | EDCB `.program.txt` からEPG番組情報を取り込み          | —                                   |
-| `video_pipeline_detect_rebroadcasts`        | 再放送グルーピング (broadcast_groups テーブル)           | —                                   |
+| `video_pipeline_detect_rebroadcasts`        | EPG `[再]` フラグ起点で再放送を分類し、根拠不足は `unknown` にする | —                                   |
 | `video_pipeline_db_backup` / `db_restore` | DBスナップショットの作成・復元                           | `action`, `descriptor`, `keep` |
 | `video_pipeline_repair_db`                  | paths テーブルの drive/dir/name 分解値を path から再生成 | —                                   |
 | `video_pipeline_logs`                       | 監査ログ (events テーブル) の参照                        | —                                   |
@@ -741,7 +741,7 @@ erDiagram
 | `programs` / `broadcasts`                      | ファイル非依存の番組シリーズ・放送履歴 (EPG由来の正規テーブル)      |
 | `path_programs`                                | ファイルと番組シリーズの紐付け (reextract等で更新)                 |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
-| `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
+| `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast/unknown 分類)             |
 
 ### path_id 生成
 
@@ -773,6 +773,23 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 ### is_current 運用
 
 `file_paths.is_current` はファイル移動時に旧パス=`0`、新パス=`1` に更新される。これにより複数パスで同一ファイルの移動履歴を追跡できる。`is_current=1` のレコードが現在のファイル位置を示す。
+
+---
+
+### 再放送判定ルール (Issue #25対応)
+
+`video_pipeline_detect_rebroadcasts` は `broadcasts.data_json.is_rebroadcast_flag` を唯一の信頼ソースとして扱う。
+
+1. `is_rebroadcast_flag=true` がある行は `rebroadcast`
+2. 同一グループ内に `rebroadcast` が1件でもある場合、その他の行は `original`
+3. EPG照合がなくフラグ根拠がないグループは全件 `unknown`
+
+このため、`air_date` の前後関係だけで `original/rebroadcast` を決めない。EPGがないケースは誤判定防止のため `unknown` のまま保持する。
+
+`is_rebroadcast_flag` の生成元は以下の流れ:
+
+- `.program.txt` → `edcb_program_parser.py` (`[再]` を検出)
+- `ingest_program_txt.py` → `broadcasts.data_json` に格納
 
 ---
 

--- a/py/detect_rebroadcasts.py
+++ b/py/detect_rebroadcasts.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
-"""Detect rebroadcasts and group same-episode recordings by air_date/broadcaster.
+"""Detect rebroadcasts and group same-episode recordings.
 
 This script groups recordings of the same episode (same normalized_program_key +
-episode_no/subtitle) and identifies original vs. rebroadcast entries based on
-air_date ordering. Rebroadcasts are NOT deleted — they are linked in the
-broadcast_groups / broadcast_group_members tables.
+episode_no/subtitle) and assigns broadcast_type using EPG rebroadcast flags:
+
+1. If broadcasts.data_json.is_rebroadcast_flag is true, classify as rebroadcast.
+2. If at least one rebroadcast exists in a group, non-flagged entries are original.
+3. If no rebroadcast flag data exists for the group, classify as unknown.
+
+Rebroadcasts are NOT deleted — only linked in broadcast_groups /
+broadcast_group_members tables.
 """
 
 from __future__ import annotations
@@ -46,6 +51,48 @@ def _stable_group_id(episode_key: str) -> str:
     return hashlib.sha256(episode_key.encode("utf-8")).hexdigest()[:16]
 
 
+def _extract_is_rebroadcast_flag(v: Any) -> bool | None:
+    """Read broadcasts.data_json.is_rebroadcast_flag from JSON payload."""
+    if v is None:
+        return None
+    try:
+        obj = json.loads(str(v))
+    except Exception:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    raw = obj.get("is_rebroadcast_flag")
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in {"true", "1", "yes", "y", "on"}:
+            return True
+        if s in {"false", "0", "no", "n", "off", ""}:
+            return False
+    return None
+
+
+def _classify_group(entries: list[dict[str, Any]]) -> list[tuple[dict[str, Any], str]]:
+    """Apply 3-stage broadcast_type rules for a single episode group."""
+    # Stable ordering for deterministic output.
+    entries_sorted = sorted(entries, key=lambda e: (e["air_date"] or "9999", e["path_id"]))
+    has_rebroadcast_flag = any(e.get("is_rebroadcast_flag") is True for e in entries_sorted)
+    out: list[tuple[dict[str, Any], str]] = []
+    for entry in entries_sorted:
+        is_reb = entry.get("is_rebroadcast_flag")
+        if is_reb is True:
+            btype = "rebroadcast"
+        elif has_rebroadcast_flag:
+            btype = "original"
+        else:
+            btype = "unknown"
+        out.append((entry, btype))
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", required=True)
@@ -62,9 +109,15 @@ def main() -> int:
         md_rows = fetchall(
             con,
             """
-            SELECT pm.path_id, pm.data_json, p.path
+            SELECT
+              pm.path_id,
+              pm.data_json,
+              p.path,
+              b.data_json AS broadcast_data_json
             FROM path_metadata pm
             JOIN paths p ON p.path_id = pm.path_id
+            LEFT JOIN path_programs pp ON pp.path_id = pm.path_id
+            LEFT JOIN broadcasts b ON b.broadcast_id = pp.broadcast_id
             WHERE pm.source != 'edcb_epg'
             """,
             (),
@@ -94,6 +147,7 @@ def main() -> int:
                 "broadcaster": md.get("broadcaster") or md.get("channel") or None,
                 "episode_key": ep_key,
                 "metadata": md,
+                "is_rebroadcast_flag": _extract_is_rebroadcast_flag(r["broadcast_data_json"]),
             }
             grouped.setdefault(ep_key, []).append(entry)
 
@@ -119,14 +173,12 @@ def main() -> int:
 
         for ep_key in group_keys:
             entries = rebroadcast_groups[ep_key]
-            # Sort by air_date ascending — earliest is "original"
-            entries_sorted = sorted(entries, key=lambda e: e["air_date"] or "9999")
+            classified_entries = _classify_group(entries)
             group_id = _stable_group_id(ep_key)
-            program_title = entries_sorted[0]["program_title"]
+            program_title = classified_entries[0][0]["program_title"]
 
             group_plan: list[dict[str, Any]] = []
-            for i, entry in enumerate(entries_sorted):
-                btype = "original" if i == 0 else "rebroadcast"
+            for entry, btype in classified_entries:
                 member = {
                     "group_id": group_id,
                     "path_id": entry["path_id"],
@@ -150,9 +202,9 @@ def main() -> int:
                 begin_immediate(con)
                 for ep_key in group_keys:
                     entries = rebroadcast_groups[ep_key]
-                    entries_sorted = sorted(entries, key=lambda e: e["air_date"] or "9999")
+                    classified_entries = _classify_group(entries)
                     group_id = _stable_group_id(ep_key)
-                    program_title = entries_sorted[0]["program_title"]
+                    program_title = classified_entries[0][0]["program_title"]
 
                     # Upsert group
                     con.execute(
@@ -167,8 +219,7 @@ def main() -> int:
                     )
                     db_inserted_groups += 1
 
-                    for i, entry in enumerate(entries_sorted):
-                        btype = "original" if i == 0 else "rebroadcast"
+                    for entry, btype in classified_entries:
                         con.execute(
                             """
                             INSERT INTO broadcast_group_members

--- a/skills/video-library-pipeline/SKILL.md
+++ b/skills/video-library-pipeline/SKILL.md
@@ -30,7 +30,7 @@ Classify the user request first, then **immediately read the sub-skill SKILL.md 
 | DB sync only ("DB化", "DBに登録して", "既存ファイルをDBに入れて") | Call `video_pipeline_backfill_moved_files` directly (no `roots` param needed) |
 | Ingest EPG (program.txt capture) | Call `video_pipeline_ingest_epg` (run before deleting program.txt) |
 | Re-run metadata extraction only | Read `skills/extract-review/SKILL.md`, then follow its sequence |
-| Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly |
+| Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly (EPG `[再]` flag based; no-flag groups become `unknown`) |
 
 If the user asks about cleanup/reorganization for an already-existing directory tree, treat that as **relocate flow** (read `skills/relocate-review/SKILL.md`), not the `sourceRoot` pipeline flow.
 

--- a/src/tool-detect-rebroadcasts.ts
+++ b/src/tool-detect-rebroadcasts.ts
@@ -6,8 +6,8 @@ export function registerToolDetectRebroadcasts(api: any, getCfg: (api: any) => a
     {
       name: "video_pipeline_detect_rebroadcasts",
       description:
-        "Detect rebroadcasts by grouping same-episode recordings with different air_date or broadcaster. " +
-        "Rebroadcasts are linked in DB (not deleted). Use apply=false for dry-run.",
+        "Detect rebroadcasts using EPG is_rebroadcast_flag from broadcasts.data_json (no reliable flag -> unknown). " +
+        "Results are linked in DB (not deleted). Use apply=false for dry-run."
       parameters: {
         type: "object",
         additionalProperties: false,


### PR DESCRIPTION
### Motivation
- 既存の `py/detect_rebroadcasts.py` は `air_date` の昇順で最古を `original` とするため、EPG 情報がない場合に誤判定が発生する問題を防ぎたい。
- EPG 側の `[再]` フラグ (`broadcasts.data_json.is_rebroadcast_flag`) を一次根拠とし、根拠がないときは判定を保留（`unknown`）にすることで誤分類を抑制する。 

### Description
- `py/detect_rebroadcasts.py`: `path_programs -> broadcasts` を `LEFT JOIN` して `broadcasts.data_json` を取得し、`_extract_is_rebroadcast_flag` と `_classify_group` を追加して3段階ルール（`rebroadcast` / `original` / `unknown`）で判定ロジックを置換した。 
- 判定ロジックは (1) `is_rebroadcast_flag=true` → `rebroadcast`、(2) グループ内に `rebroadcast` があれば非フラグは `original`、(3) フラグ根拠が無ければ全件 `unknown` を適用する。 
- `src/tool-detect-rebroadcasts.ts`: ツール説明文を新仕様（EPG フラグ優先、no-flag は `unknown`）へ更新した。 
- ドキュメント更新: `skills/video-library-pipeline/SKILL.md` と `README.md` の該当説明を `unknown` を含む仕様に合わせて修正・追記した。 

### Testing
- `python -m py_compile py/detect_rebroadcasts.py` は成功した。 
- `python py/detect_rebroadcasts.py --help` は正常にヘルプを表示した。 
- 簡易 SQLite 組み込み検証スクリプトを実行し、混在グループで `rebroadcast`/`original` が期待通りに割り当てられ、EPG フラグなしグループでは全件 `unknown` となることを確認した。 
- `npm run build` は `package.json` に `build` スクリプトが無いため実行不可で失敗した（影響範囲: ドライビルド手順だが本変更の Python ロジックには影響なし）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb73a30688329b67b0b62b0c2cd53)