### PR TITLE
relocate: require human-reviewed metadata by default before move planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ sourceRoot (未視聴フォルダ) のファイルを正規化・棚卸し、メ
 | `planPath`                   | string                       | apply時必須。dry-runが返す計画ファイルパス                         |
 | `roots`                      | string[]                     | スキャン対象。省略時は `relocate_roots.yaml`                     |
 | `allowNeedsReview`           | boolean                      | `needs_review=true`のファイルも移動対象に含める (default: false) |
+| `allowUnreviewedMetadata`    | boolean                      | `source=human_reviewed` 以外のメタデータでの計画生成を許可 (default: false) |
 | `queueMissingMetadata`       | boolean                      | メタデータ不足ファイルをキューに収集                               |
 | `writeMetadataQueueOnDryRun` | boolean                      | dry-run時もキューファイルを書き出す                                |
 | `onDstExists`                | `error`\|`rename_suffix` | 移動先に同名ファイルが存在する場合の挙動                           |
@@ -861,6 +862,10 @@ DB_CONTRACT_REQUIRED = {"program_title", "air_date", "needs_review"}
 ### allowNeedsReview のデフォルト
 
 `allowNeedsReview` は `relocate_existing_files` と `analyze_and_move_videos` の両方で **デフォルトfalse**。`needs_review=true` のファイルはレビュー完了まで移動計画から除外される。
+
+### allowUnreviewedMetadata のデフォルト
+
+`relocate_existing_files` は **デフォルトで `source=human_reviewed` のメタデータのみ** 移動計画に使用する。`source=llm` など未レビュー行は `unreviewedMetadataSkipped` として除外され、レビュー適用後に再実行する前提。
 
 ---
 

--- a/py/relocate_existing_files.py
+++ b/py/relocate_existing_files.py
@@ -173,6 +173,11 @@ def main() -> int:
     ap.add_argument("--extensions-json", default="")
     ap.add_argument("--limit", type=int, default=0)
     ap.add_argument("--allow-needs-review", default="false")
+    ap.add_argument(
+        "--allow-unreviewed-metadata",
+        default="false",
+        help="Allow non-human_reviewed metadata (e.g. source=llm) to generate relocation plans",
+    )
     ap.add_argument("--queue-missing-metadata", default="false")
     ap.add_argument("--write-metadata-queue-on-dry-run", default="false")
     ap.add_argument("--scan-error-policy", choices=["warn", "fail", "threshold"], default="warn")
@@ -231,6 +236,7 @@ def main() -> int:
     extensions = ensure_exts(exts_raw if isinstance(exts_raw, list) else DEFAULT_EXTENSIONS)
     limit = max(0, int(args.limit or 0))
     allow_needs_review = as_bool(args.allow_needs_review, False)
+    allow_unreviewed_metadata = as_bool(args.allow_unreviewed_metadata, False)
     queue_missing_metadata = as_bool(args.queue_missing_metadata, False)
     write_metadata_queue_on_dry_run = as_bool(args.write_metadata_queue_on_dry_run, False)
     scan_retry_count = max(0, int(args.scan_retry_count or DEFAULT_SCAN_RETRY_COUNT))
@@ -274,6 +280,7 @@ def main() -> int:
     invalid_contract_skipped = 0
     suspicious_program_title_skipped = 0
     needs_review_skipped = 0
+    unreviewed_metadata_skipped = 0
     corrupt_candidates = 0
     dst_exists_errors = 0
     auto_registered_paths = 0
@@ -382,6 +389,24 @@ def main() -> int:
                 continue
 
             is_human_reviewed = str(md_source or "").strip().lower() == "human_reviewed"
+            if not allow_unreviewed_metadata and not is_human_reviewed:
+                unreviewed_metadata_skipped += 1
+                rows_for_plan.append(
+                    {
+                        "path_id": path_id,
+                        "src": sf.win_path,
+                        "status": "skipped",
+                        "reason": "unreviewed_metadata",
+                        "metadata_source": md_source,
+                        "ts": ts_row,
+                    }
+                )
+                if queue_missing_metadata:
+                    queue_candidates.append(
+                        {"path_id": path_id, "path": sf.win_path, "name": sf.name, "mtime_utc": sf.mtime_utc}
+                    )
+                continue
+
             run_suspicious_title_check = not skip_suspicious_title_check and not is_human_reviewed
 
             if run_suspicious_title_check and looks_like_swallowed_program_title(sf.win_path, md):
@@ -495,6 +520,7 @@ def main() -> int:
                             "roots": roots_win,
                             "apply": bool(args.apply),
                             "allow_needs_review": allow_needs_review,
+                            "allow_unreviewed_metadata": allow_unreviewed_metadata,
                             "queue_missing_metadata": queue_missing_metadata,
                             "skip_suspicious_title_check": skip_suspicious_title_check,
                             "extensions": extensions,
@@ -798,13 +824,16 @@ def main() -> int:
             auto_registered_files_truncated = True
 
         requires_metadata_preparation = metadata_queue_planned_count > 0 or suspicious_program_title_skipped > 0
-        requires_human_review = bool(requires_metadata_preparation or needs_review_skipped > 0)
+        requires_human_review = bool(
+            requires_metadata_preparation or needs_review_skipped > 0 or unreviewed_metadata_skipped > 0
+        )
         can_proceed_to_relocate_apply = bool(
             (not args.apply)
             and planned_moves > 0
             and metadata_queue_planned_count == 0
             and suspicious_program_title_skipped == 0
             and needs_review_skipped == 0
+            and unreviewed_metadata_skipped == 0
             and len(errors) == 0
         )
 
@@ -841,6 +870,10 @@ def main() -> int:
         if suspicious_program_title_skipped > 0:
             next_actions.append(
                 "Some machine-extracted program titles look like swallowed episode titles under by_program; regenerate/review metadata before relocate apply."
+            )
+        if unreviewed_metadata_skipped > 0:
+            next_actions.append(
+                "Some files were skipped because latest metadata is not human_reviewed; review/apply metadata, or rerun with allowUnreviewedMetadata=true only when intentionally accepting machine-only metadata."
             )
         if (not args.apply) and unregistered_skipped > 0:
             next_actions.append(
@@ -882,6 +915,7 @@ def main() -> int:
             "invalidContractSkipped": invalid_contract_skipped,
             "suspiciousProgramTitleSkipped": suspicious_program_title_skipped,
             "needsReviewSkipped": needs_review_skipped,
+            "unreviewedMetadataSkipped": unreviewed_metadata_skipped,
             "corruptCandidates": corrupt_candidates,
             "dstExistsErrors": dst_exists_errors,
             "moveApplyStats": move_apply_stats,

--- a/src/tool-relocate.ts
+++ b/src/tool-relocate.ts
@@ -20,6 +20,7 @@ export function registerToolRelocate(api: any, getCfg: (api: any) => any) {
           extensions: { type: "array", items: { type: "string" }, default: [".mp4"], description: "File extensions to include. Default: [\".mp4\"]." },
           limit: { type: "integer", minimum: 1, maximum: 100000, description: "Max files to process in one run." },
           allowNeedsReview: { type: "boolean", default: false, description: "Include files flagged needs_review in move plan. Default false (skip them)." },
+          allowUnreviewedMetadata: { type: "boolean", default: false, description: "Allow relocation planning with metadata that is not source=human_reviewed. Default false (safer: skip machine-only metadata)." },
           queueMissingMetadata: { type: "boolean", default: false, description: "Collect files with missing metadata into a queue for reextract. Set true to enable metadata preparation flow." },
           writeMetadataQueueOnDryRun: { type: "boolean", default: false, description: "Write the metadata queue file even during dry-run. Required to use the queue path in a subsequent reextract call." },
           scanErrorPolicy: { type: "string", enum: ["warn", "fail", "threshold"], default: "warn", description: "How to handle scan errors: warn=continue, fail=abort, threshold=abort after N errors." },
@@ -121,6 +122,8 @@ export function registerToolRelocate(api: any, getCfg: (api: any) => any) {
           String(params.rootsFilePath || defaultRootsFile),
           "--allow-needs-review",
           String(params.allowNeedsReview === true),
+          "--allow-unreviewed-metadata",
+          String(params.allowUnreviewedMetadata === true),
           "--queue-missing-metadata",
           String(params.queueMissingMetadata === true),
           "--write-metadata-queue-on-dry-run",
@@ -187,12 +190,14 @@ export function registerToolRelocate(api: any, getCfg: (api: any) => any) {
             ? { scanErrorThreshold: Math.trunc(params.scanErrorThreshold) }
             : {}),
           ...(params.skipSuspiciousTitleCheck === true ? { skipSuspiciousTitleCheck: true } : {}),
+          ...(params.allowUnreviewedMetadata === true ? { allowUnreviewedMetadata: true } : {}),
         };
         const plannedMoves = Number(out.plannedMoves || 0);
         const hasSuspiciousTitles = Number(out.suspiciousProgramTitleSkipped || 0) > 0;
         const hasMetadataGap =
           Number(out.metadataMissingSkipped || 0) > 0 ||
-          Number(out.metadataQueuePlannedCount || 0) > 0;
+          Number(out.metadataQueuePlannedCount || 0) > 0 ||
+          Number(out.unreviewedMetadataSkipped || 0) > 0;
 
         // ── Dry-run routing ──
 


### PR DESCRIPTION
### Motivation

- Relocate dry-run sometimes generated reverse-direction moves because LLM-only metadata (`source=llm`) had shortened/incorrect `program_title` and was trusted for destination placement.
- The existing destination logic consumed `program_title` only and lacked a gate to prevent unreviewed LLM results from being used directly.
- Make the relocate flow safer by default so machine-only metadata does not produce physical-move plans unless explicitly allowed.

### Description

- Added a new CLI option `--allow-unreviewed-metadata` (default `false`) to `py/relocate_existing_files.py` to opt-in to using non-`human_reviewed` metadata. When this flag is not set, the script skips paths whose latest metadata source is not `human_reviewed` and records them as skipped with reason `unreviewed_metadata`.
- Counted and surfaced the skipped group as `unreviewedMetadataSkipped` in the relocate summary and included `allow_unreviewed_metadata` in the generated plan `_meta`.
- Updated relocate decision logic to factor `unreviewedMetadataSkipped` into `requiresHumanReview`, `canProceedToRelocateApply`, `nextActions` guidance, and partial-apply routing.
- Plumbed the option through the tool layer: added `allowUnreviewedMetadata` to `video_pipeline_relocate_existing_files` schema in `src/tool-relocate.ts` and forward it to the Python script and follow-up parameters.
- Documented the new parameter and default behavior in `README.md` under the relocate tool section.

### Testing

- Ran `python -m py_compile py/relocate_existing_files.py` to validate Python syntax, which succeeded.
- Ran `python py/relocate_existing_files.py --help` to verify the new CLI option appears, which printed the updated usage including `--allow-unreviewed-metadata`.
- Attempted TypeScript build checks (`npm run -s build` and `npm -s exec tsc --noEmit`), which did not complete due to repository-level configuration (`build` script or `tsconfig.json` not configured); these are environment/packaging issues and did not affect the Python changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac33b3dd688329beabd8a61e38f8b2)