### PR TITLE
Refactor canonical title resolution into shared module

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -2,11 +2,11 @@
 """Detect contaminated program_title values in path_metadata.
 
 Scans path_metadata.program_title for subtitle/episode contamination by
-cross-referencing human-reviewed titles and the programs table.
+cross-referencing shared canonical title sources.
 
 Source priority for canonical title:
   1. human_reviewed path_metadata (exact match → not contaminated; prefix match → suggested)
-  2. programs table (longest prefix match)
+  2. programs table (longest/most-specific prefix match)
   3. separator split fallback
 
 Generates updateInstructions (path_id based) compatible with update_program_titles.py.
@@ -19,83 +19,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
-import sqlite3
 from typing import Any
 
 from mediaops_schema import connect_db
 from path_placement_rules import normalize_title_for_comparison
+from title_resolution import (
+    SUBTITLE_SEPARATOR_RE,
+    load_canonical_title_sources,
+    suggest_canonical_title,
+)
 
-SEPARATOR_RE = re.compile(r"[▽▼◇「]")
 MIN_EXTRA_CHARS_DEFAULT = 4
-
-
-def clean_title(title: str) -> str:
-    """Split at first separator and return the prefix."""
-    return SEPARATOR_RE.split(title, maxsplit=1)[0].strip()
-
-
-def load_human_reviewed_titles(con: sqlite3.Connection) -> set[str]:
-    """Load distinct program_titles from human-reviewed path_metadata."""
-    titles: set[str] = set()
-    try:
-        rows = con.execute(
-            """SELECT DISTINCT program_title FROM path_metadata
-               WHERE program_title IS NOT NULL AND program_title != ''
-                 AND (source = 'human_reviewed' OR human_reviewed = 1)"""
-        ).fetchall()
-        for r in rows:
-            titles.add(str(r["program_title"]).strip())
-    except sqlite3.OperationalError:
-        pass
-    titles.discard("")
-    return titles
-
-
-def load_programs_titles(con: sqlite3.Connection) -> set[str]:
-    """Load canonical_title values from programs table."""
-    titles: set[str] = set()
-    try:
-        rows = con.execute(
-            "SELECT canonical_title FROM programs WHERE canonical_title IS NOT NULL AND canonical_title != ''"
-        ).fetchall()
-        for r in rows:
-            titles.add(str(r["canonical_title"]).strip())
-    except sqlite3.OperationalError:
-        pass
-    titles.discard("")
-    return titles
-
-
-def match_against_titles(
-    program_title: str,
-    canonical_titles: set[str],
-    source_label: str,
-    min_extra_chars: int = MIN_EXTRA_CHARS_DEFAULT,
-) -> tuple[str | None, str]:
-    """Longest-prefix match of program_title against canonical titles.
-
-    Returns (suggested_title, match_source).
-    """
-    pt_norm = normalize_title_for_comparison(program_title)
-    if not pt_norm:
-        return None, "no_match"
-
-    best_title: str | None = None
-    best_len = 0
-
-    for ct in canonical_titles:
-        ct_norm = normalize_title_for_comparison(ct)
-        if not ct_norm:
-            continue
-        if pt_norm.startswith(ct_norm) and len(pt_norm) >= len(ct_norm) + min_extra_chars:
-            if len(ct_norm) > best_len:
-                best_len = len(ct_norm)
-                best_title = ct
-
-    if best_title:
-        return best_title, source_label
-    return None, "no_match"
 
 
 def main() -> int:
@@ -106,14 +40,7 @@ def main() -> int:
     args = ap.parse_args()
 
     con = connect_db(args.db)
-
-    # Source 1 (highest priority): human-reviewed titles
-    hr_titles = load_human_reviewed_titles(con)
-    hr_titles_norm = {normalize_title_for_comparison(t) for t in hr_titles}
-    hr_titles_norm.discard("")
-
-    # Source 2: programs table
-    programs_titles = load_programs_titles(con)
+    sources = load_canonical_title_sources(con)
 
     # Query all distinct program_title values with their path_ids
     rows = con.execute(
@@ -133,37 +60,21 @@ def main() -> int:
     update_instructions: list[dict[str, str]] = []
 
     for program_title, path_ids in sorted(title_to_path_ids.items()):
-        has_separator = bool(SEPARATOR_RE.search(program_title))
-        pt_norm = normalize_title_for_comparison(program_title)
-
-        # Exact match against human-reviewed titles → NOT contaminated
-        if pt_norm in hr_titles_norm:
-            continue
-
-        # Priority 1: human-reviewed titles (prefix match)
-        suggested_title, match_source = match_against_titles(
-            program_title, hr_titles, "human_reviewed",
-            min_extra_chars=args.min_extra_chars,
+        suggested_title, match_source = suggest_canonical_title(
+            program_title,
+            sources,
+            min_extra_chars=max(1, int(args.min_extra_chars or MIN_EXTRA_CHARS_DEFAULT)),
         )
 
-        # Priority 2: programs table (prefix match)
-        if suggested_title is None:
-            suggested_title, match_source = match_against_titles(
-                program_title, programs_titles, "programs_table",
-                min_extra_chars=args.min_extra_chars,
-            )
-
-        # Priority 3: separator split fallback
-        if suggested_title is None and has_separator:
-            cleaned = clean_title(program_title)
-            if cleaned and cleaned != program_title:
-                suggested_title = cleaned
-                match_source = "separator_split"
+        # exact human-reviewed title is already canonical
+        if match_source == "exact_human_reviewed":
+            continue
 
         if suggested_title is None:
             continue
 
         # Verify title is actually different
+        pt_norm = normalize_title_for_comparison(program_title)
         if pt_norm == normalize_title_for_comparison(suggested_title):
             continue
 
@@ -173,18 +84,18 @@ def main() -> int:
             else "low"
         )
 
+        has_separator = bool(SUBTITLE_SEPARATOR_RE.search(program_title))
         entry: dict[str, Any] = {
             "programTitle": program_title,
             "suggestedTitle": suggested_title,
             "matchSource": match_source,
             "confidence": confidence,
-            "separatorFound": SEPARATOR_RE.search(program_title).group() if has_separator else None,
+            "separatorFound": SUBTITLE_SEPARATOR_RE.search(program_title).group() if has_separator else None,
             "affectedFiles": len(path_ids),
             "pathIds": path_ids,
         }
         contaminated_titles.append(entry)
 
-        # Build path_id based update instructions
         for pid in path_ids:
             update_instructions.append({
                 "path_id": pid,

--- a/py/fix_subtitle_contaminated_titles.py
+++ b/py/fix_subtitle_contaminated_titles.py
@@ -13,18 +13,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 
 from db_helpers import reconstruct_path_metadata, split_path_metadata
 from mediaops_schema import begin_immediate, connect_db
-
-SEPARATOR_RE = re.compile(r"[▽▼◇「]")
-
-
-def clean_title(title: str) -> str:
-    """最初のサブタイトル区切り文字で分割し、前半を返す。"""
-    return SEPARATOR_RE.split(title, maxsplit=1)[0].strip()
+from title_resolution import SUBTITLE_SEPARATOR_RE, clean_title_by_separator
 
 
 TITLE_RELATED_REASONS = {
@@ -51,7 +44,6 @@ def main() -> int:
     ).fetchall()
 
 
-
     updates: list[tuple] = []
     for r in rows:
         # Use promoted column first, fall back to data_json
@@ -67,10 +59,10 @@ def main() -> int:
                 continue
             pt = data.get("program_title", "")
 
-        if not isinstance(pt, str) or not SEPARATOR_RE.search(pt):
+        if not isinstance(pt, str) or not SUBTITLE_SEPARATOR_RE.search(pt):
             continue
 
-        cleaned = clean_title(pt)
+        cleaned = clean_title_by_separator(pt)
         if not cleaned or cleaned == pt:
             continue
 
@@ -101,7 +93,7 @@ def main() -> int:
     if args.dry_run:
         samples = []
         for row_tuple in updates[:20]:
-            samples.append({"path_id": row_tuple[4], "program_title": row_tuple[1]})
+            samples.append({"path_id": row_tuple[3], "program_title": row_tuple[1]})
         print(
             json.dumps(
                 {

--- a/py/title_resolution.py
+++ b/py/title_resolution.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Shared canonical title resolution helpers across workflow stages.
+
+This module centralizes:
+- loading canonical title sources (human_reviewed + programs)
+- prefix-based canonical title suggestion
+- subtitle separator cleanup fallback
+
+Keeping this logic in one place reduces stage drift between contamination
+inspection, cleanup scripts, and other workflow stages.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+
+from path_placement_rules import normalize_title_for_comparison
+
+SUBTITLE_SEPARATOR_RE = re.compile(r"[▽▼◇「]")
+
+
+@dataclass(frozen=True)
+class CanonicalTitleSources:
+    """Canonical title candidates grouped by source priority."""
+
+    human_reviewed: tuple[str, ...]
+    programs: tuple[str, ...]
+    human_reviewed_norm: frozenset[str]
+
+
+def clean_title_by_separator(title: str) -> str:
+    """Split at first subtitle separator and return the prefix."""
+    return SUBTITLE_SEPARATOR_RE.split(str(title or ""), maxsplit=1)[0].strip()
+
+
+def load_canonical_title_sources(con: sqlite3.Connection) -> CanonicalTitleSources:
+    """Load canonical title candidates with deterministic ordering.
+
+    Priority is intentionally explicit and stable:
+    1) human_reviewed path metadata
+    2) programs canonical titles
+    """
+
+    def _load_titles(sql: str) -> tuple[str, ...]:
+        titles: set[str] = set()
+        try:
+            rows = con.execute(sql).fetchall()
+            for row in rows:
+                raw = str(row[0] or "").strip()
+                if raw:
+                    titles.add(raw)
+        except sqlite3.OperationalError:
+            return tuple()
+        return tuple(sorted(titles, key=lambda s: (len(normalize_title_for_comparison(s)), s), reverse=True))
+
+    human_reviewed = _load_titles(
+        """SELECT DISTINCT program_title
+           FROM path_metadata
+           WHERE program_title IS NOT NULL AND program_title != ''
+             AND (source = 'human_reviewed' OR human_reviewed = 1)"""
+    )
+    programs = _load_titles(
+        "SELECT canonical_title FROM programs WHERE canonical_title IS NOT NULL AND canonical_title != ''"
+    )
+
+    human_reviewed_norm = frozenset(normalize_title_for_comparison(t) for t in human_reviewed if t)
+    return CanonicalTitleSources(
+        human_reviewed=human_reviewed,
+        programs=programs,
+        human_reviewed_norm=human_reviewed_norm,
+    )
+
+
+def suggest_canonical_title(
+    program_title: str,
+    sources: CanonicalTitleSources,
+    *,
+    min_extra_chars: int,
+) -> tuple[str | None, str]:
+    """Suggest canonical title using shared source priority.
+
+    Returns (suggested_title, match_source).
+    """
+    pt_norm = normalize_title_for_comparison(program_title)
+    if not pt_norm:
+        return None, "no_match"
+
+    if pt_norm in sources.human_reviewed_norm:
+        return None, "exact_human_reviewed"
+
+    def _match_prefix(candidates: tuple[str, ...], source_name: str) -> tuple[str | None, str]:
+        for candidate in candidates:
+            cand_norm = normalize_title_for_comparison(candidate)
+            if not cand_norm:
+                continue
+            if pt_norm.startswith(cand_norm) and len(pt_norm) >= len(cand_norm) + min_extra_chars:
+                return candidate, source_name
+        return None, "no_match"
+
+    hr_match, hr_source = _match_prefix(sources.human_reviewed, "human_reviewed")
+    if hr_match:
+        return hr_match, hr_source
+
+    pr_match, pr_source = _match_prefix(sources.programs, "programs_table")
+    if pr_match:
+        return pr_match, pr_source
+
+    cleaned = clean_title_by_separator(program_title)
+    if cleaned and normalize_title_for_comparison(cleaned) != pt_norm:
+        return cleaned, "separator_split"
+
+    return None, "no_match"


### PR DESCRIPTION
### Motivation
- Multiple tools duplicated title-canonicalization and separator logic, causing workflow drift and inconsistent downstream behavior as described in issue #73. 
- Centralizing title-source priority and prefix/ separator heuristics reduces duplicated rules and aligns contamination detection and cleanup stages. 

### Description
- Added a shared helper module `py/title_resolution.py` that exposes `load_canonical_title_sources`, `suggest_canonical_title`, `SUBTITLE_SEPARATOR_RE`, and `clean_title_by_separator` to centralize canonical title resolution. 
- Refactored `py/detect_folder_contamination.py` to use `load_canonical_title_sources` / `suggest_canonical_title` and removed its duplicated matching code while preserving source-priority semantics. 
- Refactored `py/fix_subtitle_contaminated_titles.py` to use `SUBTITLE_SEPARATOR_RE` and `clean_title_by_separator` and fixed a dry-run sample `path_id` indexing bug. 
- No external tool interfaces were changed; this is an internal unification to reduce stage drift. 

### Testing
- Ran `python -m py_compile py/title_resolution.py py/detect_folder_contamination.py py/fix_subtitle_contaminated_titles.py` and compilation completed without errors. 
- Executed an in-memory SQLite smoke test invoking `load_canonical_title_sources` and `suggest_canonical_title` to verify source-priority behavior (human-reviewed > programs table > separator fallback) and observed expected results. 
- All automated checks performed in this rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d11184cc8329b39973eeaef70800)