### PR TITLE
Refactor: centralize workflow metadata and canonical title resolution

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sqlite3
 from typing import Any
 
 from mediaops_schema import connect_db
 from path_placement_rules import normalize_title_for_comparison
+from workflow_shared import (
+    load_canonical_title_sources,
+    longest_prefix_title_match,
+)
 
 SEPARATOR_RE = re.compile(r"[▽▼◇「]")
 MIN_EXTRA_CHARS_DEFAULT = 4
@@ -33,38 +36,6 @@ MIN_EXTRA_CHARS_DEFAULT = 4
 def clean_title(title: str) -> str:
     """Split at first separator and return the prefix."""
     return SEPARATOR_RE.split(title, maxsplit=1)[0].strip()
-
-
-def load_human_reviewed_titles(con: sqlite3.Connection) -> set[str]:
-    """Load distinct program_titles from human-reviewed path_metadata."""
-    titles: set[str] = set()
-    try:
-        rows = con.execute(
-            """SELECT DISTINCT program_title FROM path_metadata
-               WHERE program_title IS NOT NULL AND program_title != ''
-                 AND (source = 'human_reviewed' OR human_reviewed = 1)"""
-        ).fetchall()
-        for r in rows:
-            titles.add(str(r["program_title"]).strip())
-    except sqlite3.OperationalError:
-        pass
-    titles.discard("")
-    return titles
-
-
-def load_programs_titles(con: sqlite3.Connection) -> set[str]:
-    """Load canonical_title values from programs table."""
-    titles: set[str] = set()
-    try:
-        rows = con.execute(
-            "SELECT canonical_title FROM programs WHERE canonical_title IS NOT NULL AND canonical_title != ''"
-        ).fetchall()
-        for r in rows:
-            titles.add(str(r["canonical_title"]).strip())
-    except sqlite3.OperationalError:
-        pass
-    titles.discard("")
-    return titles
 
 
 def match_against_titles(
@@ -77,22 +48,7 @@ def match_against_titles(
 
     Returns (suggested_title, match_source).
     """
-    pt_norm = normalize_title_for_comparison(program_title)
-    if not pt_norm:
-        return None, "no_match"
-
-    best_title: str | None = None
-    best_len = 0
-
-    for ct in canonical_titles:
-        ct_norm = normalize_title_for_comparison(ct)
-        if not ct_norm:
-            continue
-        if pt_norm.startswith(ct_norm) and len(pt_norm) >= len(ct_norm) + min_extra_chars:
-            if len(ct_norm) > best_len:
-                best_len = len(ct_norm)
-                best_title = ct
-
+    best_title = longest_prefix_title_match(program_title, canonical_titles, min_extra_chars=min_extra_chars)
     if best_title:
         return best_title, source_label
     return None, "no_match"
@@ -107,13 +63,14 @@ def main() -> int:
 
     con = connect_db(args.db)
 
+    title_sources = load_canonical_title_sources(con)
     # Source 1 (highest priority): human-reviewed titles
-    hr_titles = load_human_reviewed_titles(con)
+    hr_titles = title_sources.human_reviewed_titles
     hr_titles_norm = {normalize_title_for_comparison(t) for t in hr_titles}
     hr_titles_norm.discard("")
 
     # Source 2: programs table
-    programs_titles = load_programs_titles(con)
+    programs_titles = title_sources.programs_titles
 
     # Query all distinct program_title values with their path_ids
     rows = con.execute(

--- a/py/make_metadata_queue_from_inventory.py
+++ b/py/make_metadata_queue_from_inventory.py
@@ -7,9 +7,9 @@ import argparse
 import json
 from pathlib import PureWindowsPath
 
-from db_helpers import latest_path_metadata
 from mediaops_schema import connect_db
 from pathscan_common import now_iso
+from workflow_shared import resolve_effective_path_metadata
 
 
 def main() -> int:
@@ -70,7 +70,8 @@ def main() -> int:
                     continue
                 pid = row["path_id"]
 
-                md, _ = latest_path_metadata(con, pid)
+                effective_md = resolve_effective_path_metadata(con, str(pid))
+                md = effective_md.metadata if effective_md else None
                 if md is None:
                     pick = True
                 else:

--- a/py/make_move_plan_from_inventory.py
+++ b/py/make_move_plan_from_inventory.py
@@ -9,10 +9,10 @@ import json
 import os
 from pathlib import Path, PureWindowsPath
 
-from db_helpers import latest_path_metadata
 from mediaops_schema import connect_db
 from path_placement_rules import load_drive_routes
 from plan_validation import validate_move_candidate
+from workflow_shared import resolve_effective_path_metadata
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", default="")
@@ -87,10 +87,12 @@ def main() -> int:
                     skipped_no_path += 1
                     continue
                 pid = row[0]
-                md, md_source = latest_path_metadata(con, pid)
-                if not md:
+                effective_md = resolve_effective_path_metadata(con, str(pid))
+                if not effective_md or not effective_md.metadata:
                     skipped_no_md += 1
                     continue
+                md = effective_md.metadata
+                md_source = effective_md.source
 
                 result = validate_move_candidate(
                     src, md,
@@ -124,6 +126,7 @@ def main() -> int:
                     "program_title": prog,
                     "air_date": air,
                     "metadata_source": md_source,
+                    "metadata_selected_from": effective_md.selected_from,
                 }
                 if genre_route:
                     plan_row["genre_route"] = genre_route

--- a/py/relocate_existing_files.py
+++ b/py/relocate_existing_files.py
@@ -15,7 +15,6 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from db_helpers import latest_path_metadata
 from mediaops_schema import begin_immediate, connect_db, create_schema_if_needed, fetchone
 from move_apply_stats import aggregate_move_apply
 from path_placement_rules import (
@@ -47,6 +46,7 @@ from pathscan_common import (
     wsl_to_windows_path,
 )
 from windows_pwsh_bridge import run_pwsh_json
+from workflow_shared import metadata_source_flags, resolve_effective_path_metadata
 
 MAX_SUMMARY_AUTOREGISTER_FILES = 100
 
@@ -304,8 +304,8 @@ def main() -> int:
 
             registered_files += 1
             path_id = str(path_row["path_id"])
-            md, md_source = latest_path_metadata(con, path_id)
-            if md is None:
+            effective_md = resolve_effective_path_metadata(con, path_id)
+            if effective_md is None:
                 metadata_missing_skipped += 1
                 rows_for_plan.append(
                     {"path_id": path_id, "src": sf.win_path, "status": "skipped", "reason": "missing_metadata", "ts": ts_row}
@@ -315,13 +315,10 @@ def main() -> int:
                         {"path_id": path_id, "path": sf.win_path, "name": sf.name, "mtime_utc": sf.mtime_utc}
                     )
                 continue
+            md = effective_md.metadata
+            md_source = effective_md.source
 
-            source_norm = str(md_source or "").strip().lower()
-            is_human_reviewed = (
-                source_norm == "human_reviewed"
-                or bool(isinstance(md, dict) and md.get("human_reviewed"))
-            )
-            is_llm = source_norm in {"llm", "llm_subagent"}
+            is_human_reviewed, is_llm = metadata_source_flags(md, md_source)
 
             if not is_human_reviewed and not is_llm and not allow_unreviewed_metadata:
                 unreviewed_metadata_skipped += 1
@@ -332,6 +329,7 @@ def main() -> int:
                         "status": "skipped",
                         "reason": "unreviewed_metadata",
                         "metadata_source": md_source,
+                        "metadata_selected_from": effective_md.selected_from,
                         "ts": ts_row,
                     }
                 )
@@ -372,6 +370,7 @@ def main() -> int:
                     "status": "skipped",
                     "reason": skip_reason,
                     "metadata_source": md_source,
+                    "metadata_selected_from": effective_md.selected_from,
                     "ts": ts_row,
                 }
                 if skip_reason in ("suspicious_program_title", "suspicious_program_title_shortened",
@@ -405,6 +404,7 @@ def main() -> int:
                         "reason": "already_correct",
                         "program_title": md.get("program_title"),
                         "air_date": md.get("air_date"),
+                        "metadata_selected_from": effective_md.selected_from,
                         "ts": ts_row,
                     }
                 )
@@ -420,6 +420,8 @@ def main() -> int:
                 "reason": reason,
                 "program_title": md.get("program_title"),
                 "air_date": md.get("air_date"),
+                "metadata_source": md_source,
+                "metadata_selected_from": effective_md.selected_from,
                 "ts": ts_row,
             }
             if vr.genre_route:

--- a/py/workflow_shared.py
+++ b/py/workflow_shared.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Shared workflow-state helpers used across review/apply/move stages."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from db_helpers import reconstruct_path_metadata
+from path_placement_rules import normalize_title_for_comparison
+
+
+@dataclass(frozen=True)
+class EffectiveMetadata:
+    metadata: dict
+    source: str | None
+    selected_from: str
+
+
+@dataclass(frozen=True)
+class CanonicalTitleSources:
+    human_reviewed_titles: set[str]
+    programs_titles: set[str]
+
+
+def _latest_path_metadata_row(
+    con: sqlite3.Connection,
+    path_id: str,
+    *,
+    human_reviewed_only: bool = False,
+):
+    where = "WHERE path_id=?"
+    if human_reviewed_only:
+        where += " AND (source='human_reviewed' OR human_reviewed=1)"
+    return con.execute(
+        f"""
+        SELECT source, data_json, program_title, air_date, needs_review,
+               episode_no, subtitle, broadcaster, human_reviewed
+        FROM path_metadata
+        {where}
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """,
+        (path_id,),
+    ).fetchone()
+
+
+def resolve_effective_path_metadata(con: sqlite3.Connection, path_id: str) -> EffectiveMetadata | None:
+    """Resolve metadata with shared precedence.
+
+    Precedence:
+      1. Most recent human_reviewed metadata (authoritative when present)
+      2. Otherwise, most recent metadata row
+    """
+    human_row = _latest_path_metadata_row(con, path_id, human_reviewed_only=True)
+    if human_row:
+        md = reconstruct_path_metadata(human_row)
+        return EffectiveMetadata(
+            metadata=md if isinstance(md, dict) else {},
+            source=str(human_row["source"]) if human_row["source"] is not None else None,
+            selected_from="latest_human_reviewed",
+        )
+
+    latest_row = _latest_path_metadata_row(con, path_id, human_reviewed_only=False)
+    if not latest_row:
+        return None
+    md = reconstruct_path_metadata(latest_row)
+    return EffectiveMetadata(
+        metadata=md if isinstance(md, dict) else {},
+        source=str(latest_row["source"]) if latest_row["source"] is not None else None,
+        selected_from="latest_any",
+    )
+
+
+def metadata_source_flags(md: dict | None, source: str | None) -> tuple[bool, bool]:
+    source_norm = str(source or "").strip().lower()
+    is_human_reviewed = (
+        source_norm == "human_reviewed"
+        or bool(isinstance(md, dict) and md.get("human_reviewed"))
+    )
+    is_llm = source_norm in {"llm", "llm_subagent"}
+    return is_human_reviewed, is_llm
+
+
+def load_canonical_title_sources(con: sqlite3.Connection) -> CanonicalTitleSources:
+    human_reviewed_titles: set[str] = set()
+    programs_titles: set[str] = set()
+
+    try:
+        rows = con.execute(
+            """SELECT DISTINCT program_title FROM path_metadata
+               WHERE program_title IS NOT NULL AND program_title != ''
+                 AND (source = 'human_reviewed' OR human_reviewed = 1)"""
+        ).fetchall()
+        for r in rows:
+            title = str(r["program_title"]).strip()
+            if title:
+                human_reviewed_titles.add(title)
+    except sqlite3.OperationalError:
+        pass
+
+    try:
+        rows = con.execute(
+            "SELECT canonical_title FROM programs WHERE canonical_title IS NOT NULL AND canonical_title != ''"
+        ).fetchall()
+        for r in rows:
+            title = str(r["canonical_title"]).strip()
+            if title:
+                programs_titles.add(title)
+    except sqlite3.OperationalError:
+        pass
+
+    return CanonicalTitleSources(
+        human_reviewed_titles=human_reviewed_titles,
+        programs_titles=programs_titles,
+    )
+
+
+def longest_prefix_title_match(
+    program_title: str,
+    canonical_titles: set[str],
+    min_extra_chars: int,
+) -> str | None:
+    pt_norm = normalize_title_for_comparison(program_title)
+    if not pt_norm:
+        return None
+
+    best_title: str | None = None
+    best_len = 0
+    for ct in canonical_titles:
+        ct_norm = normalize_title_for_comparison(ct)
+        if not ct_norm:
+            continue
+        if pt_norm.startswith(ct_norm) and len(pt_norm) >= len(ct_norm) + min_extra_chars and len(ct_norm) > best_len:
+            best_len = len(ct_norm)
+            best_title = ct
+    return best_title


### PR DESCRIPTION
### Motivation
- Issue #73 showed workflow drift caused by duplicated metadata/title selection and inconsistent correctness checks across detect/review/move stages, so a single shared precedence model is needed. 
- The goal is to ensure human-reviewed corrections are authoritative and downstream stages reuse the same canonical-title and correctness logic.

### Description
- Added `py/workflow_shared.py` implementing `resolve_effective_path_metadata`, `metadata_source_flags`, `load_canonical_title_sources`, and `longest_prefix_title_match` to centralize metadata precedence and canonical-title helpers. 
- Updated `py/relocate_existing_files.py` to use `resolve_effective_path_metadata` and `metadata_source_flags`, and to emit `metadata_selected_from` provenance in move plan rows and skip rows so downstream tooling knows which precedence selected the metadata. 
- Updated `py/make_move_plan_from_inventory.py` and `py/make_metadata_queue_from_inventory.py` to use `resolve_effective_path_metadata` so move-plan and metadata-queue generation follow the same effective-metadata policy. 
- Updated `py/detect_folder_contamination.py` to use shared canonical title source loading and the shared longest-prefix match logic, removing duplicated title-collection / prefix-matching code.

### Testing
- Compiled the modified modules with `python -m py_compile py/workflow_shared.py py/detect_folder_contamination.py py/relocate_existing_files.py py/make_move_plan_from_inventory.py py/make_metadata_queue_from_inventory.py`, which succeeded. 
- Exercised CLI help for changed tools with `python py/detect_folder_contamination.py --help`, `python py/relocate_existing_files.py --help`, `python py/make_move_plan_from_inventory.py --help`, and `python py/make_metadata_queue_from_inventory.py --help`, which all returned successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d11184cc8329b39973eeaef70800)