### PR TITLE
Harden affectedRoots inference for update_program_titles chaining

### DIFF
--- a/py/update_program_titles.py
+++ b/py/update_program_titles.py
@@ -23,10 +23,70 @@ import argparse
 import json
 import sqlite3
 import sys
+from pathlib import PureWindowsPath
 
 from epg_common import normalize_program_key, program_id_for
 from mediaops_schema import begin_immediate, connect_db
+from path_placement_rules import safe_dir_name
 from pathscan_common import now_iso
+
+
+def _infer_library_root_from_layout(path: str) -> str | None:
+    """Infer managed library root from by_program_year_month path shape.
+
+    Expected suffix: <program_folder>/<YYYY>/<MM>/<filename>.
+    Returns parent directory before <program_folder> when confidently detected.
+    """
+    p = PureWindowsPath(str(path or "").replace("/", "\\"))
+    if not p.name:
+        return None
+    month_dir = p.parent
+    year_dir = month_dir.parent
+    program_dir = year_dir.parent
+    if not month_dir.name or not year_dir.name or not program_dir.name:
+        return None
+    month = month_dir.name
+    year = year_dir.name
+    if not (len(year) == 4 and year.isdigit() and len(month) == 2 and month.isdigit()):
+        return None
+    month_num = int(month)
+    if month_num < 1 or month_num > 12:
+        return None
+    root = program_dir.parent
+    root_s = str(root).rstrip("\\")
+    return root_s or None
+
+
+def _fallback_root_by_old_title(path: str, old_titles: set[str]) -> str | None:
+    """Fallback root inference using old title folder segment match."""
+    if not old_titles:
+        return None
+    p = PureWindowsPath(str(path or "").replace("/", "\\"))
+    title_variants: set[str] = set()
+    for title in old_titles:
+        t = str(title or "").strip()
+        if not t:
+            continue
+        title_variants.add(t)
+        title_variants.add(safe_dir_name(t))
+    parts = list(p.parts)
+    if not parts:
+        return None
+    # Skip anchor (e.g. "B:\") while scanning for title folder.
+    start = 1 if p.anchor else 0
+    for i in range(start, len(parts)):
+        if parts[i] in title_variants and i > 0:
+            root = PureWindowsPath(*parts[:i])
+            root_s = str(root).rstrip("\\")
+            return root_s or None
+    return None
+
+
+def _drive_root(path: str) -> str | None:
+    p = PureWindowsPath(str(path or "").replace("/", "\\"))
+    if p.drive:
+        return f"{p.drive}\\"
+    return None
 
 
 def main() -> int:
@@ -125,17 +185,13 @@ def main() -> int:
         roots: set[str] = set()
         for row in path_rows:
             path = str(row["path"] or "")
-            # Find dest_root: parent directory of the program_title folder segment
-            # e.g. B:\VideoLibrary\番組名\2026\03\file.ts → B:\VideoLibrary
-            parts = path.replace("/", "\\").split("\\")
-            for i, seg in enumerate(parts):
-                if seg in old_titles and i > 0:
-                    roots.add("\\".join(parts[:i]))
-                    break
-            else:
-                # Fallback: drive letter root
-                if len(path) >= 3 and path[1:3] == ":\\":
-                    roots.add(path[:3].upper())
+            root = (
+                _infer_library_root_from_layout(path)
+                or _fallback_root_by_old_title(path, old_titles)
+                or _drive_root(path)
+            )
+            if root:
+                roots.add(root)
         affected_roots = sorted(roots)
     result["affectedRoots"] = affected_roots
 

--- a/skills/folder-cleanup/SKILL.md
+++ b/skills/folder-cleanup/SKILL.md
@@ -124,7 +124,14 @@ video_pipeline_update_program_titles {
 ### Step 5: Relocate dry-run
 
 After title correction, run relocate to move files to correct folders.
-Use `affectedRoots` returned by `video_pipeline_update_program_titles` as the default `roots` value (fallback: parent directory of affected folders):
+Use `affectedRoots` returned by `video_pipeline_update_program_titles` as the default `roots` value.
+`affectedRoots` is computed as:
+
+1. Structural inference from managed layout (`...\\<program_folder>\\<YYYY>\\<MM>\\<file>`) → return parent before `<program_folder>`
+2. Fallback: old-title folder-segment match
+3. Last resort: drive root
+
+So it remains stable even when metadata title is already corrected but the physical path still has old/contaminated folder names.
 
 ```
 video_pipeline_relocate_existing_files {


### PR DESCRIPTION
### Motivation
- `affectedRoots` returned by `video_pipeline_update_program_titles` must be stable and directly passable to `video_pipeline_relocate_existing_files` even when `path_metadata.program_title` has already been updated but physical paths still contain old/contaminated folder names.
- The previous single-step old-title string match is fragile because `safe_dir_name()` sanitization/truncation often makes folder names differ from `program_title` text.

### Description
- Implemented layered root inference in `py/update_program_titles.py` with three helpers: ` _infer_library_root_from_layout` (primary structural detection for `...\<program>\<YYYY>\<MM>\<file>`), `_fallback_root_by_old_title` (fallback match including `safe_dir_name()` variants), and `_drive_root` (last-resort drive-root). 
- Replaced the old inline segment-scan logic with a call sequence that tries structural inference, then old-title variants, then drive root, and collects unique normalized roots into `result['affectedRoots']`.
- Added an import of `safe_dir_name` from `path_placement_rules` and used it to create title variants for more robust matching.
- Documented the new `affectedRoots` precedence and stability guarantee in `skills/folder-cleanup/SKILL.md` so agent/skill flows can rely on the contract.

### Testing
- Ran Python bytecode compile with `python -m py_compile py/update_program_titles.py`, which completed successfully. 
- Performed a smoke test of the new helpers with `PYTHONPATH=py python - <<'PY' ...` which confirmed structural inference returns the expected library root (`B:\VideoLibrary`) and the old-title fallback returned `None` for the provided sample, indicating correct precedence behavior. 
- No unit test suite exists for this script; the above checks are the automated validations performed and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c256301ff483298a673764c8ab2c38)