### PR TITLE
Make folder-cleanup operator-driven and unify review YAML; add explicit-targets to detection tool

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -13,6 +13,8 @@ Generates updateInstructions (path_id based) compatible with update_program_titl
 
 Usage:
   python detect_folder_contamination.py --db mediaops.sqlite --dry-run
+  python detect_folder_contamination.py --db mediaops.sqlite --program-title "番組名▽サブタイトル"
+  python detect_folder_contamination.py --db mediaops.sqlite --path-like "%\\by_program\\番組名▽サブタイトル\\%"
 """
 
 from __future__ import annotations
@@ -33,24 +35,61 @@ def main() -> int:
     ap.add_argument("--db", required=True)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--min-extra-chars", type=int, default=MIN_EXTRA_CHARS_DEFAULT)
+    ap.add_argument(
+        "--program-title",
+        default="",
+        help="Only analyze rows whose current program_title exactly matches this value.",
+    )
+    ap.add_argument(
+        "--path-like",
+        default="",
+        help="Only analyze rows whose path matches this SQL LIKE pattern (e.g. %\\\\by_program\\\\title\\\\%).",
+    )
+    ap.add_argument(
+        "--path-id",
+        action="append",
+        default=[],
+        help="Only analyze these path_id values (repeatable).",
+    )
     args = ap.parse_args()
 
     con = connect_db(args.db)
     sources = load_canonical_title_sources(con)
 
-    # Query all distinct program_title values with their path_ids
+    where_parts = ["pm.program_title IS NOT NULL", "pm.program_title != ''"]
+    params: list[Any] = []
+    if args.program_title.strip():
+        where_parts.append("pm.program_title = ?")
+        params.append(args.program_title.strip())
+    if args.path_like.strip():
+        where_parts.append("pm.path LIKE ?")
+        params.append(args.path_like.strip())
+    if args.path_id:
+        placeholders = ",".join("?" for _ in args.path_id)
+        where_parts.append(f"pm.path_id IN ({placeholders})")
+        params.extend(str(x) for x in args.path_id)
+
+    where_clause = " AND ".join(where_parts)
     rows = con.execute(
-        """SELECT pm.path_id, pm.program_title
-           FROM path_metadata pm
-           WHERE pm.program_title IS NOT NULL AND pm.program_title != ''"""
+        f"""SELECT pm.path_id, pm.path, pm.program_title
+            FROM path_metadata pm
+            WHERE {where_clause}""",
+        params,
     ).fetchall()
 
     # Group path_ids by program_title
     title_to_path_ids: dict[str, list[str]] = {}
+    title_to_sample_paths: dict[str, list[str]] = {}
     for r in rows:
         pt = str(r["program_title"]).strip()
         if pt:
             title_to_path_ids.setdefault(pt, []).append(str(r["path_id"]))
+            p = str(r["path"] or "").strip()
+            if p:
+                title_to_sample_paths.setdefault(pt, [])
+                sample_paths = title_to_sample_paths[pt]
+                if p not in sample_paths and len(sample_paths) < 3:
+                    sample_paths.append(p)
 
     contaminated_titles: list[dict[str, Any]] = []
     update_instructions: list[dict[str, str]] = []
@@ -89,6 +128,7 @@ def main() -> int:
             "separatorFound": SUBTITLE_SEPARATORS.search(program_title).group() if has_separator else None,
             "affectedFiles": len(path_ids),
             "pathIds": path_ids,
+            "samplePaths": title_to_sample_paths.get(program_title, []),
         }
         contaminated_titles.append(entry)
 
@@ -103,6 +143,12 @@ def main() -> int:
     result: dict[str, Any] = {
         "ok": True,
         "dryRun": args.dry_run,
+        "filters": {
+            "programTitle": args.program_title.strip() or None,
+            "pathLike": args.path_like.strip() or None,
+            "pathIds": [str(x) for x in args.path_id] if args.path_id else [],
+        },
+        "scannedRows": len(rows),
         "totalContaminatedTitles": len(contaminated_titles),
         "totalAffectedFiles": total_affected,
         "contaminatedTitles": contaminated_titles,

--- a/skills/extract-review/SKILL.md
+++ b/skills/extract-review/SKILL.md
@@ -36,6 +36,7 @@ See main `video-library-pipeline` SKILL.md for definitions of `machine_extracted
 ## YAML→DB 反映フロー (primary path)
 
 `video_pipeline_export_program_yaml` が生成する YAML は **人間のレビュー・編集用アーティファクト** であると同時に、`video_pipeline_apply_reviewed_metadata` の `sourceYamlPath` パラメータ経由で **DB に直接反映できる**。
+この YAML の人間向け編集面 (`hints[].canonical_title` + `aliases[]`) は、folder-cleanup ワークフローでも同一のレビュー体験として扱う。
 
 ### 仕組み
 

--- a/skills/folder-cleanup/SKILL.md
+++ b/skills/folder-cleanup/SKILL.md
@@ -34,7 +34,24 @@ Stop and report if `ok=false`.
 
 From the result, extract **`windowsOpsRoot`** (e.g. `B:\_AI_WORK`). The WSL-equivalent path is needed for file writes — convert by replacing the drive letter: `B:\...` → `/mnt/b/...`. The `llm/` subdirectory under this path is where all review YAML files go (same location as `program_aliases_review_*.yaml` from extract-review).
 
-### Step 2: Detect contamination
+### Step 2: Resolve target + detect contamination (primary: user-specified)
+
+Primary entry is **operator-specified wrong target**.
+When the user gives a concrete bad folder/path/title, call:
+
+```json
+video_pipeline_detect_folder_contamination {
+  "programTitle": "<exact wrong title, if known>",
+  "representativePathLike": "%<representative path fragment>%"
+}
+```
+
+- Use `programTitle` when the user points to a wrong title directly.
+- Use `representativePathLike` when the user points to a concrete bad folder/path.
+- If both are known, pass both for precise narrowing.
+- Use `pathIds` only when specific ids are already known.
+
+Fallback audit mode (secondary utility):
 
 ```
 video_pipeline_detect_folder_contamination {}
@@ -46,43 +63,42 @@ Branch on result:
 
 ### Step 3: Write review YAML to `{windowsOpsRoot}/llm/`
 
-**Output path** (required): `{wsl_windowsOpsRoot}/llm/folder_contamination_review_{YYYYMMDD_HHMMSS}.yaml`
+**Output path** (required): `{wsl_windowsOpsRoot}/llm/program_aliases_review_{YYYYMMDD_HHMMSS}.yaml`
 
-Example: if `windowsOpsRoot` = `B:\_AI_WORK`, write to `/mnt/b/_AI_WORK/llm/folder_contamination_review_20260323_211200.yaml`.
+Example: if `windowsOpsRoot` = `B:\_AI_WORK`, write to `/mnt/b/_AI_WORK/llm/program_aliases_review_20260323_211200.yaml`.
 
-The YAML is **for human editing only** — keep it minimal:
+Use the **same human-facing review shape as extract-review** (`canonical_title` + `aliases`):
 
 ```yaml
-# Folder contamination review
-# - approved_title 空欄 → suggested_title を採用
-# - approved_title 記入 → そちらを採用
-# - 行ごと削除 → スキップ
-candidates:
-  - program_title: "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
-    suggested_title: "ヒューマニエンス"
-    approved_title:
+# Folder contamination title review (same schema as extract-review)
+# - canonical_title を編集して採用タイトルを決める
+# - aliases は現在の混入タイトル（必要なら追加/整理）
+# - エントリ削除はスキップ
+hints:
+  - canonical_title: "ヒューマニエンス"
+    aliases:
+      - "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
 ```
 
 Map from the detection result's `contaminatedTitles` array:
-- `program_title` ← `programTitle`
-- `suggested_title` ← `suggestedTitle`
-- `approved_title` ← always empty
+- `canonical_title` ← `suggestedTitle`
+- `aliases[]` includes the current contaminated `programTitle`
 
 Do NOT include `pathIds`, `confidence`, `matchSource`, `affectedFiles`, or other machine data in the YAML. The agent already has this from the step 2 result.
 
 Present the file path to the user and wait for them to finish editing.
 
 **[User review gate]** — User edits the YAML:
-- Entry kept, `approved_title` empty → use `suggested_title`
-- Entry kept, `approved_title` filled → use that title
-- Entry deleted → skip
+- Entry kept: each alias maps to its edited `canonical_title`
+- Entry deleted: skip
 
 ### Step 4: Read YAML and build title updates
 
-After user signals completion, read the edited YAML. For each remaining entry:
+After user signals completion, read the edited YAML and build `alias -> canonical_title` mappings.
+For each mapping:
 
-1. Determine `new_title`: use `approved_title` when non-empty; otherwise `suggested_title`
-2. Look up `pathIds` from the **step 2 detection result** by matching `programTitle`
+1. Determine `new_title`: edited `canonical_title`
+2. Look up `pathIds` from the **step 2 detection result** by matching alias (`programTitle`)
 3. Build one `{ "path_id": "<id>", "new_title": "<new_title>" }` per path_id
 
 Then dry-run:
@@ -147,3 +163,11 @@ video_pipeline_relocate_existing_files {
   - Correct: `roots=["B:\\VideoLibrary"]`
   - Wrong: `roots=["B:\\VideoLibrary\\ヒューマニエンス 選「自律神経」..."]`
 - This ensures sibling contaminated folders are all included in the scan.
+
+## Review UX compatibility rule (issue #72)
+
+- Folder-cleanup review YAML is intentionally aligned to the extract-review mental model:
+  - `hints[]`
+  - `canonical_title`
+  - `aliases[]`
+- Do not introduce a folder-cleanup-only editable schema for long-term operation unless the common review contract is revised for all workflows together.

--- a/src/tool-detect-folder-contamination.ts
+++ b/src/tool-detect-folder-contamination.ts
@@ -20,6 +20,26 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
             default: 4,
             description: "Minimum extra characters beyond matched title to consider contaminated.",
           },
+          programTitle: {
+            type: "string",
+            description:
+              "Optional explicit target. Analyze only rows whose current program_title exactly matches this value.",
+          },
+          representativePathLike: {
+            type: "string",
+            description:
+              "Optional explicit target. SQL LIKE pattern used to resolve affected rows from a representative bad path.",
+          },
+          pathIds: {
+            type: "array",
+            description: "Optional explicit target. Restrict analysis to these path_id values.",
+            items: { type: "string" },
+          },
+          includePathIds: {
+            type: "boolean",
+            default: true,
+            description: "If false, hide pathIds in contaminatedTitles for compact output.",
+          },
         },
       },
       async execute(_id: string, params: AnyObj) {
@@ -37,6 +57,17 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
 
         if (typeof params.minExtraChars === "number" && Number.isFinite(params.minExtraChars)) {
           args.push("--min-extra-chars", String(Math.trunc(params.minExtraChars)));
+        }
+        if (typeof params.programTitle === "string" && params.programTitle.trim()) {
+          args.push("--program-title", params.programTitle.trim());
+        }
+        if (typeof params.representativePathLike === "string" && params.representativePathLike.trim()) {
+          args.push("--path-like", params.representativePathLike.trim());
+        }
+        if (Array.isArray(params.pathIds)) {
+          for (const id of params.pathIds) {
+            if (typeof id === "string" && id.trim()) args.push("--path-id", id.trim());
+          }
         }
 
         const r = runCmd("uv", args, resolved.cwd);
@@ -67,8 +98,7 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
             },
           ];
         }
-        // Strip verbose pathIds from contaminatedTitles in tool output (keep in updateInstructions)
-        if (parsed && Array.isArray(parsed.contaminatedTitles)) {
+        if (params.includePathIds === false && parsed && Array.isArray(parsed.contaminatedTitles)) {
           out.contaminatedTitles = parsed.contaminatedTitles.map((e: any) => {
             const { pathIds, ...rest } = e;
             return { ...rest, pathIdCount: Array.isArray(pathIds) ? pathIds.length : 0 };


### PR DESCRIPTION
### Motivation
- Allow folder-cleanup to start from an explicit operator-provided wrong title/path/path_id instead of relying on auto-detection (addresses issue #80). 
- Reduce operator friction by converging folder-cleanup review artifacts with extract-review so humans see one consistent YAML shape (addresses issue #72). 

### Description
- Added explicit-target filters to contamination detection: CLI flags `--program-title`, `--path-like`, and repeatable `--path-id`, and included `filters`, `scannedRows`, and per-title `samplePaths` in the script output (`py/detect_folder_contamination.py`).
- Extended the plugin tool to accept `programTitle`, `representativePathLike`, `pathIds`, and `includePathIds` parameters and pass them to the detection script, preserving `pathIds` by default and allowing compact output when `includePathIds=false` (`src/tool-detect-folder-contamination.ts`).
- Made folder-cleanup a primary user-specified workflow and changed its review YAML to reuse the extract-review shape (`hints[].canonical_title` + `aliases[]`), changed the review output path suggestion to `program_aliases_review_*`, and documented the mapping/flow in `skills/folder-cleanup/SKILL.md`.
- Noted the shared review-surface in `skills/extract-review/SKILL.md` to ensure UX compatibility across workflows.
- Files changed: `py/detect_folder_contamination.py`, `src/tool-detect-folder-contamination.ts`, `skills/folder-cleanup/SKILL.md`, `skills/extract-review/SKILL.md`.

### Testing
- Ran `python -m py_compile py/detect_folder_contamination.py` to validate Python syntax and it succeeded. 
- Manual verification: tool wiring and skill text updates were exercised via local diffs/commit (no other automated tests were available in this change set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20efbfa9c8329a2ab95106885fc79)