### PR TITLE
Folder-cleanup: targeted detection + unified YAML review contract

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -33,6 +33,21 @@ def main() -> int:
     ap.add_argument("--db", required=True)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--min-extra-chars", type=int, default=MIN_EXTRA_CHARS_DEFAULT)
+    ap.add_argument(
+        "--program-title",
+        default="",
+        help="Limit detection to a specific current program_title (exact match).",
+    )
+    ap.add_argument(
+        "--path-like",
+        default="",
+        help="Resolve candidate program_title values from paths.path LIKE pattern.",
+    )
+    ap.add_argument(
+        "--preferred-title",
+        default="",
+        help="If provided, override suggestedTitle with this value for matched targets.",
+    )
     args = ap.parse_args()
 
     con = connect_db(args.db)
@@ -40,22 +55,48 @@ def main() -> int:
 
     # Query all distinct program_title values with their path_ids
     rows = con.execute(
-        """SELECT pm.path_id, pm.program_title
+        """SELECT pm.path_id, pm.program_title, p.path
            FROM path_metadata pm
+           JOIN paths p ON p.path_id = pm.path_id
            WHERE pm.program_title IS NOT NULL AND pm.program_title != ''"""
     ).fetchall()
 
     # Group path_ids by program_title
     title_to_path_ids: dict[str, list[str]] = {}
+    title_to_paths: dict[str, list[str]] = {}
     for r in rows:
         pt = str(r["program_title"]).strip()
         if pt:
             title_to_path_ids.setdefault(pt, []).append(str(r["path_id"]))
+            title_to_paths.setdefault(pt, []).append(str(r["path"] or ""))
+
+    target_titles: set[str] = set(title_to_path_ids.keys())
+    explicit_program_title = str(args.program_title or "").strip()
+    if explicit_program_title:
+        target_titles = {explicit_program_title}
+
+    path_like = str(args.path_like or "").strip()
+    if path_like:
+        matched_rows = con.execute(
+            """SELECT DISTINCT pm.program_title
+               FROM path_metadata pm
+               JOIN paths p ON p.path_id = pm.path_id
+               WHERE p.path LIKE ? AND pm.program_title IS NOT NULL AND pm.program_title != ''""",
+            (path_like,),
+        ).fetchall()
+        matched_titles = {str(r["program_title"]).strip() for r in matched_rows if str(r["program_title"]).strip()}
+        if explicit_program_title:
+            target_titles = target_titles.intersection(matched_titles)
+        else:
+            target_titles = matched_titles
 
     contaminated_titles: list[dict[str, Any]] = []
     update_instructions: list[dict[str, str]] = []
 
+    preferred_title = str(args.preferred_title or "").strip()
     for program_title, path_ids in sorted(title_to_path_ids.items()):
+        if program_title not in target_titles:
+            continue
         suggested_title, match_source = suggest_canonical_title(
             program_title,
             sources,
@@ -65,6 +106,10 @@ def main() -> int:
         # Exact human-reviewed title → already canonical
         if match_source == "exact_human_reviewed":
             continue
+
+        if suggested_title is None and preferred_title:
+            suggested_title = preferred_title
+            match_source = "operator_override"
 
         if suggested_title is None:
             continue
@@ -77,6 +122,7 @@ def main() -> int:
         confidence = (
             "high" if match_source == "human_reviewed"
             else "medium" if match_source == "programs_table"
+            else "high" if match_source == "operator_override"
             else "low"
         )
 
@@ -89,6 +135,7 @@ def main() -> int:
             "separatorFound": SUBTITLE_SEPARATORS.search(program_title).group() if has_separator else None,
             "affectedFiles": len(path_ids),
             "pathIds": path_ids,
+            "samplePaths": title_to_paths.get(program_title, [])[:3],
         }
         contaminated_titles.append(entry)
 
@@ -103,6 +150,13 @@ def main() -> int:
     result: dict[str, Any] = {
         "ok": True,
         "dryRun": args.dry_run,
+        "mode": "targeted" if (explicit_program_title or path_like) else "scan_all",
+        "targeting": {
+            "programTitle": explicit_program_title or None,
+            "pathLike": path_like or None,
+            "preferredTitle": preferred_title or None,
+            "resolvedTargetTitles": sorted(target_titles),
+        },
         "totalContaminatedTitles": len(contaminated_titles),
         "totalAffectedFiles": total_affected,
         "contaminatedTitles": contaminated_titles,

--- a/skills/folder-cleanup/SKILL.md
+++ b/skills/folder-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-library-pipeline-folder-cleanup
-description: Detect and fix contaminated folder names under by_program/. Use when the user says "フォルダ名がおかしい", "サブタイトルがフォルダに入ってる", "folder names look wrong", or "フォルダ分けが変".
+description: Fix contaminated folder names under by_program/ with operator-directed input as the primary path. Use when the user says "このフォルダが間違い", "フォルダ名がおかしい", "サブタイトルがフォルダに入ってる", "folder names look wrong", or "フォルダ分けが変".
 metadata: {"openclaw":{"emoji":"🧹","requires":{"plugins":["video-library-pipeline"]}}}
 ---
 
@@ -34,11 +34,19 @@ Stop and report if `ok=false`.
 
 From the result, extract **`windowsOpsRoot`** (e.g. `B:\_AI_WORK`). The WSL-equivalent path is needed for file writes — convert by replacing the drive letter: `B:\...` → `/mnt/b/...`. The `llm/` subdirectory under this path is where all review YAML files go (same location as `program_aliases_review_*.yaml` from extract-review).
 
-### Step 2: Detect contamination
+### Step 2: Detect contamination (operator-directed primary path)
 
 ```
-video_pipeline_detect_folder_contamination {}
+video_pipeline_detect_folder_contamination {
+  "programTitle": "<optional: current wrong title>",
+  "representativePathLike": "<optional: %...wrong folder/path...%>",
+  "preferredTitle": "<optional: operator-intended canonical title>"
+}
 ```
+
+Rules:
+- Prefer explicit user-provided target (`programTitle` and/or `representativePathLike`) when available.
+- Use full scan (`{}`) only as a secondary audit mode when the user asks for broad cleanup.
 
 Branch on result:
 - `totalContaminatedTitles == 0` → Report clean, stop.
@@ -50,39 +58,38 @@ Branch on result:
 
 Example: if `windowsOpsRoot` = `B:\_AI_WORK`, write to `/mnt/b/_AI_WORK/llm/folder_contamination_review_20260323_211200.yaml`.
 
-The YAML is **for human editing only** — keep it minimal:
+The YAML is **for human editing only** and should use the **same review contract as extract-review** (`program_aliases_v1`):
 
 ```yaml
-# Folder contamination review
-# - approved_title 空欄 → suggested_title を採用
-# - approved_title 記入 → そちらを採用
-# - 行ごと削除 → スキップ
-candidates:
-  - program_title: "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
-    suggested_title: "ヒューマニエンス"
-    approved_title:
+# Folder contamination review (shared contract: program_aliases_v1)
+# - canonical_title をそのまま → 提案採用
+# - canonical_title を編集 → 上書き
+# - エントリ削除 → スキップ
+hints:
+  - canonical_title: "ヒューマニエンス"
+    aliases:
+      - "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
 ```
 
-Map from the detection result's `contaminatedTitles` array:
-- `program_title` ← `programTitle`
-- `suggested_title` ← `suggestedTitle`
-- `approved_title` ← always empty
+Map from the detection result's `reviewYamlTemplate.hints` (preferred) or `contaminatedTitles`:
+- `canonical_title` ← `suggestedTitle` (or edited by human)
+- `aliases[]` ← include current contaminated `programTitle`
 
-Do NOT include `pathIds`, `confidence`, `matchSource`, `affectedFiles`, or other machine data in the YAML. The agent already has this from the step 2 result.
+Do NOT include `pathIds`, `confidence`, `matchSource`, `affectedFiles`, or other machine data in the YAML.
 
 Present the file path to the user and wait for them to finish editing.
 
 **[User review gate]** — User edits the YAML:
-- Entry kept, `approved_title` empty → use `suggested_title`
-- Entry kept, `approved_title` filled → use that title
+- Entry kept, `canonical_title` unchanged → accept suggestion
+- Entry kept, `canonical_title` edited → use edited canonical title
 - Entry deleted → skip
 
 ### Step 4: Read YAML and build title updates
 
 After user signals completion, read the edited YAML. For each remaining entry:
 
-1. Determine `new_title`: use `approved_title` when non-empty; otherwise `suggested_title`
-2. Look up `pathIds` from the **step 2 detection result** by matching `programTitle`
+1. Read `hints[].canonical_title` and `hints[].aliases[]`
+2. For each alias, look up `pathIds` from the **step 2 detection result** by matching `programTitle`
 3. Build one `{ "path_id": "<id>", "new_title": "<new_title>" }` per path_id
 
 Then dry-run:

--- a/src/tool-detect-folder-contamination.ts
+++ b/src/tool-detect-folder-contamination.ts
@@ -8,7 +8,8 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
       description:
         "Detect by_program folder names contaminated with subtitle/episode info. " +
         "Cross-references programs table for suggested corrections. " +
-        "Returns updateInstructions array compatible with video_pipeline_update_program_titles.",
+        "Returns updateInstructions array compatible with video_pipeline_update_program_titles. " +
+        "Supports targeted mode (programTitle / representativePathLike) for operator-directed cleanup.",
       parameters: {
         type: "object",
         additionalProperties: false,
@@ -19,6 +20,18 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
             maximum: 20,
             default: 4,
             description: "Minimum extra characters beyond matched title to consider contaminated.",
+          },
+          programTitle: {
+            type: "string",
+            description: "Target a specific current program_title (exact match).",
+          },
+          representativePathLike: {
+            type: "string",
+            description: "Target records by paths.path LIKE pattern (for user-specified wrong folder).",
+          },
+          preferredTitle: {
+            type: "string",
+            description: "Operator-provided canonical title override to use when building suggestions.",
           },
         },
       },
@@ -38,6 +51,15 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
         if (typeof params.minExtraChars === "number" && Number.isFinite(params.minExtraChars)) {
           args.push("--min-extra-chars", String(Math.trunc(params.minExtraChars)));
         }
+        if (typeof params.programTitle === "string" && params.programTitle.trim()) {
+          args.push("--program-title", params.programTitle.trim());
+        }
+        if (typeof params.representativePathLike === "string" && params.representativePathLike.trim()) {
+          args.push("--path-like", params.representativePathLike.trim());
+        }
+        if (typeof params.preferredTitle === "string" && params.preferredTitle.trim()) {
+          args.push("--preferred-title", params.preferredTitle.trim());
+        }
 
         const r = runCmd("uv", args, resolved.cwd);
         const parsed = parseJsonObject(r.stdout);
@@ -54,6 +76,23 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
           for (const [k, v] of Object.entries(parsed)) out[k] = v;
         }
 
+        // Shared review contract with extract-review YAML: hints[].canonical_title + aliases[].
+        if (parsed && Array.isArray(parsed.contaminatedTitles)) {
+          out.reviewYamlContract = "program_aliases_v1";
+          out.reviewYamlTemplate = {
+            hints: parsed.contaminatedTitles.map((e: any) => ({
+              canonical_title: String(e?.suggestedTitle || ""),
+              aliases: [String(e?.programTitle || "")].filter(Boolean),
+            })),
+          };
+          out.reviewInstructions = [
+            "Keep entry as-is to accept suggested canonical title.",
+            "Edit canonical_title to override suggestion.",
+            "Remove entry to skip.",
+            "Optionally append aliases[] synonyms if needed.",
+          ];
+        }
+
         // Suggest follow-up tool calls based on result
         if (parsed && Array.isArray(parsed.updateInstructions) && parsed.updateInstructions.length > 0) {
           out.followUpToolCalls = [
@@ -67,7 +106,7 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
             },
           ];
         }
-        // Strip verbose pathIds from contaminatedTitles in tool output (keep in updateInstructions)
+        // Keep compact output while preserving targeted operator workflow details.
         if (parsed && Array.isArray(parsed.contaminatedTitles)) {
           out.contaminatedTitles = parsed.contaminatedTitles.map((e: any) => {
             const { pathIds, ...rest } = e;


### PR DESCRIPTION
### Motivation

- Provide an operator-directed workflow for contaminated-folder fixes so cleanup can start from explicit user intent instead of only broad auto-scan (addresses the intent behind related issues).
- Reduce cognitive friction by reusing the same review YAML contract used by extract-review so humans and tools share a single alias/canonical-title format.

### Description

- Added targeted operator parameters to `py/detect_folder_contamination.py`: `--program-title`, `--path-like`, and `--preferred-title` and limited detection to resolved target titles when provided.
- Enhanced `py/detect_folder_contamination.py` output with `mode`, `targeting`, and `samplePaths`, and treat `--preferred-title` as an operator override (`matchSource: operator_override`).
- Extended the plugin wrapper `src/tool-detect-folder-contamination.ts` to expose `programTitle`, `representativePathLike`, and `preferredTitle` parameters and to return a shared review YAML template (`reviewYamlContract = "program_aliases_v1"` with `reviewYamlTemplate.hints`) and `reviewInstructions` for human editing.
- Updated `skills/folder-cleanup/SKILL.md` to make operator-directed targeting the primary flow and to use the same `hints[].canonical_title + aliases[]` YAML contract as the extract-review skill.

### Testing

- Ran `python -m py_compile py/detect_folder_contamination.py` which completed successfully.
- Ran `python py/detect_folder_contamination.py --help` to validate CLI usage and option descriptions, which printed the updated help and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20efbfa9c8329a2ab95106885fc79)