### PR TITLE
EPGフラグベースの再放送判定に改修し `unknown` 分類を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,17 @@ erDiagram
 | `programs` / `broadcasts`                      | ファイル非依存の番組シリーズ・放送履歴 (EPG由来の正規テーブル)      |
 | `path_programs`                                | ファイルと番組シリーズの紐付け (reextract等で更新)                 |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
-| `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
+| `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (EPGフラグベースで original/rebroadcast/unknown 分類) |
+
+### 再放送フラグのデータソース
+
+```
+.program.txt → edcb_program_parser.py (_parse_title_line)
+  → annotations に [再] があれば is_rebroadcast_flag=true
+  → ingest_program_txt.py → broadcasts.data_json に格納
+```
+
+`broadcasts.data_json.is_rebroadcast_flag` を再放送判定の一次ソースとする。EPGフラグが取得できない場合は `broadcast_type=unknown` を使用し、air_date の前後のみで original/rebroadcast を断定しない。
 
 ### path_id 生成
 
@@ -878,13 +888,14 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 | 2 | ~~LLMサブエージェントのリカバリ機構がない~~ | [#13](https://github.com/NEXTAltair/video-library-pipeline/issues/13) | 解決済み (llm_extract_status ツールでバッチ状態検出・リトライ) |
 | 3 | ~~EPG match_key 衝突リスク~~ | [#7](https://github.com/NEXTAltair/video-library-pipeline/issues/7) | 解決済み (`match_key` に broadcaster を含めて衝突回避) |
 | 4 | relocateフローの source 不整合 | [#6](https://github.com/NEXTAltair/video-library-pipeline/issues/6) | open |
-| 5 | ~~DBバックアップのローテーション~~ | — | 解決済み (`rotate_backups(keep=10)`) |
-| 6 | ~~PowerShellエラーハンドリング不透明~~ | [#12](https://github.com/NEXTAltair/video-library-pipeline/issues/12) | 解決済み (`moveApplyStats` で構造化エラー伝播) |
-| 7 | ~~program_aliases.yaml 循環依存~~ | [#14](https://github.com/NEXTAltair/video-library-pipeline/issues/14) | 不要 (既存アーカイブ機構で管理可能) |
-| 8 | ~~Python/TS重複コード整理~~ | — | 完了 |
-| 9 | ~~cron定期EPG取り込み~~ | [#8](https://github.com/NEXTAltair/video-library-pipeline/issues/8) | 解決済み (毎日05:00 JST cronジョブ追加) |
-| 10 | ~~normalize_filenames.ps1 欠落サブスクリプト~~ | [#9](https://github.com/NEXTAltair/video-library-pipeline/issues/9) | 解決済み (ラッパーごと削除、メタデータ抽出側で対応済み) |
-| 11 | ~~list_remaining_unwatched.ps1 再検討~~ | [#10](https://github.com/NEXTAltair/video-library-pipeline/issues/10) | 解決済み (計算ロジックで置換、PS1削除) |
-| 12 | ~~PS1スクリプト統合検討~~ | [#11](https://github.com/NEXTAltair/video-library-pipeline/issues/11) | 統合見送り (共通部分は `_long_path_utils.ps1` に集約済み) |
+| 5 | 再放送判定のair_date依存による誤分類 | [#25](https://github.com/NEXTAltair/video-library-pipeline/issues/25) | open |
+| 6 | ~~DBバックアップのローテーション~~ | — | 解決済み (`rotate_backups(keep=10)`) |
+| 7 | ~~PowerShellエラーハンドリング不透明~~ | [#12](https://github.com/NEXTAltair/video-library-pipeline/issues/12) | 解決済み (`moveApplyStats` で構造化エラー伝播) |
+| 8 | ~~program_aliases.yaml 循環依存~~ | [#14](https://github.com/NEXTAltair/video-library-pipeline/issues/14) | 不要 (既存アーカイブ機構で管理可能) |
+| 9 | ~~Python/TS重複コード整理~~ | — | 完了 |
+| 10 | ~~cron定期EPG取り込み~~ | [#8](https://github.com/NEXTAltair/video-library-pipeline/issues/8) | 解決済み (毎日05:00 JST cronジョブ追加) |
+| 11 | ~~normalize_filenames.ps1 欠落サブスクリプト~~ | [#9](https://github.com/NEXTAltair/video-library-pipeline/issues/9) | 解決済み (ラッパーごと削除、メタデータ抽出側で対応済み) |
+| 12 | ~~list_remaining_unwatched.ps1 再検討~~ | [#10](https://github.com/NEXTAltair/video-library-pipeline/issues/10) | 解決済み (計算ロジックで置換、PS1削除) |
+| 13 | ~~PS1スクリプト統合検討~~ | [#11](https://github.com/NEXTAltair/video-library-pipeline/issues/11) | 統合見送り (共通部分は `_long_path_utils.ps1` に集約済み) |
 
 その他のIssue: [#1](https://github.com/NEXTAltair/video-library-pipeline/issues/1) data_json拡張 / [#2](https://github.com/NEXTAltair/video-library-pipeline/issues/2) by_seriesリネーム / [#3](https://github.com/NEXTAltair/video-library-pipeline/issues/3) sourceリネーム / [#4](https://github.com/NEXTAltair/video-library-pipeline/issues/4) filesテーブルにハッシュ+メタデータ / [#5](https://github.com/NEXTAltair/video-library-pipeline/issues/5) アニメ・ドラマレイアウト移行

--- a/py/detect_rebroadcasts.py
+++ b/py/detect_rebroadcasts.py
@@ -2,9 +2,10 @@
 """Detect rebroadcasts and group same-episode recordings by air_date/broadcaster.
 
 This script groups recordings of the same episode (same normalized_program_key +
-episode_no/subtitle) and identifies original vs. rebroadcast entries based on
-air_date ordering. Rebroadcasts are NOT deleted — they are linked in the
-broadcast_groups / broadcast_group_members tables.
+episode_no/subtitle) and identifies original/rebroadcast/unknown entries based
+on EPG rebroadcast flags from broadcasts.data_json. Rebroadcasts are NOT
+deleted — they are linked in the broadcast_groups / broadcast_group_members
+tables.
 """
 
 from __future__ import annotations
@@ -12,7 +13,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import uuid
 from typing import Any
 
 from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed, fetchall
@@ -46,6 +46,52 @@ def _stable_group_id(episode_key: str) -> str:
     return hashlib.sha256(episode_key.encode("utf-8")).hexdigest()[:16]
 
 
+def _parse_rebroadcast_flag(data_json: Any) -> bool | None:
+    """Extract is_rebroadcast_flag from broadcasts.data_json if available."""
+    if data_json is None:
+        return None
+    try:
+        payload = json.loads(str(data_json))
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or "is_rebroadcast_flag" not in payload:
+        return None
+    flag = payload.get("is_rebroadcast_flag")
+    if isinstance(flag, bool):
+        return flag
+    if isinstance(flag, (int, float)):
+        return bool(flag)
+    if isinstance(flag, str):
+        normalized = flag.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+    return None
+
+
+def _decide_broadcast_types(entries: list[dict[str, Any]]) -> dict[str, str]:
+    """Decide broadcast_type per path_id with EPG-first 3-stage rules.
+
+    Rule priority:
+    1) Any is_rebroadcast_flag=true -> that member is rebroadcast.
+    2) If EPG flags exist but none true -> all members original.
+    3) If no EPG flags are available -> all members unknown.
+    """
+    flags = [e.get("is_rebroadcast_flag") for e in entries]
+    has_true = any(flag is True for flag in flags)
+    has_known = any(flag is not None for flag in flags)
+
+    if has_true:
+        return {
+            str(e["path_id"]): ("rebroadcast" if e.get("is_rebroadcast_flag") is True else "original")
+            for e in entries
+        }
+    if has_known:
+        return {str(e["path_id"]): "original" for e in entries}
+    return {str(e["path_id"]): "unknown" for e in entries}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", required=True)
@@ -70,6 +116,28 @@ def main() -> int:
             (),
         )
 
+        # Load path_id -> EPG rebroadcast flag (if any) via path_programs/broadcasts.
+        epg_flag_by_path: dict[str, bool | None] = {}
+        epg_rows = fetchall(
+            con,
+            """
+            SELECT pp.path_id, b.data_json, pp.updated_at
+            FROM path_programs pp
+            LEFT JOIN broadcasts b ON b.broadcast_id = pp.broadcast_id
+            ORDER BY pp.path_id ASC, pp.updated_at DESC
+            """,
+            (),
+        )
+        for r in epg_rows:
+            path_id = str(r["path_id"])
+            parsed_flag = _parse_rebroadcast_flag(r["data_json"])
+            if path_id not in epg_flag_by_path:
+                epg_flag_by_path[path_id] = parsed_flag
+                continue
+            # Prefer known values over unknown when multiple path_program rows exist.
+            if epg_flag_by_path[path_id] is None and parsed_flag is not None:
+                epg_flag_by_path[path_id] = parsed_flag
+
         # Group by episode key
         grouped: dict[str, list[dict[str, Any]]] = {}
         skipped_no_key = 0
@@ -93,6 +161,7 @@ def main() -> int:
                 "air_date": str(md.get("air_date") or ""),
                 "broadcaster": md.get("broadcaster") or md.get("channel") or None,
                 "episode_key": ep_key,
+                "is_rebroadcast_flag": epg_flag_by_path.get(path_id),
                 "metadata": md,
             }
             grouped.setdefault(ep_key, []).append(entry)
@@ -119,14 +188,14 @@ def main() -> int:
 
         for ep_key in group_keys:
             entries = rebroadcast_groups[ep_key]
-            # Sort by air_date ascending — earliest is "original"
             entries_sorted = sorted(entries, key=lambda e: e["air_date"] or "9999")
+            type_by_path = _decide_broadcast_types(entries_sorted)
             group_id = _stable_group_id(ep_key)
             program_title = entries_sorted[0]["program_title"]
 
             group_plan: list[dict[str, Any]] = []
-            for i, entry in enumerate(entries_sorted):
-                btype = "original" if i == 0 else "rebroadcast"
+            for entry in entries_sorted:
+                btype = type_by_path.get(str(entry["path_id"]), "unknown")
                 member = {
                     "group_id": group_id,
                     "path_id": entry["path_id"],
@@ -151,6 +220,7 @@ def main() -> int:
                 for ep_key in group_keys:
                     entries = rebroadcast_groups[ep_key]
                     entries_sorted = sorted(entries, key=lambda e: e["air_date"] or "9999")
+                    type_by_path = _decide_broadcast_types(entries_sorted)
                     group_id = _stable_group_id(ep_key)
                     program_title = entries_sorted[0]["program_title"]
 
@@ -167,8 +237,8 @@ def main() -> int:
                     )
                     db_inserted_groups += 1
 
-                    for i, entry in enumerate(entries_sorted):
-                        btype = "original" if i == 0 else "rebroadcast"
+                    for entry in entries_sorted:
+                        btype = type_by_path.get(str(entry["path_id"]), "unknown")
                         con.execute(
                             """
                             INSERT INTO broadcast_group_members

--- a/skills/video-library-pipeline/SKILL.md
+++ b/skills/video-library-pipeline/SKILL.md
@@ -30,7 +30,7 @@ Classify the user request first, then **immediately read the sub-skill SKILL.md 
 | DB sync only ("DB化", "DBに登録して", "既存ファイルをDBに入れて") | Call `video_pipeline_backfill_moved_files` directly (no `roots` param needed) |
 | Ingest EPG (program.txt capture) | Call `video_pipeline_ingest_epg` (run before deleting program.txt) |
 | Re-run metadata extraction only | Read `skills/extract-review/SKILL.md`, then follow its sequence |
-| Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly |
+| Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly (EPG `is_rebroadcast_flag`優先、未取得は`unknown`) |
 
 If the user asks about cleanup/reorganization for an already-existing directory tree, treat that as **relocate flow** (read `skills/relocate-review/SKILL.md`), not the `sourceRoot` pipeline flow.
 

--- a/src/tool-detect-rebroadcasts.ts
+++ b/src/tool-detect-rebroadcasts.ts
@@ -6,8 +6,8 @@ export function registerToolDetectRebroadcasts(api: any, getCfg: (api: any) => a
     {
       name: "video_pipeline_detect_rebroadcasts",
       description:
-        "Detect rebroadcasts by grouping same-episode recordings with different air_date or broadcaster. " +
-        "Rebroadcasts are linked in DB (not deleted). Use apply=false for dry-run.",
+        "Detect rebroadcast groups and classify members using EPG is_rebroadcast_flag (broadcasts.data_json). " +
+        "Classification is original/rebroadcast/unknown (unknown when EPG flag is unavailable). Use apply=false for dry-run.",
       parameters: {
         type: "object",
         additionalProperties: false,


### PR DESCRIPTION
### Motivation
- 既存の `detect_rebroadcasts.py` は `air_date` の昇順のみで original/rebroadcast を決めており、EPG（program.txt）未取得時に誤判定が発生するため修正する必要があった。 
- Issue #25 の方針に合わせて、`broadcasts.data_json.is_rebroadcast_flag` を一次ソースにする3段階判定（EPG優先/フラグ有無判定/未取得は `unknown`）を導入するための変更。 

### Description
- `py/detect_rebroadcasts.py` に `path_programs -> broadcasts.data_json` を参照して `is_rebroadcast_flag` を取得する処理を追加し、`_parse_rebroadcast_flag` と `_decide_broadcast_types` を実装して EPG優先の3段階判定を適用するように変更した。 
- 上記ロジックにより、グループ計画作成時と DB 書き込み時の両方で `broadcast_type` が `original` / `rebroadcast` / `unknown` のいずれかとなるよう air_date 固定判定を廃止した。 
- ツール説明の文言を `src/tool-detect-rebroadcasts.ts` で EPGフラグベースかつ `unknown` を含む仕様へ更新した。 
- ドキュメントとスキル説明を `README.md` と `skills/video-library-pipeline/SKILL.md` に反映し、再放送フラグのデータソース（`.program.txt → edcb_program_parser.py → broadcasts.data_json`）と Issue #25 を追記した。 

### Testing
- `python -m py_compile py/detect_rebroadcasts.py` を実行して構文チェックを行い成功した。 
- `PYTHONPATH=py` を用いてモジュールをロードし、`_decide_broadcast_types` の3ケース（true/false/unknown）を検証するスクリプトを実行して期待どおりのマッピングが返ることを確認した。 
- 変更されたツールの説明文字列とドキュメント更新を確認し、該当ファイル（`py/detect_rebroadcasts.py`, `src/tool-detect-rebroadcasts.ts`, `README.md`, `skills/video-library-pipeline/SKILL.md`）が想定どおり更新されていることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb73a30688329b67b0b62b0c2cd53)