### PR TITLE
Issue #25: 再放送判定をEPGフラグ優先に改修

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ video-library-pipeline (本プラグイン)
 | `video_pipeline_status`                     | パイプラインの最新状態サマリ (各ステージの最新JSONL等)   | `includeRawPaths`                  |
 | `video_pipeline_export_program_yaml`        | 抽出結果からヒントYAML生成                               | `sourceJsonlPath`                  |
 | `video_pipeline_ingest_epg`                 | EDCB `.program.txt` からEPG番組情報を取り込み          | —                                   |
-| `video_pipeline_detect_rebroadcasts`        | 再放送グルーピング (broadcast_groups テーブル)           | —                                   |
+| `video_pipeline_detect_rebroadcasts`        | 再放送グルーピング (EPG `[再]` フラグ優先、未確定は `unknown`) | —                                   |
 | `video_pipeline_db_backup` / `db_restore` | DBスナップショットの作成・復元                           | `action`, `descriptor`, `keep` |
 | `video_pipeline_repair_db`                  | paths テーブルの drive/dir/name 分解値を path から再生成 | —                                   |
 | `video_pipeline_logs`                       | 監査ログ (events テーブル) の参照                        | —                                   |
@@ -741,7 +741,17 @@ erDiagram
 | `programs` / `broadcasts`                      | ファイル非依存の番組シリーズ・放送履歴 (EPG由来の正規テーブル)      |
 | `path_programs`                                | ファイルと番組シリーズの紐付け (reextract等で更新)                 |
 | `tags` / `path_tags`                           | Tablacus連携用タグ                                                 |
-| `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (original/rebroadcast 分類)                     |
+| `broadcast_groups` / `broadcast_group_members` | 再放送グルーピング (EPGフラグ基準で original/rebroadcast/unknown 分類) |
+
+
+### 再放送判定ルール (`video_pipeline_detect_rebroadcasts`)
+
+`broadcasts.data_json.is_rebroadcast_flag` を唯一の信頼ソースとして次の優先順で判定する。
+
+1. グループ内に `is_rebroadcast_flag=true` が1件でもあれば、その行を `rebroadcast`、それ以外を `original` とする。
+2. `true` が1件も無い場合（EPG未取得・全件false/不明）は、全件 `unknown` とする。
+
+このため、EPGフラグが無いケースでは `air_date` の前後だけで original/rebroadcast を決めない。
 
 ### path_id 生成
 

--- a/py/detect_rebroadcasts.py
+++ b/py/detect_rebroadcasts.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Detect rebroadcasts and group same-episode recordings by air_date/broadcaster.
+"""Detect rebroadcast candidates and classify with EPG rebroadcast flags.
 
 This script groups recordings of the same episode (same normalized_program_key +
-episode_no/subtitle) and identifies original vs. rebroadcast entries based on
-air_date ordering. Rebroadcasts are NOT deleted — they are linked in the
-broadcast_groups / broadcast_group_members tables.
+episode_no/subtitle). Classification rule priority:
+
+1) If any member has broadcasts.data_json.is_rebroadcast_flag=true, those are
+   "rebroadcast" and non-true members become "original".
+2) If no member has true flag (EPG missing or all false/unknown), all members
+   are marked "unknown" to avoid date-only misclassification.
+
+Rebroadcast candidates are linked in broadcast_groups / broadcast_group_members.
+No files are deleted.
 """
 
 from __future__ import annotations
@@ -46,6 +52,33 @@ def _stable_group_id(episode_key: str) -> str:
     return hashlib.sha256(episode_key.encode("utf-8")).hexdigest()[:16]
 
 
+def _extract_rebroadcast_flag(data_json_raw: Any) -> bool | None:
+    if not data_json_raw:
+        return None
+    try:
+        obj = json.loads(str(data_json_raw))
+    except Exception:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    v = obj.get("is_rebroadcast_flag")
+    if isinstance(v, bool):
+        return v
+    return None
+
+
+def _classify_group(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    has_rebroadcast = any(e.get("is_rebroadcast_flag") is True for e in entries)
+    classified: list[dict[str, Any]] = []
+    for e in entries:
+        if has_rebroadcast:
+            btype = "rebroadcast" if e.get("is_rebroadcast_flag") is True else "original"
+        else:
+            btype = "unknown"
+        classified.append({**e, "broadcast_type": btype})
+    return classified
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", required=True)
@@ -58,7 +91,27 @@ def main() -> int:
 
     errors: list[str] = []
     try:
-        # Load all LLM metadata
+        # Load EPG rebroadcast flags via path_programs -> broadcasts
+        epg_rows = fetchall(
+            con,
+            """
+            SELECT pp.path_id, b.data_json
+            FROM path_programs pp
+            JOIN broadcasts b ON b.broadcast_id = pp.broadcast_id
+            WHERE pp.broadcast_id IS NOT NULL
+            """,
+            (),
+        )
+        path_rebroadcast_flag: dict[str, bool | None] = {}
+        for r in epg_rows:
+            pid = str(r["path_id"])
+            flag = _extract_rebroadcast_flag(r["data_json"])
+            if flag is True:
+                path_rebroadcast_flag[pid] = True
+            elif pid not in path_rebroadcast_flag:
+                path_rebroadcast_flag[pid] = flag
+
+        # Load all non-EPG metadata for grouping keys
         md_rows = fetchall(
             con,
             """
@@ -94,6 +147,7 @@ def main() -> int:
                 "broadcaster": md.get("broadcaster") or md.get("channel") or None,
                 "episode_key": ep_key,
                 "metadata": md,
+                "is_rebroadcast_flag": path_rebroadcast_flag.get(path_id),
             }
             grouped.setdefault(ep_key, []).append(entry)
 
@@ -119,23 +173,23 @@ def main() -> int:
 
         for ep_key in group_keys:
             entries = rebroadcast_groups[ep_key]
-            # Sort by air_date ascending — earliest is "original"
-            entries_sorted = sorted(entries, key=lambda e: e["air_date"] or "9999")
+            entries_sorted = sorted(entries, key=lambda e: (e["air_date"] or "9999", e["path_id"]))
+            entries_classified = _classify_group(entries_sorted)
             group_id = _stable_group_id(ep_key)
             program_title = entries_sorted[0]["program_title"]
 
             group_plan: list[dict[str, Any]] = []
-            for i, entry in enumerate(entries_sorted):
-                btype = "original" if i == 0 else "rebroadcast"
+            for entry in entries_classified:
                 member = {
                     "group_id": group_id,
                     "path_id": entry["path_id"],
                     "path": entry["path"],
-                    "broadcast_type": btype,
+                    "broadcast_type": entry["broadcast_type"],
                     "air_date": entry["air_date"] or None,
                     "broadcaster": entry["broadcaster"],
                     "program_title": program_title,
                     "episode_key": ep_key,
+                    "is_rebroadcast_flag": entry["is_rebroadcast_flag"],
                 }
                 group_plan.append(member)
                 members_total += 1
@@ -150,7 +204,8 @@ def main() -> int:
                 begin_immediate(con)
                 for ep_key in group_keys:
                     entries = rebroadcast_groups[ep_key]
-                    entries_sorted = sorted(entries, key=lambda e: e["air_date"] or "9999")
+                    entries_sorted = sorted(entries, key=lambda e: (e["air_date"] or "9999", e["path_id"]))
+                    entries_classified = _classify_group(entries_sorted)
                     group_id = _stable_group_id(ep_key)
                     program_title = entries_sorted[0]["program_title"]
 
@@ -167,8 +222,7 @@ def main() -> int:
                     )
                     db_inserted_groups += 1
 
-                    for i, entry in enumerate(entries_sorted):
-                        btype = "original" if i == 0 else "rebroadcast"
+                    for entry in entries_classified:
                         con.execute(
                             """
                             INSERT INTO broadcast_group_members
@@ -180,7 +234,14 @@ def main() -> int:
                               broadcaster = excluded.broadcaster,
                               added_at = excluded.added_at
                             """,
-                            (group_id, entry["path_id"], btype, entry["air_date"] or None, entry["broadcaster"], now_iso()),
+                            (
+                                group_id,
+                                entry["path_id"],
+                                entry["broadcast_type"],
+                                entry["air_date"] or None,
+                                entry["broadcaster"],
+                                now_iso(),
+                            ),
                         )
                         db_inserted_members += 1
                 con.commit()

--- a/skills/video-library-pipeline/SKILL.md
+++ b/skills/video-library-pipeline/SKILL.md
@@ -30,7 +30,7 @@ Classify the user request first, then **immediately read the sub-skill SKILL.md 
 | DB sync only ("DB化", "DBに登録して", "既存ファイルをDBに入れて") | Call `video_pipeline_backfill_moved_files` directly (no `roots` param needed) |
 | Ingest EPG (program.txt capture) | Call `video_pipeline_ingest_epg` (run before deleting program.txt) |
 | Re-run metadata extraction only | Read `skills/extract-review/SKILL.md`, then follow its sequence |
-| Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly |
+| Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly (EPG `[再]` flag based: `rebroadcast` / `original` / `unknown`) |
 
 If the user asks about cleanup/reorganization for an already-existing directory tree, treat that as **relocate flow** (read `skills/relocate-review/SKILL.md`), not the `sourceRoot` pipeline flow.
 

--- a/src/tool-detect-rebroadcasts.ts
+++ b/src/tool-detect-rebroadcasts.ts
@@ -6,8 +6,8 @@ export function registerToolDetectRebroadcasts(api: any, getCfg: (api: any) => a
     {
       name: "video_pipeline_detect_rebroadcasts",
       description:
-        "Detect rebroadcasts by grouping same-episode recordings with different air_date or broadcaster. " +
-        "Rebroadcasts are linked in DB (not deleted). Use apply=false for dry-run.",
+        "Detect rebroadcast candidates by episode and classify using EPG is_rebroadcast_flag from broadcasts.data_json. " +
+        "If no positive EPG flag exists in a group, members are marked unknown (not date-inferred). Use apply=false for dry-run.",
       parameters: {
         type: "object",
         additionalProperties: false,


### PR DESCRIPTION
### Motivation
- 日付順のみの判定はEPG未取得時に誤判定を招くため、`broadcasts.data_json.is_rebroadcast_flag` を優先して再放送判定する仕様へ変更する目的。 
- EPGフラグがないケースでは人手確認待ち扱いにして誤分類（date-only推定）を抑止するため、`unknown` を導入する設計方針。 

### Description
- `py/detect_rebroadcasts.py`: `path_programs -> broadcasts` を参照して `data_json.is_rebroadcast_flag` を取得する処理を追加し、`_extract_rebroadcast_flag` と `_classify_group` を実装してグループを `original` / `rebroadcast` / `unknown` の3値で分類するように変更した。DBへの出力に `is_rebroadcast_flag` を含め、従来の air_date による date-only 判定を廃止した。 
- `src/tool-detect-rebroadcasts.ts`: ツール説明文を EPG フラグ優先かつ `unknown` を返す挙動に合わせて更新した。 
- `README.md`: ツール一覧とテーブル説明を更新し、`video_pipeline_detect_rebroadcasts` の再放送判定ルール節を追記した。 
- `skills/video-library-pipeline/SKILL.md`: rebroadcast 検出の説明を EPG `[再]` フラグ基準（`rebroadcast`/`original`/`unknown`）へ更新した。 

### Testing
- Seeded a temporary SQLite DB and ran `python py/detect_rebroadcasts.py --db <temp-db> --apply` with crafted rows; assertions confirmed that groups with `is_rebroadcast_flag=true` are classified as `rebroadcast/original` and groups without EPG flags are classified as `unknown` (test passed). 
- Ran `python -m py_compile py/detect_rebroadcasts.py` to ensure Python syntax validity (succeeded). 
- Attempted `npm -s run -q lint` but it failed because `package.json` has no `lint` script defined (known non-blocking issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb73a30688329b67b0b62b0c2cd53)