### PR TITLE
Harden affectedRoots inference for update_program_titles

### DIFF
--- a/py/relocate_scope_resolver.py
+++ b/py/relocate_scope_resolver.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import PureWindowsPath
+import re
+
+_YEAR_RE = re.compile(r"^\d{4}$")
+_MONTH_RE = re.compile(r"^(0?[1-9]|1[0-2])$")
+
+
+def _normalize_windows_path(path: str) -> str:
+    return path.replace("/", "\\").strip()
+
+
+def infer_library_root_from_layout(path: str) -> str | None:
+    """Infer library root from canonical layout: <root>\\<program>\\<year>\\<month>\\<file>."""
+    normalized = _normalize_windows_path(path)
+    if not normalized:
+        return None
+
+    parts = PureWindowsPath(normalized).parts
+    # Need at least: <root>, <program>, <year>, <month>, <file>
+    if len(parts) < 5:
+        return None
+
+    year_seg = parts[-3]
+    month_seg = parts[-2]
+    if not _YEAR_RE.match(year_seg) or not _MONTH_RE.match(month_seg):
+        return None
+
+    root_parts = parts[:-4]
+    if not root_parts:
+        return None
+
+    root = str(PureWindowsPath(*root_parts)).rstrip("\\")
+    return root or None
+
+
+def infer_library_root_from_old_title(path: str, old_titles: set[str]) -> str | None:
+    """Infer library root by matching old title folder segment in current path."""
+    normalized = _normalize_windows_path(path)
+    if not normalized:
+        return None
+
+    titles = {t.casefold() for t in old_titles if t}
+    if not titles:
+        return None
+
+    parts = [p for p in normalized.split("\\") if p]
+    for i, seg in enumerate(parts):
+        if seg.casefold() not in titles:
+            continue
+        if i == 0:
+            return None
+        return "\\".join(parts[:i]).rstrip("\\") or None
+    return None
+
+
+def infer_fallback_drive_root(path: str) -> str | None:
+    normalized = _normalize_windows_path(path)
+    if len(normalized) >= 3 and normalized[1:3] == ":\\":
+        return normalized[:3].upper()
+    return None
+
+
+def resolve_affected_roots(paths: list[str], old_titles: set[str]) -> list[str]:
+    """Resolve relocate roots with precedence:
+
+    1) canonical layout inference
+    2) old-title segment inference
+    3) drive-root fallback
+    """
+    roots: set[str] = set()
+    for path in paths:
+        root = (
+            infer_library_root_from_layout(path)
+            or infer_library_root_from_old_title(path, old_titles)
+            or infer_fallback_drive_root(path)
+        )
+        if root:
+            roots.add(root)
+    return sorted(roots)

--- a/py/tests/test_relocate_scope_resolver.py
+++ b/py/tests/test_relocate_scope_resolver.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from relocate_scope_resolver import resolve_affected_roots
+
+
+class ResolveAffectedRootsTests(unittest.TestCase):
+    def test_prefers_structural_layout_when_title_already_updated(self) -> None:
+        paths = [r"B:\VideoLibrary\汚染されたフォルダ名\2026\03\movie.ts"]
+        old_titles = {"クリーンな番組名"}
+
+        roots = resolve_affected_roots(paths, old_titles)
+
+        self.assertEqual(roots, [r"B:\VideoLibrary"])
+
+    def test_uses_old_title_fallback_when_layout_shape_not_detected(self) -> None:
+        paths = [r"B:\VideoLibrary\古い番組名\special\movie.ts"]
+        old_titles = {"古い番組名"}
+
+        roots = resolve_affected_roots(paths, old_titles)
+
+        self.assertEqual(roots, [r"B:\VideoLibrary"])
+
+    def test_drive_root_fallback_when_no_layout_or_old_title_match(self) -> None:
+        paths = [r"D:\misc\movie.ts"]
+        old_titles = {"無関係タイトル"}
+
+        roots = resolve_affected_roots(paths, old_titles)
+
+        self.assertEqual(roots, ["D:\\"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/update_program_titles.py
+++ b/py/update_program_titles.py
@@ -27,6 +27,7 @@ import sys
 from epg_common import normalize_program_key, program_id_for
 from mediaops_schema import begin_immediate, connect_db
 from pathscan_common import now_iso
+from relocate_scope_resolver import resolve_affected_roots
 
 
 def main() -> int:
@@ -110,7 +111,6 @@ def main() -> int:
 
     affected_roots: list[str] = []
     if updated_path_ids:
-        # Collect old program_titles (current folder names) for path-based root detection
         placeholders = ",".join("?" for _ in updated_path_ids)
         title_rows = con.execute(
             f"SELECT DISTINCT program_title FROM path_metadata WHERE path_id IN ({placeholders})",
@@ -122,21 +122,9 @@ def main() -> int:
             f"SELECT DISTINCT path FROM paths WHERE path_id IN ({placeholders})",
             updated_path_ids,
         ).fetchall()
-        roots: set[str] = set()
-        for row in path_rows:
-            path = str(row["path"] or "")
-            # Find dest_root: parent directory of the program_title folder segment
-            # e.g. B:\VideoLibrary\番組名\2026\03\file.ts → B:\VideoLibrary
-            parts = path.replace("/", "\\").split("\\")
-            for i, seg in enumerate(parts):
-                if seg in old_titles and i > 0:
-                    roots.add("\\".join(parts[:i]))
-                    break
-            else:
-                # Fallback: drive letter root
-                if len(path) >= 3 and path[1:3] == ":\\":
-                    roots.add(path[:3].upper())
-        affected_roots = sorted(roots)
+        current_paths = [str(r["path"] or "") for r in path_rows if r["path"]]
+
+        affected_roots = resolve_affected_roots(current_paths, old_titles)
     result["affectedRoots"] = affected_roots
 
     if args.dry_run:

--- a/skills/folder-cleanup/SKILL.md
+++ b/skills/folder-cleanup/SKILL.md
@@ -126,6 +126,10 @@ video_pipeline_update_program_titles {
 After title correction, run relocate to move files to correct folders.
 Use `affectedRoots` returned by `video_pipeline_update_program_titles` as the default `roots` value (fallback: parent directory of affected folders):
 
+- `affectedRoots` means: **the narrowest library root(s) that can be passed directly to `video_pipeline_relocate_existing_files.roots`** for the just-corrected paths.
+- Root inference order is: (1) library layout (`<root>\<program>\<year>\<month>\<file>`), (2) old title folder segment, (3) drive-root fallback.
+- This keeps chaining stable when `program_title` has already been corrected but physical paths still use old/contaminated folders.
+
 ```
 video_pipeline_relocate_existing_files {
   "apply": false,


### PR DESCRIPTION
### Motivation
- Make `affectedRoots` deterministic and robust when `program_title` has been corrected but physical paths still contain old/contaminated folder names so the chain into `video_pipeline_relocate_existing_files` can be called reliably.
- Move heuristic logic out of `update_program_titles` into a testable helper to centralize the inference contract and reduce fragile string-matching spread across the codebase.

### Description
- Added `py/relocate_scope_resolver.py` which implements `resolve_affected_roots()` with layered precedence: (1) structural library-layout inference (`<root>\\<program>\\<year>\\<month>\\<file>`), (2) old-title folder-segment fallback, (3) drive-root fallback.
- Updated `py/update_program_titles.py` to call `resolve_affected_roots()` and replace the previous ad-hoc path/title matching logic with the shared resolver.
- Added unit tests `py/tests/test_relocate_scope_resolver.py` covering structural inference, old-title fallback, and drive-root fallback.
- Documented the `affectedRoots` contract and inference order in `skills/folder-cleanup/SKILL.md` so downstream SKILLs/agents know the exact semantics.

### Testing
- Ran unit tests with `PYTHONPATH=py python -m unittest discover -s py/tests` and all tests passed (`OK`).
- Verified syntax/compilation using `python -m py_compile py/update_program_titles.py py/relocate_scope_resolver.py py/tests/test_relocate_scope_resolver.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c256301ff483298a673764c8ab2c38)