### PR TITLE
Fix: apply_reviewed_metadata の source デフォルトを human_reviewed に修正

### DIFF
--- a/src/tool-apply-reviewed-metadata.ts
+++ b/src/tool-apply-reviewed-metadata.ts
@@ -166,7 +166,7 @@ export function registerToolApplyReviewedMetadata(api: any, getCfg: (api: any) =
           markHumanReviewed: { type: "boolean", default: true },
           allowNoContentChanges: { type: "boolean", default: false },
           reviewedBy: { type: "string" },
-          source: { type: "string", default: "rule_based" },
+          source: { type: "string", default: "human_reviewed" },
         },
       },
       async execute(_id: string, params: AnyObj) {
@@ -300,7 +300,7 @@ export function registerToolApplyReviewedMetadata(api: any, getCfg: (api: any) =
           "--in",
           outputStampedJsonlPath,
           "--source",
-          String(params.source || "rule_based"),
+          String(params.source || (markHumanReviewed ? "human_reviewed" : "rule_based")),
           "--franchise-rules",
           franchiseRulesPath,
         ];


### PR DESCRIPTION
## Summary

- `tool-apply-reviewed-metadata.ts` の `source` パラメータのデフォルトが `rule_based` にハードコードされていた
- `markHumanReviewed=true` でも DB の `path_metadata.source` が `rule_based` で書き込まれ、relocate の `is_human_reviewed` チェック（PR #37）を通過できなかった
- デフォルトを `human_reviewed` に変更し、フォールバックも `markHumanReviewed` に連動させた

## DB 修復

`source=rule_based` かつ `updated_at=2026-03-08T00:58:50.855387+00:00` の 6588 件を `source=human_reviewed` に UPDATE 済み。

## Test plan

- [ ] `apply_reviewed_metadata` 実行後に DB の `path_metadata.source` が `human_reviewed` であること
- [ ] relocate dry-run で `unreviewedMetadataSkipped` が 0 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)