### PR TITLE
Align folder-cleanup to user-specified entrypoint and unified review YAML

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -33,16 +33,45 @@ def main() -> int:
     ap.add_argument("--db", required=True)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--min-extra-chars", type=int, default=MIN_EXTRA_CHARS_DEFAULT)
+    ap.add_argument(
+        "--program-title",
+        default="",
+        help="Only inspect this exact current program_title (user-specified cleanup mode).",
+    )
+    ap.add_argument(
+        "--path-contains",
+        default="",
+        help="Only inspect rows where file path contains this substring (SQL LIKE %%value%%).",
+    )
     args = ap.parse_args()
 
     con = connect_db(args.db)
     sources = load_canonical_title_sources(con)
 
-    # Query all distinct program_title values with their path_ids
+    where = ["pm.program_title IS NOT NULL", "pm.program_title != ''"]
+    q_params: list[str] = []
+    joins = ""
+    mode = "auto_detect"
+
+    program_title_filter = str(args.program_title or "").strip()
+    path_contains_filter = str(args.path_contains or "").strip()
+    if program_title_filter:
+        where.append("pm.program_title = ?")
+        q_params.append(program_title_filter)
+        mode = "user_specified"
+    if path_contains_filter:
+        joins = "JOIN paths p ON p.path_id = pm.path_id"
+        where.append("p.path LIKE ?")
+        q_params.append(f"%{path_contains_filter}%")
+        mode = "user_specified"
+
+    # Query program_title values with their path_ids in requested scope
     rows = con.execute(
-        """SELECT pm.path_id, pm.program_title
-           FROM path_metadata pm
-           WHERE pm.program_title IS NOT NULL AND pm.program_title != ''"""
+        f"""SELECT pm.path_id, pm.program_title
+            FROM path_metadata pm
+            {joins}
+            WHERE {" AND ".join(where)}""",
+        q_params,
     ).fetchall()
 
     # Group path_ids by program_title
@@ -103,6 +132,11 @@ def main() -> int:
     result: dict[str, Any] = {
         "ok": True,
         "dryRun": args.dry_run,
+        "mode": mode,
+        "filters": {
+            "programTitle": program_title_filter or None,
+            "pathContains": path_contains_filter or None,
+        },
         "totalContaminatedTitles": len(contaminated_titles),
         "totalAffectedFiles": total_affected,
         "contaminatedTitles": contaminated_titles,

--- a/skills/folder-cleanup/SKILL.md
+++ b/skills/folder-cleanup/SKILL.md
@@ -4,7 +4,7 @@ description: Detect and fix contaminated folder names under by_program/. Use whe
 metadata: {"openclaw":{"emoji":"🧹","requires":{"plugins":["video-library-pipeline"]}}}
 ---
 
-# Folder contamination cleanup
+# Folder contamination cleanup (user-specified primary)
 
 ## !! Critical rules !!
 
@@ -34,7 +34,27 @@ Stop and report if `ok=false`.
 
 From the result, extract **`windowsOpsRoot`** (e.g. `B:\_AI_WORK`). The WSL-equivalent path is needed for file writes — convert by replacing the drive letter: `B:\...` → `/mnt/b/...`. The `llm/` subdirectory under this path is where all review YAML files go (same location as `program_aliases_review_*.yaml` from extract-review).
 
-### Step 2: Detect contamination
+### Step 2: Resolve target titles (user-specified first, detect second)
+
+Primary path (recommended):
+- If user provided a concrete wrong folder/path, call:
+
+```
+video_pipeline_detect_folder_contamination {
+  "pathContains": "<representative wrong folder/path substring>"
+}
+```
+
+- If user provided the current wrong title directly, call:
+
+```
+video_pipeline_detect_folder_contamination {
+  "programTitle": "<current wrong program_title>"
+}
+```
+
+Fallback audit path (optional):
+- When the user does **not** provide a concrete target, run full detect:
 
 ```
 video_pipeline_detect_folder_contamination {}
@@ -50,39 +70,41 @@ Branch on result:
 
 Example: if `windowsOpsRoot` = `B:\_AI_WORK`, write to `/mnt/b/_AI_WORK/llm/folder_contamination_review_20260323_211200.yaml`.
 
+Use the **same review YAML shape as extract-review** (`hints[].canonical_title + aliases[]`).
 The YAML is **for human editing only** — keep it minimal:
 
 ```yaml
 # Folder contamination review
-# - approved_title 空欄 → suggested_title を採用
-# - approved_title 記入 → そちらを採用
-# - 行ごと削除 → スキップ
-candidates:
-  - program_title: "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
-    suggested_title: "ヒューマニエンス"
-    approved_title:
+# extract-review と同じ hints 形式:
+# - canonical_title を確定/修正
+# - aliases は現在の汚染タイトル (通常 1 件)
+# - ブロックごと削除でスキップ
+hints:
+  - canonical_title: "ヒューマニエンス"
+    aliases:
+      - "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
 ```
 
 Map from the detection result's `contaminatedTitles` array:
-- `program_title` ← `programTitle`
-- `suggested_title` ← `suggestedTitle`
-- `approved_title` ← always empty
+- `hints[].canonical_title` ← `suggestedTitle`
+- `hints[].aliases[0]` ← `programTitle`
 
 Do NOT include `pathIds`, `confidence`, `matchSource`, `affectedFiles`, or other machine data in the YAML. The agent already has this from the step 2 result.
 
 Present the file path to the user and wait for them to finish editing.
 
 **[User review gate]** — User edits the YAML:
-- Entry kept, `approved_title` empty → use `suggested_title`
-- Entry kept, `approved_title` filled → use that title
-- Entry deleted → skip
+- ブロックを残す → 採用
+- `canonical_title` を編集 → その値を採用
+- ブロック削除 → スキップ
 
 ### Step 4: Read YAML and build title updates
 
 After user signals completion, read the edited YAML. For each remaining entry:
 
-1. Determine `new_title`: use `approved_title` when non-empty; otherwise `suggested_title`
-2. Look up `pathIds` from the **step 2 detection result** by matching `programTitle`
+1. Determine `new_title`: `hints[].canonical_title`
+2. Determine original contaminated title: `hints[].aliases[0]` (or first alias)
+3. Look up `pathIds` from the **step 2 detection result** by matching `programTitle`
 3. Build one `{ "path_id": "<id>", "new_title": "<new_title>" }` per path_id
 
 Then dry-run:

--- a/skills/video-library-pipeline/SKILL.md
+++ b/skills/video-library-pipeline/SKILL.md
@@ -32,7 +32,7 @@ Classify the user request first, then **immediately read the sub-skill SKILL.md 
 | Re-run metadata extraction only | Read `skills/extract-review/SKILL.md`, then follow its sequence |
 | Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly (EPG `[再]` flag based: `rebroadcast` / `original` / `unknown`) |
 | Fix program titles ("タイトル修正", "番組名を直して", folder name ≠ program name) | Call `video_pipeline_update_program_titles` with dryRun=true first, then apply. **Never write raw SQL scripts.** |
-| Contaminated folder names ("フォルダ名がおかしい", "フォルダ分けが変", "サブタイトルがフォルダに入ってる", "folder cleanup") | Read `skills/folder-cleanup/SKILL.md`, then follow its sequence |
+| Contaminated folder names ("フォルダ名がおかしい", "フォルダ分けが変", "サブタイトルがフォルダに入ってる", "folder cleanup") | Read `skills/folder-cleanup/SKILL.md`, then follow its sequence (**user-specified target first, auto-detect second**) |
 
 If the user asks about cleanup/reorganization for an already-existing directory tree, treat that as **relocate flow** (read `skills/relocate-review/SKILL.md`), not the `sourceRoot` pipeline flow.
 

--- a/src/tool-detect-folder-contamination.ts
+++ b/src/tool-detect-folder-contamination.ts
@@ -8,11 +8,23 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
       description:
         "Detect by_program folder names contaminated with subtitle/episode info. " +
         "Cross-references programs table for suggested corrections. " +
+        "Supports user-specified scoping by current title or representative path substring. " +
         "Returns updateInstructions array compatible with video_pipeline_update_program_titles.",
       parameters: {
         type: "object",
         additionalProperties: false,
         properties: {
+          programTitle: {
+            type: "string",
+            description:
+              "Optional explicit current program_title to inspect (user-specified cleanup entry point).",
+          },
+          pathContains: {
+            type: "string",
+            description:
+              "Optional path substring to scope detection (matched as SQL LIKE %value%). " +
+              "Useful when user provides a representative wrong folder/path.",
+          },
           minExtraChars: {
             type: "integer",
             minimum: 1,
@@ -37,6 +49,12 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
 
         if (typeof params.minExtraChars === "number" && Number.isFinite(params.minExtraChars)) {
           args.push("--min-extra-chars", String(Math.trunc(params.minExtraChars)));
+        }
+        if (typeof params.programTitle === "string" && params.programTitle.trim()) {
+          args.push("--program-title", params.programTitle.trim());
+        }
+        if (typeof params.pathContains === "string" && params.pathContains.trim()) {
+          args.push("--path-contains", params.pathContains.trim());
         }
 
         const r = runCmd("uv", args, resolved.cwd);


### PR DESCRIPTION
### Motivation
- Make contaminated-folder cleanup start from explicit operator input instead of depending on auto-detection to enable predictable, operator-driven corrections. 
- Converge the human-facing review artifact across workflows so operators and agents use a single YAML contract. 
- Reduce agent-side branching and schema-mapping by surfacing only human-relevant fields in review files. 

### Description
- Added optional scoping parameters to the detection tool API by extending `video_pipeline_detect_folder_contamination` with `programTitle` and `pathContains` and passed them through to the Python detector. 
- Extended `py/detect_folder_contamination.py` to accept `--program-title` and `--path-contains`, apply SQL-level filters when provided, and return `mode` and `filters` metadata (`user_specified` vs `auto_detect`). 
- Updated `skills/folder-cleanup/SKILL.md` to make user-specified cleanup the primary path (representative `pathContains` or explicit `programTitle`) and to produce/edit a unified review YAML using the same `hints[].canonical_title + aliases[]` shape as `extract-review`. 
- Updated `skills/video-library-pipeline/SKILL.md` and the TypeScript tool description to document the user-first behavior and the new parameters so orchestrator routing and operators are clear. 

### Testing
- Ran `python3 -m py_compile py/detect_folder_contamination.py` which succeeded with no syntax errors. 
- Invoked `npx tsc --noEmit`; the repository has no `tsconfig.json` so `tsc` printed usage/help and did not perform a project type-check (no TypeScript build was executed). 
- No additional automated unit tests exist for these flows, so behavior should be validated with the normal pipeline runs (user-specified detection → YAML review → `video_pipeline_update_program_titles` dry-run) in a staging environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20efbfa9c8329a2ab95106885fc79)