### PR TITLE
Guard relocate against truncated LLM program titles

### DIFF
--- a/py/relocate_existing_files.py
+++ b/py/relocate_existing_files.py
@@ -133,6 +133,29 @@ def looks_like_swallowed_program_title(src_path_win: str, md: dict[str, Any] | N
     return False
 
 
+def looks_like_truncated_program_title(src_path_win: str, md: dict[str, Any] | None) -> bool:
+    """現在フォルダ名より program_title が不自然に短い場合を検出する。"""
+    if not isinstance(md, dict):
+        return False
+    group = _folder_title_from_path(src_path_win)
+    title = md.get("program_title")
+    if not group or not isinstance(title, str):
+        return False
+    title = title.strip()
+    if not title:
+        return False
+
+    g = _normalize_title_compare(group)
+    t = _normalize_title_compare(title)
+    if not g or not t or t == g:
+        return False
+
+    # LLM short extraction (ex: "RNC_news_every" folder vs "RNC" title)
+    if g.startswith(t) and len(g) >= len(t) + 3:
+        return True
+    return False
+
+
 def parse_last_json_object(stdout: str) -> dict[str, Any] | None:
     for line in reversed((stdout or "").splitlines()):
         s = line.strip()
@@ -412,6 +435,26 @@ def main() -> int:
                         "src": sf.win_path,
                         "status": "skipped",
                         "reason": "subtitle_separator_in_program_title",
+                        "metadata_source": md_source,
+                        "program_title": md.get("program_title"),
+                        "folderTitle": _folder_title_from_path(sf.win_path),
+                        "ts": ts_row,
+                    }
+                )
+                if queue_missing_metadata:
+                    queue_candidates.append(
+                        {"path_id": path_id, "path": sf.win_path, "name": sf.name, "mtime_utc": sf.mtime_utc}
+                    )
+                continue
+
+            if run_suspicious_title_check and looks_like_truncated_program_title(sf.win_path, md):
+                suspicious_program_title_skipped += 1
+                rows_for_plan.append(
+                    {
+                        "path_id": path_id,
+                        "src": sf.win_path,
+                        "status": "skipped",
+                        "reason": "truncated_program_title_vs_folder",
                         "metadata_source": md_source,
                         "program_title": md.get("program_title"),
                         "folderTitle": _folder_title_from_path(sf.win_path),

--- a/tests/test_relocate_existing_files.py
+++ b/tests/test_relocate_existing_files.py
@@ -1,0 +1,27 @@
+import unittest
+
+from relocate_existing_files import (
+    looks_like_swallowed_program_title,
+    looks_like_truncated_program_title,
+)
+
+
+class RelocateSuspiciousTitleTests(unittest.TestCase):
+    def test_swallowed_program_title_detects_prefix_plus_episode_text(self):
+        src = r"B:\VideoLibrary\RNC_news_every\2026\03\RNC_news_every▽特集.mp4"
+        md = {"program_title": "RNC_news_every きょうの特集"}
+        self.assertTrue(looks_like_swallowed_program_title(src, md))
+
+    def test_truncated_program_title_detects_shortened_llm_title(self):
+        src = r"B:\VideoLibrary\RNC_news_every\2026\03\foo.mp4"
+        md = {"program_title": "RNC"}
+        self.assertTrue(looks_like_truncated_program_title(src, md))
+
+    def test_truncated_program_title_not_triggered_when_title_matches_folder(self):
+        src = r"B:\VideoLibrary\RNC_news_every\2026\03\foo.mp4"
+        md = {"program_title": "RNC_news_every"}
+        self.assertFalse(looks_like_truncated_program_title(src, md))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Relocate dry-run sometimes generated reverse-direction move plans because LLM-only metadata produced a shortened `program_title` (e.g. `RNC`), which conflicted with the file's current folder (e.g. `RNC_news_every`).
- The intent is to avoid trusting unreviewed LLM outputs for destination decisions and force those items into the metadata preparation/review flow instead of proposing unsafe moves.

### Description
- Added `looks_like_truncated_program_title()` in `py/relocate_existing_files.py` to detect when `program_title` is unnaturally shorter than the current folder title.
- Integrated the detector into the relocate planning path so non-`human_reviewed` records that trigger this check are skipped with reason `truncated_program_title_vs_folder` and can be queued for re-extraction.
- Preserved existing suspicious-title checks (`looks_like_swallowed_program_title` and subtitle-separator detection) and kept the queue behavior when `queue_missing_metadata` is enabled.
- Added unit tests at `tests/test_relocate_existing_files.py` covering the swallowed-title case, the new truncated-title case, and the non-trigger matching-title case.

### Testing
- Ran the unit test suite with `PYTHONPATH=py python -m unittest discover -s tests -v` and all tests passed (`3 tests, OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac33b3dd688329beabd8a61e38f8b2)