### PR TITLE
Add folder-case normalization flow for relocate case-only mismatches

### DIFF
--- a/assets/windows-scripts/normalize_case_dirs.ps1
+++ b/assets/windows-scripts/normalize_case_dirs.ps1
@@ -1,0 +1,90 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PlanJsonl,
+  [Parameter(Mandatory = $true)]
+  [string]$OpsRoot
+)
+
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$ErrorActionPreference = 'Continue'
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $here '_long_path_utils.ps1')
+
+if (!(Test-PathFileLong $PlanJsonl)) {
+  throw "Plan not found: $PlanJsonl"
+}
+
+$runId = "{0}_{1}" -f (Get-Date -Format 'yyyyMMdd_HHmmss_fff'), $PID
+$moveDir = Join-Path -Path $OpsRoot -ChildPath "move"
+$out = Join-Path -Path $moveDir -ChildPath "normalize_case_apply_${runId}.jsonl"
+Ensure-DirectoryLong $moveDir
+
+function J([hashtable]$h) { ([pscustomobject]$h | ConvertTo-Json -Compress -Depth 6) }
+
+$sw = New-Object System.IO.StreamWriter($out, $false, (New-Object System.Text.UTF8Encoding($false)))
+try {
+  $sw.WriteLine((J @{ _meta = @{ kind='normalize_case_apply'; run_id=$runId; plan=$PlanJsonl; generated_at=(Get-Date).ToString('o') } }))
+
+  Get-Content -LiteralPath $PlanJsonl -Encoding UTF8 | ForEach-Object {
+    $line = $_.Trim()
+    if (!$line) { return }
+    if ($line.StartsWith('{') -and $line.Contains('"_meta"')) { return }
+
+    $o = $null
+    try { $o = $line | ConvertFrom-Json } catch { return }
+    if ($o.status -ne 'planned') { return }
+
+    $src = [string]$o.src
+    $dst = [string]$o.dst
+    $ts = (Get-Date).ToString('o')
+
+    if ([string]::IsNullOrWhiteSpace($src) -or [string]::IsNullOrWhiteSpace($dst)) {
+      $sw.WriteLine((J @{ op='normalize_case'; ts=$ts; src=$src; dst=$dst; ok=$false; error='missing_src_or_dst' }))
+      return
+    }
+
+    if ($src.ToLowerInvariant() -ne $dst.ToLowerInvariant()) {
+      $sw.WriteLine((J @{ op='normalize_case'; ts=$ts; src=$src; dst=$dst; ok=$false; error='not_case_only_pair' }))
+      return
+    }
+
+    if (!(Test-PathDirLong $src)) {
+      $sw.WriteLine((J @{ op='normalize_case'; ts=$ts; src=$src; dst=$dst; ok=$false; error='src_dir_not_found' }))
+      return
+    }
+
+    $srcParent = Split-Path -Parent $src
+    $dstParent = Split-Path -Parent $dst
+    $srcLeaf = Split-Path -Leaf $src
+    $dstLeaf = Split-Path -Leaf $dst
+
+    if ($srcParent.ToLowerInvariant() -ne $dstParent.ToLowerInvariant()) {
+      $sw.WriteLine((J @{ op='normalize_case'; ts=$ts; src=$src; dst=$dst; ok=$false; error='parent_mismatch' }))
+      return
+    }
+
+    # Two-step rename to force case change on case-insensitive filesystem.
+    $tmpLeaf = "__case_tmp_${runId}_$([guid]::NewGuid().ToString('N'))"
+    $tmpPath = Join-Path -Path $srcParent -ChildPath $tmpLeaf
+
+    try {
+      Rename-Item -LiteralPath $src -NewName $tmpLeaf -ErrorAction Stop
+      Rename-Item -LiteralPath $tmpPath -NewName $dstLeaf -ErrorAction Stop
+      $sw.WriteLine((J @{ op='normalize_case'; ts=$ts; src=$src; dst=$dst; ok=$true }))
+    } catch {
+      # Best effort rollback if 2nd step failed.
+      try {
+        if (Test-PathDirLong $tmpPath) {
+          Rename-Item -LiteralPath $tmpPath -NewName $srcLeaf -ErrorAction SilentlyContinue
+        }
+      } catch {}
+      $sw.WriteLine((J @{ op='normalize_case'; ts=$ts; src=$src; dst=$dst; ok=$false; error=$_.Exception.Message }))
+    }
+  }
+}
+finally {
+  $sw.Flush(); $sw.Close()
+}
+
+Write-Output (J @{ run_id=$runId; out_jsonl=$out })

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { registerToolDetectRebroadcasts } from "./src/tool-detect-rebroadcasts";
 import { registerToolIngestEpg } from "./src/tool-ingest-epg";
 import { registerToolPrepareRelocateMetadata } from "./src/tool-prepare-relocate-metadata";
 import { registerToolRelocate } from "./src/tool-relocate";
+import { registerToolNormalizeFolderCase } from "./src/tool-normalize-folder-case";
 import { registerToolReextract } from "./src/tool-reextract";
 import { registerToolLlmExtract } from "./src/tool-llm-extract";
 import { registerToolLlmExtractStatus } from "./src/tool-llm-extract-status";
@@ -39,6 +40,7 @@ export default function register(api: any) {
   registerToolBackfill(api, getCfg);
   registerToolDedup(api, getCfg);
   registerToolRelocate(api, getCfg);
+  registerToolNormalizeFolderCase(api, getCfg);
   registerToolPrepareRelocateMetadata(api, getCfg);
   registerToolStatus(api, getCfg);
   registerToolValidate(api, getCfg);

--- a/py/normalize_folder_case_from_plan.py
+++ b/py/normalize_folder_case_from_plan.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Normalize folder name casing based on relocate dry-run plan rows.
+
+This tool focuses on Windows case-insensitive limitation where case-only moves are
+reported as already_correct by relocate. It extracts case-only candidates from the
+plan and performs directory rename via PowerShell (two-step temp rename), then
+updates DB paths using synthetic move-apply JSONL rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from pathscan_common import (
+    iter_jsonl,
+    now_iso,
+    safe_json,
+    ts_compact,
+    windows_to_wsl_path,
+    wsl_to_windows_path,
+)
+from windows_pwsh_bridge import run_pwsh_json
+from relocate_existing_files import run_uv_python_json
+
+
+def _split_win(p: str) -> list[str]:
+    return str(p or "").split("\\")
+
+
+def _first_case_only_dir_pair(src: str, dst: str) -> tuple[str, str] | None:
+    src_parts = _split_win(src)
+    dst_parts = _split_win(dst)
+    if len(src_parts) != len(dst_parts):
+        return None
+    diff_idx = -1
+    for i, (a, b) in enumerate(zip(src_parts, dst_parts)):
+        if a == b:
+            continue
+        if a.lower() != b.lower():
+            return None
+        diff_idx = i
+        break
+    if diff_idx <= 0:
+        return None
+
+    # Last segment is usually a file name; we need directory rename candidates.
+    if diff_idx >= len(src_parts) - 1:
+        return None
+
+    src_dir = "\\".join(src_parts[: diff_idx + 1])
+    dst_dir = "\\".join(dst_parts[: diff_idx + 1])
+    if src_dir.lower() != dst_dir.lower() or src_dir == dst_dir:
+        return None
+
+    return src_dir, dst_dir
+
+
+def _parse_plan_rows(plan_path: str) -> tuple[list[dict[str, Any]], list[dict[str, str]], list[str]]:
+    file_rows: list[dict[str, Any]] = []
+    dir_pairs_by_src_lower: dict[str, dict[str, str]] = {}
+    errors: list[str] = []
+
+    for rec in iter_jsonl(plan_path):
+        if rec.get("_meta") is not None:
+            continue
+        src = str(rec.get("src") or "")
+        dst = str(rec.get("dst") or "")
+        if not src or not dst:
+            continue
+
+        # Keep scope narrow: only rows that relocate marked as already_correct.
+        if str(rec.get("reason") or "") != "already_correct":
+            continue
+        if src.lower() != dst.lower() or src == dst:
+            continue
+
+        pair = _first_case_only_dir_pair(src, dst)
+        if not pair:
+            continue
+        src_dir, dst_dir = pair
+
+        src_key = src_dir.lower()
+        existing = dir_pairs_by_src_lower.get(src_key)
+        if existing and existing["dst"] != dst_dir:
+            errors.append(
+                f"conflict case destination for same source dir: {src_dir} -> {existing['dst']} vs {dst_dir}"
+            )
+            continue
+
+        dir_pairs_by_src_lower[src_key] = {"src": src_dir, "dst": dst_dir}
+        file_rows.append({
+            "path_id": rec.get("path_id"),
+            "src": src,
+            "dst": dst,
+            "reason": "normalize_folder_case",
+            "ts": now_iso(),
+        })
+
+    dir_pairs = list(dir_pairs_by_src_lower.values())
+    # Rename deeper paths first to avoid parent rename side effects.
+    dir_pairs.sort(key=lambda x: len(_split_win(x["src"])), reverse=True)
+    return file_rows, dir_pairs, errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--windows-ops-root", required=True)
+    ap.add_argument("--plan-path", required=True)
+    ap.add_argument("--apply", action="store_true")
+    args = ap.parse_args()
+
+    db_path = windows_to_wsl_path(args.db)
+    if not os.path.exists(db_path):
+        raise SystemExit(f"DB not found: {args.db}")
+
+    plan_path = windows_to_wsl_path(args.plan_path)
+    if not os.path.exists(plan_path):
+        raise SystemExit(f"planPath not found: {args.plan_path}")
+
+    ops_root = Path(windows_to_wsl_path(args.windows_ops_root)).resolve()
+    move_dir = ops_root / "move"
+    scripts_root_win = wsl_to_windows_path(str(ops_root / "scripts"))
+    move_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = ts_compact()
+    case_plan_path = move_dir / f"normalize_case_plan_{ts}.jsonl"
+    case_apply_path = move_dir / f"normalize_case_apply_{ts}.jsonl"
+    synthetic_move_apply_path = move_dir / f"normalize_case_move_apply_{ts}.jsonl"
+
+    file_rows, dir_pairs, errors = _parse_plan_rows(plan_path)
+
+    with case_plan_path.open("w", encoding="utf-8") as w:
+        w.write(safe_json({"_meta": {"kind": "normalize_case_plan", "generated_at": now_iso(), "planPath": plan_path}}) + "\n")
+        for row in dir_pairs:
+            w.write(safe_json({"status": "planned", **row}) + "\n")
+
+    normalized_dirs = 0
+    apply_rows: list[dict[str, Any]] = []
+    db_updated_paths = 0
+
+    if args.apply and dir_pairs and not errors:
+        dir_plan_win = wsl_to_windows_path(str(case_plan_path))
+        apply_meta = run_pwsh_json(
+            scripts_root_win + r"\normalize_case_dirs.ps1",
+            ["-PlanJsonl", dir_plan_win, "-OpsRoot", wsl_to_windows_path(str(ops_root))],
+        )
+        raw_apply_win = str(apply_meta.get("out_jsonl") or "")
+        raw_apply_path = windows_to_wsl_path(raw_apply_win) if raw_apply_win else ""
+        if not raw_apply_path or not os.path.exists(raw_apply_path):
+            errors.append("normalize_case_dirs.ps1 did not return valid out_jsonl")
+        else:
+            for rec in iter_jsonl(raw_apply_path):
+                if rec.get("_meta") is not None:
+                    continue
+                ok = bool(rec.get("ok"))
+                if ok:
+                    normalized_dirs += 1
+                else:
+                    err = str(rec.get("error") or "normalize_failed")
+                    errors.append(err)
+                apply_rows.append(rec)
+
+    if args.apply and file_rows and not errors:
+        with synthetic_move_apply_path.open("w", encoding="utf-8") as w:
+            w.write(safe_json({"_meta": {"kind": "move_apply", "generated_at": now_iso(), "source": "normalize_folder_case_from_plan.py"}}) + "\n")
+            for row in file_rows:
+                w.write(safe_json({"op": "move", "ok": True, **row}) + "\n")
+
+        here = Path(__file__).resolve().parent
+        db_res, db_stdout, db_stderr, db_rc = run_uv_python_json(
+            here / "update_db_paths_from_move_apply.py",
+            [
+                "--db",
+                db_path,
+                "--applied",
+                str(synthetic_move_apply_path),
+                "--run-kind",
+                "normalize_case",
+                "--notes",
+                f"normalize_folder_case_from_plan {Path(str(synthetic_move_apply_path)).name}",
+            ],
+            cwd=str(here),
+        )
+        if db_rc != 0:
+            errors.append(f"update_db_paths_from_move_apply failed rc={db_rc}: {(db_stderr or db_stdout).strip()}")
+        else:
+            db_updated_paths = int((db_res or {}).get("updated") or 0)
+
+    if args.apply:
+        with case_apply_path.open("w", encoding="utf-8") as w:
+            w.write(
+                safe_json(
+                    {
+                        "_meta": {
+                            "kind": "normalize_case_apply",
+                            "generated_at": now_iso(),
+                            "planPath": str(case_plan_path),
+                            "rows": len(apply_rows),
+                        }
+                    }
+                )
+                + "\n"
+            )
+            for row in apply_rows:
+                w.write(safe_json(row) + "\n")
+
+    summary = {
+        "ok": len(errors) == 0,
+        "tool": "video_pipeline_normalize_folder_case",
+        "apply": bool(args.apply),
+        "planPath": str(case_plan_path),
+        "applyPath": str(case_apply_path) if args.apply else None,
+        "inputRelocatePlanPath": plan_path,
+        "caseCandidateDirs": len(dir_pairs),
+        "caseCandidateFiles": len(file_rows),
+        "normalizedDirs": normalized_dirs if args.apply else 0,
+        "dbUpdatedPaths": db_updated_paths if args.apply else 0,
+        "errors": errors,
+    }
+    print(safe_json(summary))
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tool-normalize-folder-case.ts
+++ b/src/tool-normalize-folder-case.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import { parseJsonObject, resolvePythonScript, runCmd, toToolResult } from "./runtime";
+import type { AnyObj } from "./types";
+import { ensureWindowsScripts } from "./windows-scripts-bootstrap";
+
+export function registerToolNormalizeFolderCase(api: any, getCfg: (api: any) => any) {
+  api.registerTool(
+    {
+      name: "video_pipeline_normalize_folder_case",
+      description:
+        "Normalize case-only folder name differences using a relocate dry-run plan. " +
+        "Use this when relocate marks entries as already_correct due to Windows case-insensitive paths.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        required: ["planPath"],
+        properties: {
+          planPath: {
+            type: "string",
+            description:
+              "Path to relocate dry-run plan JSONL (planPath from video_pipeline_relocate_existing_files apply=false).",
+          },
+          apply: {
+            type: "boolean",
+            default: false,
+            description: "false=dry-run candidate extraction only, true=perform actual case normalization and DB path update.",
+          },
+        },
+      },
+      async execute(_id: string, params: AnyObj) {
+        const cfg = getCfg(api);
+        const scriptsProvision = ensureWindowsScripts(cfg);
+        if (!scriptsProvision.ok) {
+          return toToolResult({
+            ok: false,
+            tool: "video_pipeline_normalize_folder_case",
+            error: "failed to provision required windows scripts",
+            scriptsProvision,
+          });
+        }
+
+        const planPath = typeof params.planPath === "string" ? params.planPath.trim() : "";
+        if (!planPath) {
+          return toToolResult({
+            ok: false,
+            tool: "video_pipeline_normalize_folder_case",
+            error: "planPath is required",
+          });
+        }
+        if (!fs.existsSync(planPath)) {
+          return toToolResult({
+            ok: false,
+            tool: "video_pipeline_normalize_folder_case",
+            error: `planPath does not exist: ${planPath}`,
+          });
+        }
+
+        const resolved = resolvePythonScript("normalize_folder_case_from_plan.py");
+        const args = [
+          "run",
+          "python",
+          resolved.scriptPath,
+          "--db",
+          String(cfg.db || ""),
+          "--windows-ops-root",
+          String(cfg.windowsOpsRoot || ""),
+          "--plan-path",
+          planPath,
+        ];
+        if (params.apply === true) args.push("--apply");
+
+        const r = runCmd("uv", args, resolved.cwd);
+        const parsed = parseJsonObject(r.stdout);
+        const out: AnyObj = {
+          ok: r.ok,
+          tool: "video_pipeline_normalize_folder_case",
+          scriptSource: resolved.source,
+          scriptPath: resolved.scriptPath,
+          exitCode: r.code,
+          stdout: r.stdout,
+          stderr: r.stderr,
+          scriptsProvision: {
+            created: scriptsProvision.created,
+            updated: scriptsProvision.updated,
+            existing: scriptsProvision.existing,
+            failed: scriptsProvision.failed,
+            missingTemplates: scriptsProvision.missingTemplates,
+          },
+        };
+        if (parsed) {
+          for (const [k, v] of Object.entries(parsed)) out[k] = v;
+        }
+        if (r.ok && params.apply !== true && Number(out.caseCandidateDirs || 0) > 0) {
+          out.nextAction =
+            "Review normalize_case_plan and rerun with apply=true to perform directory case normalization and DB path updates.";
+        }
+        if (r.ok && params.apply !== true && Number(out.caseCandidateDirs || 0) === 0) {
+          out.nextAction = "No case-only folder mismatch candidates found in this relocate plan.";
+        }
+        return toToolResult(out);
+      },
+    },
+  );
+}

--- a/src/windows-scripts-bootstrap.ts
+++ b/src/windows-scripts-bootstrap.ts
@@ -5,6 +5,7 @@ import { getExtensionRootDir } from "./runtime";
 export const REQUIRED_WINDOWS_SCRIPTS = [
   "unwatched_inventory.ps1",
   "apply_move_plan.ps1",
+  "normalize_case_dirs.ps1",
 ] as const;
 
 export const INTERNAL_WINDOWS_SCRIPTS = ["_long_path_utils.ps1", "enumerate_files_jsonl.ps1"] as const;


### PR DESCRIPTION
### Motivation
- Relocate dry-run can mark moves as `already_correct` on Windows when the only difference is letter casing, so case-only folder mismatches are not being fixed by the existing flow.
- Provide a safe, focused approach that reuses relocate's destination logic (dry-run plan) but performs a Windows-aware case normalization step to actually rename directories and keep DB paths consistent.

### Description
- Add new tool registration `video_pipeline_normalize_folder_case` (`src/tool-normalize-folder-case.ts`) which accepts a relocate dry-run `planPath` and an `apply` flag.
- Implement Python backend `py/normalize_folder_case_from_plan.py` that extracts case-only `already_correct` rows from a relocate plan, builds a case-normalization plan, calls PowerShell to perform two-step renames, and produces synthetic move-apply JSONL for DB updates via `update_db_paths_from_move_apply.py`.
- Add PowerShell script template `assets/windows-scripts/normalize_case_dirs.ps1` that executes safe two-step temporary renames to force case changes on Windows and emits JSONL audit output.
- Ensure the new PowerShell template is provisioned by adding it to `REQUIRED_WINDOWS_SCRIPTS` in `src/windows-scripts-bootstrap.ts` and register the new tool in `index.ts`.

### Testing
- Ran `python -m py_compile py/normalize_folder_case_from_plan.py` which completed successfully and printed `OK_PY`.
- Attempted to import `index.ts` with `node -e "import('./index.ts')..."` which failed in this environment due to TypeScript/ESM runtime import constraints (the repository requires normal TypeScript build/transpile step), not due to the added tool logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2b53cf088329be67568068bf903c)