### PR TITLE
folder-cleanup: ユーザー指定ターゲット優先 + review YAML統一 (#80, #72)

### DIFF
--- a/py/detect_folder_contamination.py
+++ b/py/detect_folder_contamination.py
@@ -13,6 +13,8 @@ Generates updateInstructions (path_id based) compatible with update_program_titl
 
 Usage:
   python detect_folder_contamination.py --db mediaops.sqlite --dry-run
+  python detect_folder_contamination.py --db mediaops.sqlite --program-title "番組名▽サブタイトル"
+  python detect_folder_contamination.py --db mediaops.sqlite --path-like "%\\by_program\\番組名▽サブタイトル\\%"
 """
 
 from __future__ import annotations
@@ -33,24 +35,75 @@ def main() -> int:
     ap.add_argument("--db", required=True)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--min-extra-chars", type=int, default=MIN_EXTRA_CHARS_DEFAULT)
+    ap.add_argument(
+        "--program-title",
+        default="",
+        help="Only analyze rows whose current program_title exactly matches this value.",
+    )
+    ap.add_argument(
+        "--path-like",
+        default="",
+        help="Only analyze rows whose path matches this SQL LIKE pattern (e.g. %%\\\\by_program\\\\title\\\\%%).",
+    )
+    ap.add_argument(
+        "--path-id",
+        action="append",
+        default=[],
+        help="Only analyze these path_id values (repeatable).",
+    )
     args = ap.parse_args()
 
     con = connect_db(args.db)
     sources = load_canonical_title_sources(con)
 
-    # Query all distinct program_title values with their path_ids
+    # Build dynamic WHERE clause for scoping
+    where_parts = ["pm.program_title IS NOT NULL", "pm.program_title != ''"]
+    params: list[Any] = []
+    needs_path_join = False
+
+    program_title_filter = str(args.program_title or "").strip()
+    path_like_filter = str(args.path_like or "").strip()
+    path_id_filters = [str(x).strip() for x in (args.path_id or []) if str(x).strip()]
+
+    if program_title_filter:
+        where_parts.append("pm.program_title = ?")
+        params.append(program_title_filter)
+    if path_like_filter:
+        needs_path_join = True
+        where_parts.append("p.path LIKE ?")
+        params.append(path_like_filter)
+    if path_id_filters:
+        placeholders = ",".join("?" for _ in path_id_filters)
+        where_parts.append(f"pm.path_id IN ({placeholders})")
+        params.extend(path_id_filters)
+
+    is_targeted = bool(program_title_filter or path_like_filter or path_id_filters)
+
+    # Always JOIN paths for samplePaths; only filter on p.path when --path-like given
+    join_clause = "JOIN paths p ON p.path_id = pm.path_id"
+    where_clause = " AND ".join(where_parts)
+
     rows = con.execute(
-        """SELECT pm.path_id, pm.program_title
-           FROM path_metadata pm
-           WHERE pm.program_title IS NOT NULL AND pm.program_title != ''"""
+        f"""SELECT pm.path_id, pm.program_title, p.path
+            FROM path_metadata pm
+            {join_clause}
+            WHERE {where_clause}""",
+        params,
     ).fetchall()
 
-    # Group path_ids by program_title
+    # Group path_ids by program_title, collect sample paths
     title_to_path_ids: dict[str, list[str]] = {}
+    title_to_sample_paths: dict[str, list[str]] = {}
     for r in rows:
         pt = str(r["program_title"]).strip()
-        if pt:
-            title_to_path_ids.setdefault(pt, []).append(str(r["path_id"]))
+        if not pt:
+            continue
+        title_to_path_ids.setdefault(pt, []).append(str(r["path_id"]))
+        path_str = str(r["path"] or "").strip()
+        if path_str:
+            samples = title_to_sample_paths.setdefault(pt, [])
+            if path_str not in samples and len(samples) < 3:
+                samples.append(path_str)
 
     contaminated_titles: list[dict[str, Any]] = []
     update_instructions: list[dict[str, str]] = []
@@ -89,6 +142,7 @@ def main() -> int:
             "separatorFound": SUBTITLE_SEPARATORS.search(program_title).group() if has_separator else None,
             "affectedFiles": len(path_ids),
             "pathIds": path_ids,
+            "samplePaths": title_to_sample_paths.get(program_title, []),
         }
         contaminated_titles.append(entry)
 
@@ -103,6 +157,13 @@ def main() -> int:
     result: dict[str, Any] = {
         "ok": True,
         "dryRun": args.dry_run,
+        "mode": "targeted" if is_targeted else "scan_all",
+        "filters": {
+            "programTitle": program_title_filter or None,
+            "pathLike": path_like_filter or None,
+            "pathIds": path_id_filters if path_id_filters else [],
+        },
+        "scannedRows": len(rows),
         "totalContaminatedTitles": len(contaminated_titles),
         "totalAffectedFiles": total_affected,
         "contaminatedTitles": contaminated_titles,

--- a/skills/extract-review/SKILL.md
+++ b/skills/extract-review/SKILL.md
@@ -36,6 +36,7 @@ See main `video-library-pipeline` SKILL.md for definitions of `machine_extracted
 ## YAML→DB 反映フロー (primary path)
 
 `video_pipeline_export_program_yaml` が生成する YAML は **人間のレビュー・編集用アーティファクト** であると同時に、`video_pipeline_apply_reviewed_metadata` の `sourceYamlPath` パラメータ経由で **DB に直接反映できる**。
+この YAML の人間向け編集面 (`hints[].canonical_title` + `aliases[]`) は、folder-cleanup ワークフローでも同一のレビュー体験として扱う。
 
 ### 仕組み
 

--- a/skills/folder-cleanup/SKILL.md
+++ b/skills/folder-cleanup/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: video-library-pipeline-folder-cleanup
-description: Detect and fix contaminated folder names under by_program/. Use when the user says "フォルダ名がおかしい", "サブタイトルがフォルダに入ってる", "folder names look wrong", or "フォルダ分けが変".
+description: Fix contaminated folder names under by_program/ with operator-directed input as the primary path. Use when the user says "このフォルダが間違い", "フォルダ名がおかしい", "サブタイトルがフォルダに入ってる", "folder names look wrong", or "フォルダ分けが変".
 metadata: {"openclaw":{"emoji":"🧹","requires":{"plugins":["video-library-pipeline"]}}}
 ---
 
-# Folder contamination cleanup
+# Folder contamination cleanup (user-specified primary)
 
 ## !! Critical rules !!
 
@@ -12,10 +12,12 @@ metadata: {"openclaw":{"emoji":"🧹","requires":{"plugins":["video-library-pipe
 - **suggestedTitle is a proposal, not a decision.** Always present to user for review. Some folder names that contain separators ARE the complete canonical title.
 - Folder name = `program_title` only. Subtitle, episode info, or guest names in folder names = contamination.
 - **Selective approval is the default.** User may approve some, reject others, or override suggestedTitle.
+- Primary entry is **operator-specified wrong target** (path/title), not auto-detect full scan.
 
 ## When to use this skill
 
 - "フォルダ名がおかしい" / "フォルダ分けが変" / "サブタイトルがフォルダに入ってる"
+- "このフォルダが間違い" / user points to a specific wrong folder or title
 - "folder names look wrong" / "folder cleanup"
 - Folder names contain `▽▼◇「` or episode descriptions beyond the program title
 
@@ -34,7 +36,23 @@ Stop and report if `ok=false`.
 
 From the result, extract **`windowsOpsRoot`** (e.g. `B:\_AI_WORK`). The WSL-equivalent path is needed for file writes — convert by replacing the drive letter: `B:\...` → `/mnt/b/...`. The `llm/` subdirectory under this path is where all review YAML files go (same location as `program_aliases_review_*.yaml` from extract-review).
 
-### Step 2: Detect contamination
+### Step 2: Resolve target + detect contamination (primary: user-specified)
+
+When the user gives a concrete bad folder/path/title, call with explicit target:
+
+```json
+video_pipeline_detect_folder_contamination {
+  "programTitle": "<exact wrong title, if known>",
+  "representativePathLike": "%<representative path fragment>%"
+}
+```
+
+- Use `programTitle` when the user points to a wrong title directly.
+- Use `representativePathLike` when the user points to a concrete bad folder/path.
+- If both are known, pass both for precise narrowing.
+- Use `pathIds` only when specific ids are already known.
+
+Fallback audit mode (when user does **not** provide a concrete target):
 
 ```
 video_pipeline_detect_folder_contamination {}
@@ -46,43 +64,43 @@ Branch on result:
 
 ### Step 3: Write review YAML to `{windowsOpsRoot}/llm/`
 
-**Output path** (required): `{wsl_windowsOpsRoot}/llm/folder_contamination_review_{YYYYMMDD_HHMMSS}.yaml`
+**Output path** (required): `{wsl_windowsOpsRoot}/llm/program_aliases_review_{YYYYMMDD_HHMMSS}.yaml`
 
-Example: if `windowsOpsRoot` = `B:\_AI_WORK`, write to `/mnt/b/_AI_WORK/llm/folder_contamination_review_20260323_211200.yaml`.
+Example: if `windowsOpsRoot` = `B:\_AI_WORK`, write to `/mnt/b/_AI_WORK/llm/program_aliases_review_20260323_211200.yaml`.
 
-The YAML is **for human editing only** — keep it minimal:
+Use the **same human-facing review shape as extract-review** (`canonical_title` + `aliases`):
 
 ```yaml
-# Folder contamination review
-# - approved_title 空欄 → suggested_title を採用
-# - approved_title 記入 → そちらを採用
-# - 行ごと削除 → スキップ
-candidates:
-  - program_title: "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
-    suggested_title: "ヒューマニエンス"
-    approved_title:
+# Folder contamination title review (same schema as extract-review)
+# - canonical_title を編集して採用タイトルを決める
+# - aliases は現在の混入タイトル（必要なら追加/整理）
+# - エントリ削除はスキップ
+hints:
+  - canonical_title: "ヒューマニエンス"
+    aliases:
+      - "ヒューマニエンス 選「自律神経」あなたを操るもう一人のあなた"
 ```
 
 Map from the detection result's `contaminatedTitles` array:
-- `program_title` ← `programTitle`
-- `suggested_title` ← `suggestedTitle`
-- `approved_title` ← always empty
+- `canonical_title` ← `suggestedTitle`
+- `aliases[]` includes the current contaminated `programTitle`
 
 Do NOT include `pathIds`, `confidence`, `matchSource`, `affectedFiles`, or other machine data in the YAML. The agent already has this from the step 2 result.
 
 Present the file path to the user and wait for them to finish editing.
 
 **[User review gate]** — User edits the YAML:
-- Entry kept, `approved_title` empty → use `suggested_title`
-- Entry kept, `approved_title` filled → use that title
+- Entry kept, `canonical_title` unchanged → accept suggestion
+- Entry kept, `canonical_title` edited → use edited canonical title
 - Entry deleted → skip
 
 ### Step 4: Read YAML and build title updates
 
-After user signals completion, read the edited YAML. For each remaining entry:
+After user signals completion, read the edited YAML and build `alias -> canonical_title` mappings.
+For each mapping:
 
-1. Determine `new_title`: use `approved_title` when non-empty; otherwise `suggested_title`
-2. Look up `pathIds` from the **step 2 detection result** by matching `programTitle`
+1. Read `hints[].canonical_title` as `new_title`
+2. For each alias in `hints[].aliases[]`, look up `pathIds` from the **step 2 detection result** by matching `programTitle`
 3. Build one `{ "path_id": "<id>", "new_title": "<new_title>" }` per path_id
 
 Then dry-run:
@@ -147,3 +165,11 @@ video_pipeline_relocate_existing_files {
   - Correct: `roots=["B:\\VideoLibrary"]`
   - Wrong: `roots=["B:\\VideoLibrary\\ヒューマニエンス 選「自律神経」..."]`
 - This ensures sibling contaminated folders are all included in the scan.
+
+## Review UX compatibility rule (issue #72)
+
+- Folder-cleanup review YAML is intentionally aligned to the extract-review mental model:
+  - `hints[]`
+  - `canonical_title`
+  - `aliases[]`
+- Do not introduce a folder-cleanup-only editable schema unless the common review contract is revised for all workflows together.

--- a/skills/video-library-pipeline/SKILL.md
+++ b/skills/video-library-pipeline/SKILL.md
@@ -32,7 +32,7 @@ Classify the user request first, then **immediately read the sub-skill SKILL.md 
 | Re-run metadata extraction only | Read `skills/extract-review/SKILL.md`, then follow its sequence |
 | Rebroadcast detection | Call `video_pipeline_detect_rebroadcasts` directly (EPG `[再]` flag based: `rebroadcast` / `original` / `unknown`) |
 | Fix program titles ("タイトル修正", "番組名を直して", folder name ≠ program name) | Call `video_pipeline_update_program_titles` with dryRun=true first, then apply. **Never write raw SQL scripts.** |
-| Contaminated folder names ("フォルダ名がおかしい", "フォルダ分けが変", "サブタイトルがフォルダに入ってる", "folder cleanup") | Read `skills/folder-cleanup/SKILL.md`, then follow its sequence |
+| Contaminated folder names ("フォルダ名がおかしい", "フォルダ分けが変", "サブタイトルがフォルダに入ってる", "folder cleanup") | Read `skills/folder-cleanup/SKILL.md`, then follow its sequence (**user-specified wrong path/title is the primary entry**) |
 
 If the user asks about cleanup/reorganization for an already-existing directory tree, treat that as **relocate flow** (read `skills/relocate-review/SKILL.md`), not the `sourceRoot` pipeline flow.
 

--- a/src/tool-detect-folder-contamination.ts
+++ b/src/tool-detect-folder-contamination.ts
@@ -8,6 +8,7 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
       description:
         "Detect by_program folder names contaminated with subtitle/episode info. " +
         "Cross-references programs table for suggested corrections. " +
+        "Supports targeted mode (programTitle / representativePathLike / pathIds) for operator-directed cleanup. " +
         "Returns updateInstructions array compatible with video_pipeline_update_program_titles.",
       parameters: {
         type: "object",
@@ -19,6 +20,26 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
             maximum: 20,
             default: 4,
             description: "Minimum extra characters beyond matched title to consider contaminated.",
+          },
+          programTitle: {
+            type: "string",
+            description:
+              "Optional explicit target. Analyze only rows whose current program_title exactly matches this value.",
+          },
+          representativePathLike: {
+            type: "string",
+            description:
+              "Optional explicit target. SQL LIKE pattern used to resolve affected rows from a representative bad path.",
+          },
+          pathIds: {
+            type: "array",
+            description: "Optional explicit target. Restrict analysis to these path_id values.",
+            items: { type: "string" },
+          },
+          includePathIds: {
+            type: "boolean",
+            default: true,
+            description: "If false, hide pathIds in contaminatedTitles for compact output.",
           },
         },
       },
@@ -37,6 +58,17 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
 
         if (typeof params.minExtraChars === "number" && Number.isFinite(params.minExtraChars)) {
           args.push("--min-extra-chars", String(Math.trunc(params.minExtraChars)));
+        }
+        if (typeof params.programTitle === "string" && params.programTitle.trim()) {
+          args.push("--program-title", params.programTitle.trim());
+        }
+        if (typeof params.representativePathLike === "string" && params.representativePathLike.trim()) {
+          args.push("--path-like", params.representativePathLike.trim());
+        }
+        if (Array.isArray(params.pathIds)) {
+          for (const id of params.pathIds) {
+            if (typeof id === "string" && id.trim()) args.push("--path-id", id.trim());
+          }
         }
 
         const r = runCmd("uv", args, resolved.cwd);
@@ -67,8 +99,8 @@ export function registerToolDetectFolderContamination(api: any, getCfg: (api: an
             },
           ];
         }
-        // Strip verbose pathIds from contaminatedTitles in tool output (keep in updateInstructions)
-        if (parsed && Array.isArray(parsed.contaminatedTitles)) {
+        // Conditionally strip verbose pathIds from contaminatedTitles (keep in updateInstructions)
+        if (params.includePathIds === false && parsed && Array.isArray(parsed.contaminatedTitles)) {
           out.contaminatedTitles = parsed.contaminatedTitles.map((e: any) => {
             const { pathIds, ...rest } = e;
             return { ...rest, pathIdCount: Array.isArray(pathIds) ? pathIds.length : 0 };


### PR DESCRIPTION
## Summary

PR #81〜#84 (Codex生成) の分析・統合。各PRの最良部分をcherry-pickしたマージ実装。

### 各PRから採用した要素

| 要素 | 採用元 | 理由 |
|---|---|---|
| SQL-level WHERE構築パターン | #84 | 動的フィルタ構築が最もクリーン |
| `paths` テーブル JOIN | #81 | `path_metadata` に `path` カラムなし。#82/#84 は `pm.path` でクエリ失敗する |
| `samplePaths` (重複除去、3件上限) | #84 | デバッグ・確認用に有用 |
| `--path-id` (repeatable) | #84 | 特定path_idのみ分析する柔軟性 |
| `scannedRows` / `filters` / `mode` 出力 | #84 | targeted vs scan_all の透明性 |
| conditional `includePathIds` | #84 | compact出力の制御をユーザーに委ねる |
| SKILL.md: `hints[]/canonical_title/aliases[]` 形式 | #81/#83/#84 | extract-review と統一（#82 の独自形式は不採用） |
| SKILL.md: Steps 5-7 + roots rule + handoff 保全 | #84 | #82 はこれらを削除していたが、運用上必要 |
| SKILL.md: Review UX compatibility rule | #84 | 将来のschema divergence防止 |
| extract-review SKILL.md: 1行追記 | #84 | 最も保守的な変更 |

### 不採用とした要素

| 要素 | PR | 理由 |
|---|---|---|
| `pm.path` 直接参照 | #82, #84 | `path_metadata` テーブルに `path` カラムが存在しない（`paths` テーブルにある） |
| `current_value/suggested_value/decision` YAML形式 | #82 | extract-review の `hints[]` 形式と乖離する |
| Steps 5-7 / roots rule / handoff 削除 | #82 | 運用上必要な情報の喪失 |
| `--preferred-title` (operator override) | #83 | 便利だが複雑化。必要時に別PRで追加可能 |
| TS内 `reviewYamlTemplate` 生成 | #83 | SKILL.md で十分。ツール側で生成するのは premature |
| Python-level path filtering | #82 | SQL-level の方が効率的かつ明確 |

Closes #80, Closes #72

## Test plan

- [ ] `python3 -m py_compile py/detect_folder_contamination.py` — 構文チェック済み
- [ ] `--program-title` フィルタで targeted mode 動作確認
- [ ] `--path-like` フィルタでJOIN経由のパス絞り込み確認
- [ ] `--path-id` repeatable フィルタ確認
- [ ] フィルタなしで scan_all mode の既存動作が変わらないこと
- [ ] SKILL.md の review YAML が extract-review と同じ `hints[]` 形式であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)