### PR TITLE
Add folder-case normalization tool for Windows relocate workflow

### DIFF
--- a/assets/windows-scripts/apply_case_rename_plan.ps1
+++ b/assets/windows-scripts/apply_case_rename_plan.ps1
@@ -1,0 +1,98 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PlanJsonl,
+  [Parameter(Mandatory = $true)]
+  [string]$OpsRoot
+)
+
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$ErrorActionPreference = 'Continue'
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $here '_long_path_utils.ps1')
+
+if (!(Test-PathFileLong $PlanJsonl)) {
+  throw "Plan not found: $PlanJsonl"
+}
+
+$runId = "{0}_{1}" -f (Get-Date -Format 'yyyyMMdd_HHmmss_fff'), $PID
+$moveDir = Join-Path -Path $OpsRoot -ChildPath "move"
+$out = Join-Path -Path $moveDir -ChildPath "folder_case_apply_${runId}.jsonl"
+Ensure-DirectoryLong $moveDir
+
+function J([hashtable]$h) { ([pscustomobject]$h | ConvertTo-Json -Compress -Depth 6) }
+
+$renamed = 0
+$skipped = 0
+$errors = 0
+
+$sw = New-Object System.IO.StreamWriter($out, $false, (New-Object System.Text.UTF8Encoding($false)))
+try {
+  $sw.WriteLine((J @{ _meta = @{ kind='folder_case_apply'; run_id=$runId; plan=$PlanJsonl; generated_at=(Get-Date).ToString('o') } }))
+
+  Get-Content -LiteralPath $PlanJsonl -Encoding UTF8 | ForEach-Object {
+    $line = $_.Trim()
+    if (!$line) { return }
+
+    $o = $null
+    try { $o = $line | ConvertFrom-Json } catch { return }
+    if ($null -ne $o._meta) { return }
+
+    $srcDir = [string]$o.src_dir
+    $dstDir = [string]$o.dst_dir
+    $ts = (Get-Date).ToString('o')
+
+    if ([string]::IsNullOrWhiteSpace($srcDir) -or [string]::IsNullOrWhiteSpace($dstDir)) {
+      $errors += 1
+      $sw.WriteLine((J @{ op='rename_dir_case'; ts=$ts; src_dir=$srcDir; dst_dir=$dstDir; ok=$false; error='missing_src_or_dst' }))
+      return
+    }
+
+    if ($srcDir -ceq $dstDir) {
+      $skipped += 1
+      $sw.WriteLine((J @{ op='rename_dir_case'; ts=$ts; src_dir=$srcDir; dst_dir=$dstDir; ok=$true; skipped='already_correct' }))
+      return
+    }
+
+    if ($srcDir.ToLowerInvariant() -cne $dstDir.ToLowerInvariant()) {
+      $errors += 1
+      $sw.WriteLine((J @{ op='rename_dir_case'; ts=$ts; src_dir=$srcDir; dst_dir=$dstDir; ok=$false; error='not_case_only' }))
+      return
+    }
+
+    if (!(Test-PathDirLong $srcDir)) {
+      $skipped += 1
+      $sw.WriteLine((J @{ op='rename_dir_case'; ts=$ts; src_dir=$srcDir; dst_dir=$dstDir; ok=$true; skipped='src_not_found' }))
+      return
+    }
+
+    try {
+      $parent = Split-Path -Parent $srcDir
+      $dstName = Split-Path -Leaf $dstDir
+      if ([string]::IsNullOrWhiteSpace($parent) -or [string]::IsNullOrWhiteSpace($dstName)) {
+        throw "invalid_parent_or_dst_name"
+      }
+
+      $tmpName = "__case_tmp_${runId}_$([guid]::NewGuid().ToString('N'))"
+      $tmpPath = Join-Path -Path $parent -ChildPath $tmpName
+
+      [System.IO.Directory]::Move((Convert-ToLongPathLiteral $srcDir), (Convert-ToLongPathLiteral $tmpPath))
+      [System.IO.Directory]::Move((Convert-ToLongPathLiteral $tmpPath), (Convert-ToLongPathLiteral $dstDir))
+
+      $renamed += 1
+      $sw.WriteLine((J @{ op='rename_dir_case'; ts=$ts; src_dir=$srcDir; dst_dir=$dstDir; ok=$true }))
+    } catch {
+      $errors += 1
+      $sw.WriteLine((J @{ op='rename_dir_case'; ts=$ts; src_dir=$srcDir; dst_dir=$dstDir; ok=$false; error=$_.Exception.Message }))
+    }
+  }
+}
+finally {
+  $sw.Flush(); $sw.Close()
+}
+
+$ok = ($errors -eq 0)
+Write-Output (J @{ ok=$ok; run_id=$runId; out_jsonl=$out; renamed=$renamed; skipped=$skipped; errors=$errors })
+if (-not $ok) {
+  exit 1
+}

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { registerToolDetectRebroadcasts } from "./src/tool-detect-rebroadcasts";
 import { registerToolIngestEpg } from "./src/tool-ingest-epg";
 import { registerToolPrepareRelocateMetadata } from "./src/tool-prepare-relocate-metadata";
 import { registerToolRelocate } from "./src/tool-relocate";
+import { registerToolNormalizeFolderCase } from "./src/tool-normalize-folder-case";
 import { registerToolReextract } from "./src/tool-reextract";
 import { registerToolLlmExtract } from "./src/tool-llm-extract";
 import { registerToolLlmExtractStatus } from "./src/tool-llm-extract-status";
@@ -39,6 +40,7 @@ export default function register(api: any) {
   registerToolBackfill(api, getCfg);
   registerToolDedup(api, getCfg);
   registerToolRelocate(api, getCfg);
+  registerToolNormalizeFolderCase(api, getCfg);
   registerToolPrepareRelocateMetadata(api, getCfg);
   registerToolStatus(api, getCfg);
   registerToolValidate(api, getCfg);

--- a/py/normalize_folder_case.py
+++ b/py/normalize_folder_case.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Normalize case-only directory name differences based on DB metadata destination rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mediaops_schema import connect_db
+from path_placement_rules import build_expected_dest_path, build_routed_dest_path, load_drive_routes
+from pathscan_common import canonicalize_windows_path, now_iso, safe_json, split_win, ts_compact, windows_to_wsl_path
+from windows_pwsh_bridge import run_pwsh_json
+
+
+@dataclass
+class Candidate:
+    src_dir: str
+    dst_dir: str
+    depth: int
+
+
+def _split_dirs(win_path: str) -> list[str]:
+    return canonicalize_windows_path(win_path).split("\\")
+
+
+def _starts_with_prefix(path_win: str, prefixes: list[str]) -> bool:
+    p = canonicalize_windows_path(path_win).lower()
+    for pref in prefixes:
+        x = canonicalize_windows_path(pref).rstrip("\\").lower()
+        if p == x or p.startswith(x + "\\"):
+            return True
+    return False
+
+
+def _iter_case_dir_candidates(src_path: str, dst_path: str) -> list[Candidate]:
+    src_parts = _split_dirs(src_path)
+    dst_parts = _split_dirs(dst_path)
+    if len(src_parts) != len(dst_parts):
+        return []
+    out: list[Candidate] = []
+    # filename is excluded (last segment)
+    for i in range(1, len(src_parts) - 1):
+        s = src_parts[i]
+        d = dst_parts[i]
+        if s == d:
+            continue
+        if s.lower() != d.lower():
+            continue
+        src_dir = "\\".join(src_parts[: i + 1])
+        dst_dir = "\\".join(dst_parts[: i + 1])
+        out.append(Candidate(src_dir=src_dir, dst_dir=dst_dir, depth=i + 1))
+    return out
+
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--windows-ops-root", required=True)
+    ap.add_argument("--dest-root", required=True)
+    ap.add_argument("--drive-routes", default="")
+    ap.add_argument("--roots-json", default="")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--plan-path", default="")
+    args = ap.parse_args()
+
+    ops_root = Path(windows_to_wsl_path(args.windows_ops_root)).resolve()
+    move_dir = ops_root / "move"
+    move_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = ts_compact()
+    plan_path = Path(windows_to_wsl_path(args.plan_path)).resolve() if args.plan_path else (move_dir / f"folder_case_plan_{ts}.jsonl")
+
+    if args.apply:
+        if not plan_path.exists():
+            raise SystemExit(f"plan not found: {plan_path}")
+        apply_ps1 = Path(windows_to_wsl_path(args.windows_ops_root)) / "scripts" / "apply_case_rename_plan.ps1"
+        if not apply_ps1.exists():
+            raise SystemExit(f"windows script not found: {apply_ps1}")
+        applied = run_pwsh_json(
+            str(apply_ps1),
+            [
+                "-PlanJsonl",
+                str(plan_path),
+                "-OpsRoot",
+                str(args.windows_ops_root),
+            ],
+            normalize_args=True,
+        )
+        print(
+            safe_json(
+                {
+                    "ok": bool(applied.get("ok", True)),
+                    "apply": True,
+                    "planPath": str(plan_path),
+                    "appliedPath": applied.get("out_jsonl"),
+                    "appliedCount": int(applied.get("renamed", 0) or 0),
+                    "skippedCount": int(applied.get("skipped", 0) or 0),
+                    "errorCount": int(applied.get("errors", 0) or 0),
+                    "runId": applied.get("run_id"),
+                }
+            )
+        )
+        return 0 if bool(applied.get("ok", True)) else 1
+
+    db_path = windows_to_wsl_path(args.db)
+    if not os.path.exists(db_path):
+        raise SystemExit(f"DB not found: {args.db}")
+
+    con = connect_db(db_path)
+    rows = con.execute(
+        """
+        SELECT p.path_id, p.path, pm.program_title, pm.air_date
+        FROM file_paths fp
+        JOIN paths p ON p.path_id = fp.path_id
+        LEFT JOIN path_metadata pm ON pm.path_id = p.path_id
+        WHERE fp.is_current = 1
+          AND pm.program_title IS NOT NULL
+          AND pm.program_title != ''
+        """
+    ).fetchall()
+
+    roots: list[str] = []
+    if args.roots_json:
+        try:
+            v = json.loads(args.roots_json)
+            if isinstance(v, list):
+                roots = [str(x) for x in v if str(x).strip()]
+        except Exception:
+            roots = []
+    if not roots:
+        roots = [str(args.dest_root)]
+
+    routes = load_drive_routes(args.drive_routes) if args.drive_routes else []
+
+    scanned = 0
+    case_path_matches = 0
+    dir_candidate_count = 0
+    conflicts = 0
+    candidate_map: dict[str, Candidate] = {}
+
+    for row in rows:
+        scanned += 1
+        src = canonicalize_windows_path(str(row["path"] or ""))
+        if not src or not _starts_with_prefix(src, roots):
+            continue
+        md = {
+            "program_title": row["program_title"],
+            "air_date": row["air_date"],
+        }
+        if routes:
+            dst, _route, err = build_routed_dest_path(routes, src, md)
+        else:
+            dst, err = build_expected_dest_path(args.dest_root, src, md)
+        if err or not dst:
+            continue
+        dst = canonicalize_windows_path(dst)
+        if src == dst or src.lower() != dst.lower():
+            continue
+        case_path_matches += 1
+        for cand in _iter_case_dir_candidates(src, dst):
+            dir_candidate_count += 1
+            key = cand.src_dir.lower()
+            existing = candidate_map.get(key)
+            if existing is None:
+                candidate_map[key] = cand
+                continue
+            if canonicalize_windows_path(existing.dst_dir) != canonicalize_windows_path(cand.dst_dir):
+                conflicts += 1
+
+    candidates = sorted(candidate_map.values(), key=lambda x: (-x.depth, x.src_dir.lower()))
+
+    with plan_path.open("w", encoding="utf-8") as w:
+        w.write(
+            safe_json(
+                {
+                    "_meta": {
+                        "kind": "folder_case_plan",
+                        "generated_at": now_iso(),
+                        "db": db_path,
+                        "dest_root": canonicalize_windows_path(args.dest_root),
+                        "roots": roots,
+                    }
+                }
+            )
+            + "\n"
+        )
+        for c in candidates:
+            drv, parent, _name, _ext = split_win(c.src_dir)
+            w.write(
+                safe_json(
+                    {
+                        "src_dir": c.src_dir,
+                        "dst_dir": c.dst_dir,
+                        "parent_dir": f"{drv}\\{parent}" if drv and parent else parent,
+                        "depth": c.depth,
+                        "reason": "case_only_directory_normalization",
+                    }
+                )
+                + "\n"
+            )
+
+    summary = {
+        "ok": True,
+        "apply": False,
+        "planPath": str(plan_path),
+        "scannedFiles": scanned,
+        "casePathMatches": case_path_matches,
+        "directoryCandidates": dir_candidate_count,
+        "plannedRenames": len(candidates),
+        "conflictCount": conflicts,
+    }
+    print(safe_json(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tool-normalize-folder-case.ts
+++ b/src/tool-normalize-folder-case.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import { parseJsonObject, resolvePythonScript, runCmd, toToolResult } from "./runtime";
+import type { AnyObj } from "./types";
+import { ensureWindowsScripts } from "./windows-scripts-bootstrap";
+
+export function registerToolNormalizeFolderCase(api: any, getCfg: (api: any) => any) {
+  api.registerTool(
+    {
+      name: "video_pipeline_normalize_folder_case",
+      description:
+        "Normalize case-only folder name differences (e.g. 'vs' -> 'VS') based on DB metadata destination rules. " +
+        "Use apply=false for dry-run first, then apply=true with planPath.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          apply: {
+            type: "boolean",
+            default: false,
+            description: "false=dry-run (plan only), true=execute case-normalization renames.",
+          },
+          planPath: {
+            type: "string",
+            description: "Required when apply=true. Plan path returned by dry-run.",
+          },
+          roots: {
+            type: "array",
+            items: { type: "string" },
+            description: "Optional Windows roots to limit target files. Default: [destRoot].",
+          },
+        },
+      },
+      async execute(_id: string, params: AnyObj) {
+        const cfg = getCfg(api);
+        const resolved = resolvePythonScript("normalize_folder_case.py");
+        const scriptsProvision = ensureWindowsScripts(cfg);
+        if (!scriptsProvision.ok) {
+          return toToolResult({
+            ok: false,
+            tool: "video_pipeline_normalize_folder_case",
+            error: "failed to provision required windows scripts",
+            scriptsProvision,
+          });
+        }
+
+        if (params.apply === true) {
+          const planPath = typeof params.planPath === "string" ? params.planPath.trim() : "";
+          if (!planPath) {
+            return toToolResult({
+              ok: false,
+              tool: "video_pipeline_normalize_folder_case",
+              error: "apply=true requires planPath.",
+            });
+          }
+          if (!fs.existsSync(planPath)) {
+            return toToolResult({
+              ok: false,
+              tool: "video_pipeline_normalize_folder_case",
+              error: `planPath does not exist: ${planPath}`,
+            });
+          }
+        }
+
+        const args = [
+          "run",
+          "python",
+          resolved.scriptPath,
+          "--db",
+          String(cfg.db || ""),
+          "--windows-ops-root",
+          String(cfg.windowsOpsRoot || ""),
+          "--dest-root",
+          String(cfg.destRoot || ""),
+        ];
+
+        if (params.apply === true) args.push("--apply");
+        if (typeof params.planPath === "string" && params.planPath.trim()) {
+          args.push("--plan-path", String(params.planPath));
+        }
+        if (Array.isArray(params.roots) && params.roots.length > 0) {
+          args.push("--roots-json", JSON.stringify(params.roots));
+        }
+        if (typeof cfg.driveRoutesPath === "string" && cfg.driveRoutesPath.trim()) {
+          args.push("--drive-routes", String(cfg.driveRoutesPath));
+        }
+
+        const r = runCmd("uv", args, resolved.cwd);
+        const parsed = parseJsonObject(r.stdout);
+        const out: AnyObj = {
+          ok: r.ok,
+          tool: "video_pipeline_normalize_folder_case",
+          scriptSource: resolved.source,
+          scriptPath: resolved.scriptPath,
+          exitCode: r.code,
+          stdout: r.stdout,
+          stderr: r.stderr,
+          scriptsProvision,
+        };
+        if (parsed) {
+          for (const [k, v] of Object.entries(parsed)) out[k] = v;
+        }
+        return toToolResult(out);
+      },
+    },
+  );
+}

--- a/src/windows-scripts-bootstrap.ts
+++ b/src/windows-scripts-bootstrap.ts
@@ -5,6 +5,7 @@ import { getExtensionRootDir } from "./runtime";
 export const REQUIRED_WINDOWS_SCRIPTS = [
   "unwatched_inventory.ps1",
   "apply_move_plan.ps1",
+  "apply_case_rename_plan.ps1",
 ] as const;
 
 export const INTERNAL_WINDOWS_SCRIPTS = ["_long_path_utils.ps1", "enumerate_files_jsonl.ps1"] as const;


### PR DESCRIPTION
### Motivation
- Windows is case-insensitive so the existing `relocate` flow intentionally skips case-only path changes (`already_correct`) and there was no safe way to normalize folder name casing to match DB `program_title` values.
- A dedicated tool is needed to compute DB-driven expected paths and apply case-only renames reliably on Windows without risking incorrect moves.

### Description
- Adds a new pipeline tool `video_pipeline_normalize_folder_case` (registered in `index.ts`) that implements a dry-run/apply flow with `planPath` safety checks via `src/tool-normalize-folder-case.ts`.
- Implements `py/normalize_folder_case.py` to recompute expected destinations using DB metadata and placement rules, detect case-only directory mismatches, deduplicate candidates, and emit a JSONL plan file for review.
- Adds `assets/windows-scripts/apply_case_rename_plan.ps1` which safely applies case-only directory renames on Windows using a two-step temp rename (`src -> temp -> dst`) to work around case-insensitive filesystem semantics.
- Updates Windows script provisioning (`src/windows-scripts-bootstrap.ts`) to include the new `apply_case_rename_plan.ps1` template so scripts are automatically installed.

### Testing
- Ran `python -m py_compile py/normalize_folder_case.py` which succeeded without syntax errors.
- Ran `python py/normalize_folder_case.py --help` which printed expected CLI usage and returned successfully.
- Performed a Node-based sanity check that the new files are present with `node -e "..."` which printed `files-ok`.
- Ran `git diff --check` which reported no whitespace or diff problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2b53cf088329be67568068bf903c)