### PR TITLE
Bypass suspicious-title gating for human-reviewed metadata and add skip flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ sourceRoot (未視聴フォルダ) のファイルを正規化・棚卸し、メ
 | `queueMissingMetadata`       | boolean                      | メタデータ不足ファイルをキューに収集                               |
 | `writeMetadataQueueOnDryRun` | boolean                      | dry-run時もキューファイルを書き出す                                |
 | `onDstExists`                | `error`\|`rename_suffix` | 移動先に同名ファイルが存在する場合の挙動                           |
+| `skipSuspiciousTitleCheck`    | boolean                      | suspiciousなtitle安全チェックを一時的に無効化 (default: false)       |
 
 **安全機構:**
 

--- a/py/relocate_existing_files.py
+++ b/py/relocate_existing_files.py
@@ -180,6 +180,11 @@ def main() -> int:
     ap.add_argument("--scan-retry-count", type=int, default=DEFAULT_SCAN_RETRY_COUNT)
     ap.add_argument("--on-dst-exists", choices=["error", "rename_suffix"], default="error")
     ap.add_argument("--drive-routes", default="", help="Path to drive_routes.yaml for multi-dest routing")
+    ap.add_argument(
+        "--skip-suspicious-title-check",
+        default="false",
+        help="Skip suspicious program_title checks (swallowed title / subtitle separator)",
+    )
     args = ap.parse_args()
 
     db_path = windows_to_wsl_path(args.db)
@@ -229,6 +234,7 @@ def main() -> int:
     queue_missing_metadata = as_bool(args.queue_missing_metadata, False)
     write_metadata_queue_on_dry_run = as_bool(args.write_metadata_queue_on_dry_run, False)
     scan_retry_count = max(0, int(args.scan_retry_count or DEFAULT_SCAN_RETRY_COUNT))
+    skip_suspicious_title_check = as_bool(args.skip_suspicious_title_check, False)
 
     scanned, scan_warnings, scan_errors, fallback_stats = scan_files(
         roots=roots,
@@ -375,7 +381,10 @@ def main() -> int:
                     )
                 continue
 
-            if looks_like_swallowed_program_title(sf.win_path, md):
+            is_human_reviewed = str(md_source or "").strip().lower() == "human_reviewed"
+            run_suspicious_title_check = not skip_suspicious_title_check and not is_human_reviewed
+
+            if run_suspicious_title_check and looks_like_swallowed_program_title(sf.win_path, md):
                 suspicious_program_title_skipped += 1
                 rows_for_plan.append(
                     {
@@ -395,7 +404,7 @@ def main() -> int:
                     )
                 continue
 
-            if detect_subtitle_in_program_title(str(md.get("program_title", ""))):
+            if run_suspicious_title_check and detect_subtitle_in_program_title(str(md.get("program_title", ""))):
                 suspicious_program_title_skipped += 1
                 rows_for_plan.append(
                     {
@@ -487,6 +496,7 @@ def main() -> int:
                             "apply": bool(args.apply),
                             "allow_needs_review": allow_needs_review,
                             "queue_missing_metadata": queue_missing_metadata,
+                            "skip_suspicious_title_check": skip_suspicious_title_check,
                             "extensions": extensions,
                             "on_dst_exists": str(args.on_dst_exists),
                         }

--- a/src/tool-relocate.ts
+++ b/src/tool-relocate.ts
@@ -26,6 +26,7 @@ export function registerToolRelocate(api: any, getCfg: (api: any) => any) {
           scanErrorThreshold: { type: "integer", minimum: 1, maximum: 100000, description: "Error count threshold when scanErrorPolicy=threshold." },
           scanRetryCount: { type: "integer", minimum: 0, maximum: 10, default: 1, description: "Retry count per file on scan error." },
           onDstExists: { type: "string", enum: ["error", "rename_suffix"], default: "error", description: "Behavior when destination file already exists: error=abort that file, rename_suffix=add suffix." },
+          skipSuspiciousTitleCheck: { type: "boolean", default: false, description: "Skip swallowed-title and subtitle-separator suspicious checks. Use only after validating metadata quality (e.g., human-reviewed)." },
         },
       },
       async execute(_id: string, params: AnyObj) {
@@ -130,6 +131,8 @@ export function registerToolRelocate(api: any, getCfg: (api: any) => any) {
           String(params.scanRetryCount ?? 1),
           "--on-dst-exists",
           String(params.onDstExists || "error"),
+          "--skip-suspicious-title-check",
+          String(params.skipSuspiciousTitleCheck === true),
         ];
         if (driveRoutesPath && fs.existsSync(driveRoutesPath)) {
           args.push("--drive-routes", driveRoutesPath);
@@ -183,6 +186,7 @@ export function registerToolRelocate(api: any, getCfg: (api: any) => any) {
           ...(typeof params.scanErrorThreshold === "number"
             ? { scanErrorThreshold: Math.trunc(params.scanErrorThreshold) }
             : {}),
+          ...(params.skipSuspiciousTitleCheck === true ? { skipSuspiciousTitleCheck: true } : {}),
         };
         const plannedMoves = Number(out.plannedMoves || 0);
         const hasSuspiciousTitles = Number(out.suspiciousProgramTitleSkipped || 0) > 0;


### PR DESCRIPTION
### Motivation

- The `looks_like_swallowed_program_title()` and subtitle-separator checks can block legitimate relocation when metadata is already human-reviewed or when files are simply in the wrong folder; this change trusts `human_reviewed` metadata and provides an explicit operator override.

### Description

- Added CLI flag `--skip-suspicious-title-check` to `py/relocate_existing_files.py` to allow explicit bypass of suspicious-title checks and recorded the flag in relocate plan `_meta`.
- Changed runtime logic to skip `looks_like_swallowed_program_title()` and `detect_subtitle_in_program_title()` when the latest metadata source is `human_reviewed` or when the skip flag is set; machine-derived metadata still runs the checks.
- Exposed `skipSuspiciousTitleCheck` parameter in `src/tool-relocate.ts` and passed it through to the Python script and follow-up common params.
- Documented the new `skipSuspiciousTitleCheck` parameter in `README.md`.

### Testing

- Ran `python -m py_compile py/relocate_existing_files.py` and `python -m py_compile py/path_placement_rules.py` to ensure Python syntax correctness; both succeeded.
- Ran `uv run python py/relocate_existing_files.py --help | head -n 40` to verify the new CLI option is listed; output included `--skip-suspicious-title-check` and showed the updated usage.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdfd2db3083298d95d44fc281bff1)