### PR TITLE
Refactor contamination title resolution into shared workflow module

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -19,52 +19,19 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
-import sqlite3
 from typing import Any
 
 from mediaops_schema import connect_db
 from path_placement_rules import normalize_title_for_comparison
+from workflow_title_resolution import (
+    SUBTITLE_SEPARATOR_RE,
+    clean_title_prefix,
+    load_human_reviewed_titles,
+    load_programs_titles,
+    longest_prefix_title_match,
+)
 
-SEPARATOR_RE = re.compile(r"[▽▼◇「]")
 MIN_EXTRA_CHARS_DEFAULT = 4
-
-
-def clean_title(title: str) -> str:
-    """Split at first separator and return the prefix."""
-    return SEPARATOR_RE.split(title, maxsplit=1)[0].strip()
-
-
-def load_human_reviewed_titles(con: sqlite3.Connection) -> set[str]:
-    """Load distinct program_titles from human-reviewed path_metadata."""
-    titles: set[str] = set()
-    try:
-        rows = con.execute(
-            """SELECT DISTINCT program_title FROM path_metadata
-               WHERE program_title IS NOT NULL AND program_title != ''
-                 AND (source = 'human_reviewed' OR human_reviewed = 1)"""
-        ).fetchall()
-        for r in rows:
-            titles.add(str(r["program_title"]).strip())
-    except sqlite3.OperationalError:
-        pass
-    titles.discard("")
-    return titles
-
-
-def load_programs_titles(con: sqlite3.Connection) -> set[str]:
-    """Load canonical_title values from programs table."""
-    titles: set[str] = set()
-    try:
-        rows = con.execute(
-            "SELECT canonical_title FROM programs WHERE canonical_title IS NOT NULL AND canonical_title != ''"
-        ).fetchall()
-        for r in rows:
-            titles.add(str(r["canonical_title"]).strip())
-    except sqlite3.OperationalError:
-        pass
-    titles.discard("")
-    return titles
 
 
 def match_against_titles(
@@ -77,21 +44,11 @@ def match_against_titles(
 
     Returns (suggested_title, match_source).
     """
-    pt_norm = normalize_title_for_comparison(program_title)
-    if not pt_norm:
-        return None, "no_match"
-
-    best_title: str | None = None
-    best_len = 0
-
-    for ct in canonical_titles:
-        ct_norm = normalize_title_for_comparison(ct)
-        if not ct_norm:
-            continue
-        if pt_norm.startswith(ct_norm) and len(pt_norm) >= len(ct_norm) + min_extra_chars:
-            if len(ct_norm) > best_len:
-                best_len = len(ct_norm)
-                best_title = ct
+    best_title = longest_prefix_title_match(
+        program_title,
+        canonical_titles,
+        min_extra_chars=min_extra_chars,
+    )
 
     if best_title:
         return best_title, source_label
@@ -133,7 +90,7 @@ def main() -> int:
     update_instructions: list[dict[str, str]] = []
 
     for program_title, path_ids in sorted(title_to_path_ids.items()):
-        has_separator = bool(SEPARATOR_RE.search(program_title))
+        has_separator = bool(SUBTITLE_SEPARATOR_RE.search(program_title))
         pt_norm = normalize_title_for_comparison(program_title)
 
         # Exact match against human-reviewed titles → NOT contaminated
@@ -155,7 +112,7 @@ def main() -> int:
 
         # Priority 3: separator split fallback
         if suggested_title is None and has_separator:
-            cleaned = clean_title(program_title)
+            cleaned = clean_title_prefix(program_title)
             if cleaned and cleaned != program_title:
                 suggested_title = cleaned
                 match_source = "separator_split"
@@ -178,7 +135,7 @@ def main() -> int:
             "suggestedTitle": suggested_title,
             "matchSource": match_source,
             "confidence": confidence,
-            "separatorFound": SEPARATOR_RE.search(program_title).group() if has_separator else None,
+            "separatorFound": SUBTITLE_SEPARATOR_RE.search(program_title).group() if has_separator else None,
             "affectedFiles": len(path_ids),
             "pathIds": path_ids,
         }

--- a/py/fix_subtitle_contaminated_titles.py
+++ b/py/fix_subtitle_contaminated_titles.py
@@ -13,28 +13,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 
 from db_helpers import reconstruct_path_metadata, split_path_metadata
 from mediaops_schema import begin_immediate, connect_db
-
-SEPARATOR_RE = re.compile(r"[▽▼◇「]")
-
-
-def clean_title(title: str) -> str:
-    """最初のサブタイトル区切り文字で分割し、前半を返す。"""
-    return SEPARATOR_RE.split(title, maxsplit=1)[0].strip()
-
-
-TITLE_RELATED_REASONS = {
-    "needs_review_flagged",
-    "program_title_may_include_description",
-    "relocate_suspicious_program_title",
-    "relocate_suspicious_program_title_shortened",
-    "subtitle_separator_in_program_title",
-    "relocate_subtitle_separator_in_program_title",
-}
+from path_placement_rules import TITLE_RELATED_REASONS
+from workflow_title_resolution import SUBTITLE_SEPARATOR_RE, clean_title_prefix
 
 
 def main() -> int:
@@ -67,10 +51,10 @@ def main() -> int:
                 continue
             pt = data.get("program_title", "")
 
-        if not isinstance(pt, str) or not SEPARATOR_RE.search(pt):
+        if not isinstance(pt, str) or not SUBTITLE_SEPARATOR_RE.search(pt):
             continue
 
-        cleaned = clean_title(pt)
+        cleaned = clean_title_prefix(pt)
         if not cleaned or cleaned == pt:
             continue
 
@@ -101,7 +85,7 @@ def main() -> int:
     if args.dry_run:
         samples = []
         for row_tuple in updates[:20]:
-            samples.append({"path_id": row_tuple[4], "program_title": row_tuple[1]})
+            samples.append({"path_id": row_tuple[3], "program_title": row_tuple[1]})
         print(
             json.dumps(
                 {

--- a/py/workflow_title_resolution.py
+++ b/py/workflow_title_resolution.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Shared canonical title resolution helpers for review/apply/move workflows."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+
+from path_placement_rules import normalize_title_for_comparison
+
+SUBTITLE_SEPARATOR_RE = re.compile(r"[▽▼◇「]")
+
+
+def clean_title_prefix(title: str) -> str:
+    """Split at first subtitle separator and return the prefix."""
+    return SUBTITLE_SEPARATOR_RE.split(str(title or ""), maxsplit=1)[0].strip()
+
+
+def load_human_reviewed_titles(con: sqlite3.Connection) -> set[str]:
+    """Load distinct canonical candidates from human-reviewed path_metadata."""
+    titles: set[str] = set()
+    try:
+        rows = con.execute(
+            """SELECT DISTINCT program_title FROM path_metadata
+               WHERE program_title IS NOT NULL AND program_title != ''
+                 AND (source = 'human_reviewed' OR human_reviewed = 1)"""
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return titles
+
+    for r in rows:
+        t = str(r["program_title"] or "").strip()
+        if t:
+            titles.add(t)
+    return titles
+
+
+def load_programs_titles(con: sqlite3.Connection) -> set[str]:
+    """Load canonical_title values from programs table."""
+    titles: set[str] = set()
+    try:
+        rows = con.execute(
+            "SELECT canonical_title FROM programs WHERE canonical_title IS NOT NULL AND canonical_title != ''"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return titles
+
+    for r in rows:
+        t = str(r["canonical_title"] or "").strip()
+        if t:
+            titles.add(t)
+    return titles
+
+
+def longest_prefix_title_match(
+    program_title: str,
+    canonical_titles: set[str],
+    *,
+    min_extra_chars: int,
+) -> str | None:
+    """Return best longest-prefix canonical title match, if any."""
+    pt_norm = normalize_title_for_comparison(program_title)
+    if not pt_norm:
+        return None
+
+    best_title: str | None = None
+    best_len = 0
+    for ct in canonical_titles:
+        ct_norm = normalize_title_for_comparison(ct)
+        if not ct_norm:
+            continue
+        if pt_norm.startswith(ct_norm) and len(pt_norm) >= len(ct_norm) + min_extra_chars:
+            if len(ct_norm) > best_len:
+                best_len = len(ct_norm)
+                best_title = ct
+    return best_title


### PR DESCRIPTION
### Motivation
- Reduce duplicated title-resolution logic across detection/fix/move stages to address workflow drift described in issue #73. 
- Centralize human-reviewed/programs fallback, subtitle-separator handling, and longest-prefix matching so downstream stages share consistent canonical-title semantics.

### Description
- Added `py/workflow_title_resolution.py` which provides `SUBTITLE_SEPARATOR_RE`, `clean_title_prefix`, `load_human_reviewed_titles`, `load_programs_titles`, and `longest_prefix_title_match` for shared canonical title resolution.
- Updated `py/detect_folder_contamination.py` to use the shared helpers and removed its in-file title-loading/matching duplication, preserving the priority order: human_reviewed → programs table → separator split.
- Updated `py/fix_subtitle_contaminated_titles.py` to use the shared separator and clean-up helpers and to use `TITLE_RELATED_REASONS` from `path_placement_rules`; also fixed a dry-run sample indexing bug (`row_tuple[4]` → `row_tuple[3]`).
- Small API/behaviour-preserving adjustments: replaced local `SEPARATOR_RE` usage with `SUBTITLE_SEPARATOR_RE` and delegated longest-prefix logic to the new module.

### Testing
- Compiled updated modules with `python -m py_compile py/workflow_title_resolution.py py/detect_folder_contamination.py py/fix_subtitle_contaminated_titles.py` and it succeeded.
- Ran `python py/detect_folder_contamination.py --help` and `python py/fix_subtitle_contaminated_titles.py --help` and both returned help output successfully.
- Confirmed updated files (`py/workflow_title_resolution.py`, `py/detect_folder_contamination.py`, `py/fix_subtitle_contaminated_titles.py`) were exercised during the rollout and no runtime compile errors were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d11184cc8329b39973eeaef70800)