### PR TITLE
[codex] fix issue97 review yaml handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ flowchart TD
     style S2_DB fill:#1565c0,color:#fff
 ```
 
+`video_pipeline_analyze_and_move_videos` の dry-run は、`queue_unwatched_batch_*.jsonl` 生成後に内部で rule-based `reextract` まで進む。レビューが必要な抽出結果が残った場合は、`program_aliases_review_*.yaml` を自動生成し、結果JSONに `reviewYamlPath` / `reviewYamlPaths` を返す。手動で `video_pipeline_reextract` を呼ぶのは、既存キューを個別再処理したい場合の補助フロー。
+
 ---
 
 ## 4. Relocateフロー
@@ -319,6 +321,8 @@ sourceRoot (未視聴フォルダ) のファイルを棚卸し、メタデータ
 | `allowNeedsReview` | boolean | `needs_review=true`のファイルも移動対象に含める (default: false)              |
 
 内部で `unwatched_pipeline_runner.py` を実行し、`drive_routes.yaml` に基づくジャンルルーティングを適用する。
+
+dry-run (`apply=false`) 時は inventory → queue生成 → rule-based `reextract` → move plan まで一括で実行する。`reextract` 結果に `needs_review` 行が残った場合は、`llm/` 配下に `program_aliases_review_*.yaml` を自動生成し、結果JSONに `reviewYamlPath` / `reviewYamlPaths` / `reviewSummary` を含める。この分岐では `followUpToolCalls` は `video_pipeline_apply_reviewed_metadata` を案内し、追加の `reextract` 呼び出しは不要。
 
 ---
 
@@ -543,6 +547,8 @@ flowchart TD
     RELOC_QUEUE --> OUTPUT
     DB --> RELOC_PLAN --> RELOC_APPLY
 ```
+
+未視聴フロー (`video_pipeline_analyze_and_move_videos`) では、dry-run 実行中に `QUEUE -> OUTPUT -> YAML` まで自動で進む。`reviewSummary.rowsNeedingReview > 0` の場合だけ `program_aliases_review_*.yaml` が生成され、生成パスは tool/script の戻り値から参照する。
 
 ### windowsOpsRoot ディレクトリ構成
 

--- a/py/export_program_yaml.py
+++ b/py/export_program_yaml.py
@@ -1,0 +1,392 @@
+"""Export reviewed candidate program info YAML from extracted metadata JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import unicodedata
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+MAX_REVIEW_CANDIDATES = 50
+MAX_PREVIEW_CHARS = 220
+
+
+def json_scalar(value: Any) -> str:
+    return json.dumps("" if value is None else value, ensure_ascii=False)
+
+
+def as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def preview_text(value: Any, max_chars: int = MAX_PREVIEW_CHARS) -> str | None:
+    text = as_str(value).strip()
+    if not text:
+        return None
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max_chars - 1]}…"
+
+
+def is_iso_date(text: str) -> bool:
+    return bool(re.fullmatch(r"\d{4}-\d{2}-\d{2}", text))
+
+
+def push_count(counts: dict[str, int], key: str) -> None:
+    counts[key] = counts.get(key, 0) + 1
+
+
+def append_unique(items: list[str], value: str) -> None:
+    if value and value not in items:
+        items.append(value)
+
+
+def lower_compact(text: str) -> str:
+    return re.sub(r'[<>:"/\\|?*\s]+', "", unicodedata.normalize("NFKC", str(text or "")).lower())
+
+
+def by_program_group_from_path(win_path: str | None) -> str | None:
+    parts = [part for part in re.split(r"[\\/]+", str(win_path or "")) if part]
+    for idx, part in enumerate(parts):
+        if part.lower() == "by_program" and idx + 1 < len(parts):
+            return parts[idx + 1]
+    for idx, part in enumerate(parts):
+        if part.lower() == "videolibrary" and idx + 1 < len(parts):
+            return parts[idx + 1]
+    return None
+
+
+def looks_swallowed_program_title(program_title: str, folder_title: str) -> bool:
+    program = program_title.strip()
+    folder = folder_title.strip()
+    if not program or not folder or program == folder:
+        return False
+    program_norm = lower_compact(program)
+    folder_norm = lower_compact(folder)
+    if not program_norm or not folder_norm or not program_norm.startswith(folder_norm):
+        return False
+    return len(program_norm) >= len(folder_norm) + 8
+
+
+def sha256_short(content: str, length: int = 16) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:length]
+
+
+def read_jsonl_rows(source_jsonl_path: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    raw = Path(source_jsonl_path).read_text(encoding="utf-8")
+    text = raw[1:] if raw.startswith("\ufeff") else raw
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except Exception:
+            continue
+        if isinstance(obj, dict) and "_meta" not in obj:
+            rows.append(obj)
+    return rows
+
+
+def build_review_diagnostics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    field_counts: dict[str, int] = {}
+    reason_counts: dict[str, int] = {}
+    candidates: list[dict[str, Any]] = []
+    rows_needing_review = 0
+    required_field_missing_rows = 0
+    invalid_air_date_rows = 0
+    needs_review_flag_rows = 0
+    suspicious_program_title_rows = 0
+
+    for row in rows:
+        columns: list[str] = []
+        reasons: list[str] = []
+        severity = "review"
+        program_title = as_str(row.get("program_title")).strip()
+        air_date = as_str(row.get("air_date")).strip()
+        needs_review = row.get("needs_review") is True
+        needs_review_reason = as_str(row.get("needs_review_reason")).strip()
+        path_value = as_str(row.get("path")).strip()
+
+        if not program_title:
+            append_unique(columns, "program_title")
+            append_unique(reasons, "missing_program_title")
+            severity = "required"
+        if not air_date:
+            append_unique(columns, "air_date")
+            append_unique(reasons, "missing_air_date")
+            severity = "required"
+        elif not is_iso_date(air_date):
+            append_unique(columns, "air_date")
+            append_unique(reasons, "invalid_air_date")
+            severity = "required"
+        if not isinstance(row.get("needs_review"), bool):
+            append_unique(columns, "needs_review")
+            append_unique(reasons, "missing_or_invalid_needs_review")
+            severity = "required"
+        if needs_review:
+            append_unique(columns, "needs_review")
+            if needs_review_reason:
+                append_unique(columns, "needs_review_reason")
+            append_unique(reasons, needs_review_reason or "needs_review_flagged")
+
+        folder_title = by_program_group_from_path(path_value)
+        if folder_title and program_title and looks_swallowed_program_title(program_title, folder_title):
+            append_unique(columns, "program_title")
+            append_unique(reasons, "program_title_may_include_description")
+
+        if not reasons:
+            continue
+
+        rows_needing_review += 1
+        if any(reason.startswith("missing_") or reason in {"invalid_air_date", "missing_or_invalid_needs_review"} for reason in reasons):
+            required_field_missing_rows += 1
+        if "invalid_air_date" in reasons:
+            invalid_air_date_rows += 1
+        if needs_review:
+            needs_review_flag_rows += 1
+        if "program_title_may_include_description" in reasons:
+            suspicious_program_title_rows += 1
+        for column in columns:
+            push_count(field_counts, column)
+        for reason in reasons:
+            push_count(reason_counts, reason)
+
+        if len(candidates) < MAX_REVIEW_CANDIDATES:
+            evidence = row.get("evidence")
+            evidence_raw = evidence.get("raw") if isinstance(evidence, dict) else None
+            candidates.append(
+                {
+                    "pathId": row.get("path_id") if isinstance(row.get("path_id"), str) else None,
+                    "path": path_value,
+                    "columns": columns,
+                    "reasons": reasons,
+                    "severity": severity,
+                    "folderTitle": folder_title,
+                    "current": {
+                        "program_title": preview_text(row.get("program_title")),
+                        "air_date": preview_text(row.get("air_date")),
+                        "subtitle": preview_text(row.get("subtitle")),
+                        "needs_review": row.get("needs_review") if isinstance(row.get("needs_review"), bool) else None,
+                        "needs_review_reason": preview_text(row.get("needs_review_reason")),
+                    },
+                    "evidence": {
+                        "raw": preview_text(evidence_raw),
+                    },
+                }
+            )
+
+    return {
+        "summary": {
+            "rowsNeedingReview": rows_needing_review,
+            "requiredFieldMissingRows": required_field_missing_rows,
+            "invalidAirDateRows": invalid_air_date_rows,
+            "needsReviewFlagRows": needs_review_flag_rows,
+            "suspiciousProgramTitleRows": suspicious_program_title_rows,
+            "fieldCounts": field_counts,
+            "reasonCounts": reason_counts,
+        },
+        "candidates": candidates,
+        "truncated": rows_needing_review > len(candidates),
+    }
+
+
+def build_yaml(
+    source_jsonl_path: str,
+    rows_total: int,
+    rows_used: int,
+    include_needs_review: bool,
+    include_unknown: bool,
+    stats: list[dict[str, Any]],
+    cohort: dict[str, Any] | None = None,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Auto-generated candidate YAML from extraction output.")
+    lines.append("# Review manually before using as production hints.")
+    lines.append(f"generated_at: {json_scalar(datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))}")
+    lines.append(f"source_jsonl: {json_scalar(source_jsonl_path)}")
+    lines.append(f"rows_total: {rows_total}")
+    lines.append(f"rows_used: {rows_used}")
+    if cohort:
+        lines.append("cohort:")
+        lines.append(f"  source_jsonl_sha256: {json_scalar(cohort['sourceJsonlSha256'])}")
+        lines.append(f"  path_id_count: {cohort['pathIdCount']}")
+        lines.append(f"  path_id_set_hash: {json_scalar(cohort['pathIdSetHash'])}")
+    lines.append("filters:")
+    lines.append(f"  include_needs_review: {'true' if include_needs_review else 'false'}")
+    lines.append(f"  include_unknown: {'true' if include_unknown else 'false'}")
+    lines.append("hints:")
+    for stat in stats:
+        lines.append(f"  - canonical_title: {json_scalar(stat['canonicalTitle'])}")
+        lines.append("    aliases:")
+        lines.append(f"      - {json_scalar(stat['canonicalTitle'])}")
+        lines.append("    stats:")
+        lines.append(f"      count: {stat['count']}")
+        lines.append(f"      needs_review_count: {stat['needsReviewCount']}")
+        lines.append("    samples:")
+        sample_paths = stat.get("samplePaths", [])
+        sample_raw_names = stat.get("sampleRawNames", [])
+        if not sample_paths and not sample_raw_names:
+            lines.append("      - {}")
+        else:
+            sample_count = max(len(sample_paths), len(sample_raw_names))
+            for index in range(sample_count):
+                lines.append(f"      - path: {json_scalar(sample_paths[index] if index < len(sample_paths) else '')}")
+                lines.append(f"        raw: {json_scalar(sample_raw_names[index] if index < len(sample_raw_names) else '')}")
+    return "\n".join(lines) + "\n"
+
+
+def default_output_path_for_source(source_jsonl_path: str, output_path: str | None = None) -> str:
+    if output_path:
+        return output_path
+    source_path = Path(source_jsonl_path)
+    source_name = source_path.name
+    if source_name.startswith("llm_filename_extract_output_") and source_name.endswith(".jsonl"):
+        suffix = source_name[len("llm_filename_extract_output_") : -len(".jsonl")]
+        return str(source_path.with_name(f"program_aliases_review_{suffix}.yaml"))
+    return str(source_path.with_name(f"{source_path.stem}_review.yaml"))
+
+
+def generate_review_yaml(
+    source_jsonl_path: str,
+    output_path: str | None = None,
+    *,
+    include_needs_review: bool = True,
+    include_unknown: bool = False,
+    max_samples_per_program: int = 3,
+    only_if_reviewable: bool = False,
+) -> dict[str, Any]:
+    if not os.path.exists(source_jsonl_path):
+        return {
+            "ok": False,
+            "tool": "export_program_yaml",
+            "error": f"sourceJsonlPath does not exist: {source_jsonl_path}",
+        }
+
+    rows = read_jsonl_rows(source_jsonl_path)
+    review = build_review_diagnostics(rows)
+    if only_if_reviewable and review["summary"]["rowsNeedingReview"] <= 0:
+        return {
+            "ok": True,
+            "tool": "export_program_yaml",
+            "sourceJsonlPath": source_jsonl_path,
+            "outputPath": None,
+            "rowsTotal": len(rows),
+            "rowsUsed": 0,
+            "programs": 0,
+            "includeNeedsReview": include_needs_review,
+            "includeUnknown": include_unknown,
+            "maxSamplesPerProgram": max_samples_per_program,
+            "reviewSummary": review["summary"],
+            "reviewCandidates": review["candidates"],
+            "reviewCandidatesTruncated": review["truncated"],
+            "skippedReason": "no_reviewable_rows",
+        }
+
+    source_content = Path(source_jsonl_path).read_text(encoding="utf-8")
+    path_ids = [row.get("path_id") for row in rows if isinstance(row.get("path_id"), str) and row.get("path_id")]
+    cohort = {
+        "sourceJsonlSha256": sha256_short(source_content),
+        "pathIdCount": len(path_ids),
+        "pathIdSetHash": sha256_short("\n".join(sorted(path_ids))),
+    }
+
+    stats_map: dict[str, dict[str, Any]] = {}
+    rows_used = 0
+    max_samples = max(1, int(max_samples_per_program))
+
+    for row in rows:
+        title = as_str(row.get("program_title")).strip()
+        if not title:
+            continue
+        if not include_unknown and title == "UNKNOWN":
+            continue
+        needs_review = row.get("needs_review") is True
+        if not include_needs_review and needs_review:
+            continue
+        normalized_program_key = lower_compact(title)
+        key = f"{title}::{normalized_program_key}"
+        current = stats_map.get(key) or {
+            "canonicalTitle": title,
+            "normalizedProgramKey": normalized_program_key,
+            "count": 0,
+            "needsReviewCount": 0,
+            "samplePaths": [],
+            "sampleRawNames": [],
+        }
+        current["count"] += 1
+        if needs_review:
+            current["needsReviewCount"] += 1
+        if len(current["samplePaths"]) < max_samples and isinstance(row.get("path"), str):
+            current["samplePaths"].append(str(row["path"]))
+        evidence = row.get("evidence")
+        raw_name = evidence.get("raw") if isinstance(evidence, dict) else None
+        if len(current["sampleRawNames"]) < max_samples and isinstance(raw_name, str):
+            current["sampleRawNames"].append(raw_name)
+        stats_map[key] = current
+        rows_used += 1
+
+    stats = sorted(stats_map.values(), key=lambda item: item["canonicalTitle"])
+    resolved_output_path = default_output_path_for_source(source_jsonl_path, output_path)
+    yaml_text = build_yaml(
+        source_jsonl_path,
+        len(rows),
+        rows_used,
+        include_needs_review,
+        include_unknown,
+        stats,
+        cohort,
+    )
+
+    Path(resolved_output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(resolved_output_path).write_text(yaml_text, encoding="utf-8")
+
+    return {
+        "ok": True,
+        "tool": "export_program_yaml",
+        "sourceJsonlPath": source_jsonl_path,
+        "outputPath": resolved_output_path,
+        "rowsTotal": len(rows),
+        "rowsUsed": rows_used,
+        "programs": len(stats),
+        "includeNeedsReview": include_needs_review,
+        "includeUnknown": include_unknown,
+        "maxSamplesPerProgram": max_samples,
+        "cohort": cohort,
+        "reviewSummary": review["summary"],
+        "reviewCandidates": review["candidates"],
+        "reviewCandidatesTruncated": review["truncated"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-jsonl", required=True)
+    parser.add_argument("--output", default="")
+    parser.add_argument("--exclude-needs-review", action="store_true")
+    parser.add_argument("--include-unknown", action="store_true")
+    parser.add_argument("--max-samples-per-program", type=int, default=3)
+    parser.add_argument("--only-if-reviewable", action="store_true")
+    args = parser.parse_args()
+
+    result = generate_review_yaml(
+        args.source_jsonl,
+        args.output or None,
+        include_needs_review=not bool(args.exclude_needs_review),
+        include_unknown=bool(args.include_unknown),
+        max_samples_per_program=args.max_samples_per_program,
+        only_if_reviewable=bool(args.only_if_reviewable),
+    )
+    print(json.dumps(result, ensure_ascii=False))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/tests/test_export_program_yaml.py
+++ b/py/tests/test_export_program_yaml.py
@@ -1,0 +1,72 @@
+import json
+
+from export_program_yaml import default_output_path_for_source, generate_review_yaml
+
+
+def write_jsonl(path, rows):
+    path.write_text("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n", encoding="utf-8")
+
+
+def test_default_output_path_uses_program_aliases_prefix_for_extract_outputs(tmp_path) -> None:
+    source = tmp_path / "llm_filename_extract_output_0001_0013.jsonl"
+    assert default_output_path_for_source(str(source)) == str(tmp_path / "program_aliases_review_0001_0013.yaml")
+
+
+def test_generate_review_yaml_creates_yaml_and_review_summary(tmp_path) -> None:
+    source = tmp_path / "llm_filename_extract_output_0001_0013.jsonl"
+    write_jsonl(source, [
+        {
+            "path_id": "p1",
+            "path": r"B:\VideoLibrary\番組A\2026\04\ep1.ts",
+            "program_title": "番組A",
+            "air_date": "2026-04-07",
+            "subtitle": "第1話",
+            "needs_review": True,
+            "needs_review_reason": "suspicious_program_title",
+            "evidence": {"raw": "番組A 2026_04_07.ts"},
+        },
+        {
+            "path_id": "p2",
+            "path": r"B:\VideoLibrary\番組B\2026\04\ep2.ts",
+            "program_title": "UNKNOWN",
+            "air_date": "2026-04-08",
+            "subtitle": None,
+            "needs_review": True,
+            "needs_review_reason": "unknown_program_title",
+            "evidence": {"raw": "UNKNOWN.ts"},
+        },
+    ])
+
+    result = generate_review_yaml(str(source), only_if_reviewable=True)
+
+    assert result["ok"] is True
+    assert result["outputPath"] == str(tmp_path / "program_aliases_review_0001_0013.yaml")
+    assert result["reviewSummary"]["rowsNeedingReview"] == 2
+    assert result["reviewSummary"]["needsReviewFlagRows"] == 2
+    yaml_text = (tmp_path / "program_aliases_review_0001_0013.yaml").read_text(encoding="utf-8")
+    assert "source_jsonl:" in yaml_text
+    assert '"番組A"' in yaml_text
+    assert '"UNKNOWN"' not in yaml_text
+
+
+def test_generate_review_yaml_skips_output_when_no_reviewable_rows(tmp_path) -> None:
+    source = tmp_path / "llm_filename_extract_output_0002_0001.jsonl"
+    write_jsonl(source, [
+        {
+            "path_id": "p1",
+            "path": r"B:\VideoLibrary\番組A\2026\04\ep1.ts",
+            "program_title": "番組A",
+            "air_date": "2026-04-07",
+            "subtitle": "第1話",
+            "needs_review": False,
+            "needs_review_reason": "",
+            "evidence": {"raw": "番組A 2026_04_07.ts"},
+        },
+    ])
+
+    result = generate_review_yaml(str(source), only_if_reviewable=True)
+
+    assert result["ok"] is True
+    assert result["outputPath"] is None
+    assert result["skippedReason"] == "no_reviewable_rows"
+

--- a/py/tests/test_unwatched_pipeline_runner.py
+++ b/py/tests/test_unwatched_pipeline_runner.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+from unwatched_pipeline_runner import export_review_yaml_artifacts
+
+
+def test_export_review_yaml_artifacts_aggregates_single_review_yaml(tmp_path) -> None:
+    output_jsonl = tmp_path / "llm_filename_extract_output_0001_0013.jsonl"
+    output_jsonl.write_text("", encoding="utf-8")
+
+    def fake_runner(script: Path, args: list[str], cwd: str | None = None) -> str:
+        assert script.name == "export_program_yaml.py"
+        assert "--source-jsonl" in args
+        return json.dumps(
+            {
+                "ok": True,
+                "outputPath": str(tmp_path / "program_aliases_review_0001_0013.yaml"),
+                "sourceJsonlPath": str(output_jsonl),
+                "reviewSummary": {
+                    "rowsNeedingReview": 13,
+                    "requiredFieldMissingRows": 1,
+                    "invalidAirDateRows": 0,
+                    "needsReviewFlagRows": 13,
+                    "suspiciousProgramTitleRows": 2,
+                    "fieldCounts": {"program_title": 13},
+                    "reasonCounts": {"suspicious_program_title": 13},
+                },
+                "reviewCandidates": [
+                    {
+                        "path": r"B:\VideoLibrary\番組A\2026\04\ep1.ts",
+                        "columns": ["program_title"],
+                        "reasons": ["suspicious_program_title"],
+                    },
+                ],
+                "reviewCandidatesTruncated": False,
+            },
+            ensure_ascii=False,
+        )
+
+    result = export_review_yaml_artifacts([str(output_jsonl)], tmp_path / "export_program_yaml.py", cwd=str(tmp_path), runner=fake_runner)
+
+    assert result["ok"] is True
+    assert result["reviewYamlPath"] == str(tmp_path / "program_aliases_review_0001_0013.yaml")
+    assert result["reviewYamlPaths"] == [str(tmp_path / "program_aliases_review_0001_0013.yaml")]
+    assert result["reviewSummary"]["rowsNeedingReview"] == 13
+    assert len(result["reviewCandidates"]) == 1
+
+
+def test_export_review_yaml_artifacts_ignores_non_reviewable_batches(tmp_path) -> None:
+    batch1 = tmp_path / "llm_filename_extract_output_0001_0013.jsonl"
+    batch2 = tmp_path / "llm_filename_extract_output_0002_0001.jsonl"
+    batch1.write_text("", encoding="utf-8")
+    batch2.write_text("", encoding="utf-8")
+
+    def fake_runner(script: Path, args: list[str], cwd: str | None = None) -> str:
+        source = args[args.index("--source-jsonl") + 1]
+        if source.endswith("0001_0013.jsonl"):
+            return json.dumps(
+                {
+                    "ok": True,
+                    "outputPath": str(tmp_path / "program_aliases_review_0001_0013.yaml"),
+                    "sourceJsonlPath": source,
+                    "reviewSummary": {
+                        "rowsNeedingReview": 13,
+                        "requiredFieldMissingRows": 0,
+                        "invalidAirDateRows": 0,
+                        "needsReviewFlagRows": 13,
+                        "suspiciousProgramTitleRows": 0,
+                        "fieldCounts": {"needs_review": 13},
+                        "reasonCounts": {"needs_review_flagged": 13},
+                    },
+                    "reviewCandidates": [],
+                    "reviewCandidatesTruncated": False,
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {
+                "ok": True,
+                "outputPath": None,
+                "sourceJsonlPath": source,
+                "reviewSummary": {
+                    "rowsNeedingReview": 0,
+                    "requiredFieldMissingRows": 0,
+                    "invalidAirDateRows": 0,
+                    "needsReviewFlagRows": 0,
+                    "suspiciousProgramTitleRows": 0,
+                    "fieldCounts": {},
+                    "reasonCounts": {},
+                },
+                "reviewCandidates": [],
+                "reviewCandidatesTruncated": False,
+                "skippedReason": "no_reviewable_rows",
+            },
+            ensure_ascii=False,
+        )
+
+    result = export_review_yaml_artifacts(
+        [str(batch1), str(batch2)],
+        tmp_path / "export_program_yaml.py",
+        cwd=str(tmp_path),
+        runner=fake_runner,
+    )
+
+    assert result["ok"] is True
+    assert result["reviewYamlPaths"] == [str(tmp_path / "program_aliases_review_0001_0013.yaml")]
+    assert result["reviewSummary"]["rowsNeedingReview"] == 13
+
+
+def test_export_review_yaml_artifacts_reports_export_failure(tmp_path) -> None:
+    batch = tmp_path / "llm_filename_extract_output_0001_0013.jsonl"
+    batch.write_text("", encoding="utf-8")
+
+    def fake_runner(script: Path, args: list[str], cwd: str | None = None) -> str:
+        return json.dumps({"ok": False, "error": "boom"}, ensure_ascii=False)
+
+    result = export_review_yaml_artifacts([str(batch)], tmp_path / "export_program_yaml.py", cwd=str(tmp_path), runner=fake_runner)
+
+    assert result["ok"] is False
+    assert result["error"] == f"failed to export review YAML for {batch}"

--- a/py/tests/test_unwatched_pipeline_runner.py
+++ b/py/tests/test_unwatched_pipeline_runner.py
@@ -118,3 +118,18 @@ def test_export_review_yaml_artifacts_reports_export_failure(tmp_path) -> None:
 
     assert result["ok"] is False
     assert result["error"] == f"failed to export review YAML for {batch}"
+
+
+def test_export_review_yaml_artifacts_reports_runner_exception(tmp_path) -> None:
+    batch = tmp_path / "llm_filename_extract_output_0001_0013.jsonl"
+    batch.write_text("", encoding="utf-8")
+
+    def fake_runner(script: Path, args: list[str], cwd: str | None = None) -> str:
+        raise RuntimeError("python failed rc=1: export_program_yaml.py")
+
+    result = export_review_yaml_artifacts([str(batch)], tmp_path / "export_program_yaml.py", cwd=str(tmp_path), runner=fake_runner)
+
+    assert result["ok"] is False
+    assert result["error"] == f"failed to export review YAML for {batch}"
+    assert result["exception"] == "python failed rc=1: export_program_yaml.py"
+    assert result["raw"] is None

--- a/py/unwatched_pipeline_runner.py
+++ b/py/unwatched_pipeline_runner.py
@@ -112,15 +112,25 @@ def export_review_yaml_artifacts(
     review_candidates_truncated = False
 
     for output_jsonl_path in output_jsonl_paths:
-        raw = runner(
-            export_script,
-            [
-                "--source-jsonl",
-                output_jsonl_path,
-                "--only-if-reviewable",
-            ],
-            cwd,
-        )
+        try:
+            raw = runner(
+                export_script,
+                [
+                    "--source-jsonl",
+                    output_jsonl_path,
+                    "--only-if-reviewable",
+                ],
+                cwd,
+            )
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": f"failed to export review YAML for {output_jsonl_path}",
+                "sourceJsonlPath": output_jsonl_path,
+                "raw": None,
+                "parsed": None,
+                "exception": str(exc),
+            }
         parsed = parse_last_json_object_line(raw)
         if not isinstance(parsed, dict) or parsed.get("ok") is not True:
             return {

--- a/py/unwatched_pipeline_runner.py
+++ b/py/unwatched_pipeline_runner.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Callable
 
 from move_apply_stats import aggregate_move_apply
 from windows_pwsh_bridge import canonicalize_windows_path, run_pwsh_json
@@ -47,6 +48,109 @@ def run_py(cmd: list[str], env: dict[str, str] | None = None, cwd: str | None = 
 
 def run_py_uv(script: Path, args: list[str], cwd: str | None = None) -> str:
     return run_py(["uv", "run", "python", str(script), *args], cwd=cwd)
+
+
+def parse_last_json_object_line(output: str) -> dict[str, Any] | None:
+    if not isinstance(output, str):
+        return None
+    for line in reversed(output.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def string_array(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def aggregate_review_summaries(results: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = {
+        "rowsNeedingReview": 0,
+        "requiredFieldMissingRows": 0,
+        "invalidAirDateRows": 0,
+        "needsReviewFlagRows": 0,
+        "suspiciousProgramTitleRows": 0,
+        "fieldCounts": {},
+        "reasonCounts": {},
+    }
+    for result in results:
+        review_summary = result.get("reviewSummary")
+        if not isinstance(review_summary, dict):
+            continue
+        summary["rowsNeedingReview"] += int(review_summary.get("rowsNeedingReview") or 0)
+        summary["requiredFieldMissingRows"] += int(review_summary.get("requiredFieldMissingRows") or 0)
+        summary["invalidAirDateRows"] += int(review_summary.get("invalidAirDateRows") or 0)
+        summary["needsReviewFlagRows"] += int(review_summary.get("needsReviewFlagRows") or 0)
+        summary["suspiciousProgramTitleRows"] += int(review_summary.get("suspiciousProgramTitleRows") or 0)
+        for key, value in (review_summary.get("fieldCounts") or {}).items():
+            if isinstance(key, str):
+                summary["fieldCounts"][key] = int(summary["fieldCounts"].get(key, 0)) + int(value or 0)
+        for key, value in (review_summary.get("reasonCounts") or {}).items():
+            if isinstance(key, str):
+                summary["reasonCounts"][key] = int(summary["reasonCounts"].get(key, 0)) + int(value or 0)
+    return summary
+
+
+def export_review_yaml_artifacts(
+    output_jsonl_paths: list[str],
+    export_script: Path,
+    *,
+    cwd: str,
+    runner: Callable[[Path, list[str], str | None], str] = run_py_uv,
+) -> dict[str, Any]:
+    artifacts: list[dict[str, Any]] = []
+    review_candidates: list[dict[str, Any]] = []
+    review_candidates_truncated = False
+
+    for output_jsonl_path in output_jsonl_paths:
+        raw = runner(
+            export_script,
+            [
+                "--source-jsonl",
+                output_jsonl_path,
+                "--only-if-reviewable",
+            ],
+            cwd,
+        )
+        parsed = parse_last_json_object_line(raw)
+        if not isinstance(parsed, dict) or parsed.get("ok") is not True:
+            return {
+                "ok": False,
+                "error": f"failed to export review YAML for {output_jsonl_path}",
+                "sourceJsonlPath": output_jsonl_path,
+                "raw": raw,
+                "parsed": parsed,
+            }
+        if not parsed.get("outputPath"):
+            continue
+        artifacts.append(parsed)
+        for candidate in parsed.get("reviewCandidates") or []:
+            if len(review_candidates) < 50 and isinstance(candidate, dict):
+                review_candidates.append(candidate)
+            else:
+                review_candidates_truncated = True
+        if parsed.get("reviewCandidatesTruncated") is True:
+            review_candidates_truncated = True
+
+    review_yaml_paths = [str(result["outputPath"]) for result in artifacts if isinstance(result.get("outputPath"), str)]
+    return {
+        "ok": True,
+        "reviewArtifacts": artifacts,
+        "reviewYamlPaths": review_yaml_paths,
+        "reviewYamlPath": review_yaml_paths[0] if len(review_yaml_paths) == 1 else None,
+        "reviewSummary": aggregate_review_summaries(artifacts),
+        "reviewCandidates": review_candidates,
+        "reviewCandidatesTruncated": review_candidates_truncated,
+    }
 
 
 def latest(move_dir: Path, glob_pat: str) -> Path:
@@ -118,6 +222,7 @@ def main() -> int:
     ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     here = Path(__file__).resolve().parent
     hints_yaml = here.parent / "rules" / "program_aliases.yaml"
+    export_yaml_script = here / "export_program_yaml.py"
 
     inv_meta = run_pwsh_json(
         scripts_root_win + r"\unwatched_inventory.ps1",
@@ -150,7 +255,7 @@ def main() -> int:
         cwd=str(here),
     )
 
-    run_py_uv(
+    reextract_raw = run_py_uv(
         here / "run_metadata_batches_promptv1.py",
         [
             "--db",
@@ -168,6 +273,11 @@ def main() -> int:
         ],
         cwd=str(here),
     )
+    reextract_parsed = parse_last_json_object_line(reextract_raw) or {}
+    reextract_output_jsonl_paths = string_array(reextract_parsed.get("outputJsonlPaths"))
+    latest_output_jsonl_path = reextract_parsed.get("latestOutputJsonlPath")
+    if not reextract_output_jsonl_paths and isinstance(latest_output_jsonl_path, str) and latest_output_jsonl_path:
+        reextract_output_jsonl_paths = [latest_output_jsonl_path]
 
     plan_cmd = [
         "--db",
@@ -197,7 +307,8 @@ def main() -> int:
     plan_stats = plan_out if isinstance(plan_out, dict) else {}
     planned = int(plan_stats.get("planned", 0))
 
-    summary: dict = {
+    summary: dict[str, Any] = {
+        "ok": True,
         "inventory": str(inv),
         "queue": str(queue),
         "plan": str(plan),
@@ -205,7 +316,39 @@ def main() -> int:
         "apply": bool(args.apply),
         "windows_ops_root": str(ops_root),
         "max_files_per_run": int(args.max_files_per_run),
+        "reextract": {
+            "ok": True,
+            "queuePath": str(queue),
+            "summary": reextract_parsed,
+            "outputJsonlPaths": reextract_output_jsonl_paths,
+            "outputJsonlPath": reextract_output_jsonl_paths[-1] if reextract_output_jsonl_paths else None,
+            "raw": reextract_raw,
+        },
+        "workflowState": "relocate_plan_ready",
     }
+
+    if reextract_output_jsonl_paths:
+        review_export = export_review_yaml_artifacts(
+            reextract_output_jsonl_paths,
+            export_yaml_script,
+            cwd=str(here),
+        )
+        if not review_export.get("ok"):
+            summary["ok"] = False
+            summary["workflowState"] = "review_yaml_export_failed"
+            summary["error"] = review_export.get("error") or "failed to export review yaml artifacts"
+            summary["reviewExport"] = review_export
+            print(json.dumps(summary, ensure_ascii=False))
+            return 1
+        summary.update(review_export)
+        if summary.get("reviewYamlPaths"):
+            review_summary = summary.get("reviewSummary") or {}
+            summary["workflowState"] = "metadata_review_required"
+            summary["nextStep"] = (
+                "Human review required for extracted metadata. "
+                f"Review reviewYamlPath/reviewYamlPaths and apply corrections before relying on apply=true. "
+                f"rowsNeedingReview={int((review_summary or {}).get('rowsNeedingReview') or 0)}."
+            )
 
     if args.apply and planned > 0:
         # Stage 3: 実際にファイルを移動
@@ -239,9 +382,22 @@ def main() -> int:
         summary["applied"] = str(applied)
         summary["moveApplyStats"] = move_stats
         summary["remaining_files"] = max(inv_count - move_stats["succeeded"], 0)
+        if summary.get("reviewYamlPaths"):
+            summary["nextStep"] = (
+                "Moves were applied for ready rows, but reviewable metadata remains. "
+                "Review reviewYamlPath/reviewYamlPaths and apply corrections before the next run."
+            )
     else:
         # Dry-run: plan のみ。apply は実行しない。
         summary["remaining_files"] = inv_count
+        if not summary.get("reviewYamlPaths") and planned > 0:
+            summary["nextStep"] = (
+                f"Dry-run complete. {planned} files planned for move and no review YAML was needed. "
+                "Present the plan before calling this runner with --apply."
+            )
+        elif not summary.get("reviewYamlPaths") and planned == 0:
+            summary["workflowState"] = "no_moves_planned"
+            summary["nextStep"] = "Dry-run complete. No files planned for move. Check plan_stats for skip reasons."
 
     print(
         json.dumps(summary, ensure_ascii=False)

--- a/src/tools/tool-run.test.ts
+++ b/src/tools/tool-run.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime", async () => {
+  const actual = await vi.importActual<typeof import("./runtime")>("./runtime");
+  return {
+    ...actual,
+    getExtensionRootDir: vi.fn(() => "/ext"),
+    resolvePythonScript: vi.fn(() => ({ scriptPath: "/ext/py/unwatched_pipeline_runner.py", cwd: "/ext/py", source: "extension" })),
+    runCmd: vi.fn(),
+    toToolResult: vi.fn((obj: Record<string, unknown>) => obj),
+  };
+});
+
+vi.mock("./windows-scripts-bootstrap", () => ({
+  ensureWindowsScripts: vi.fn(() => ({
+    ok: true,
+    created: [],
+    updated: [],
+    existing: [],
+    failed: [],
+    missingTemplates: [],
+  })),
+}));
+
+import { registerToolRun } from "./tool-run";
+import { runCmd } from "./runtime";
+
+function createMockApi() {
+  return {
+    registerTool: vi.fn(),
+  };
+}
+
+function getRegisteredTool(api: ReturnType<typeof createMockApi>) {
+  const toolDefs = api.registerTool.mock.calls.map(([def]) => def);
+  const tool = toolDefs.find((def: { name: string }) => def.name === "video_pipeline_analyze_and_move_videos");
+  expect(tool).toBeTruthy();
+  return tool;
+}
+
+describe("video_pipeline_analyze_and_move_videos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes review-required runs to apply_reviewed_metadata when review YAML already exists", async () => {
+    vi.mocked(runCmd).mockReturnValue({
+      ok: true,
+      code: 0,
+      stdout: JSON.stringify({
+        ok: true,
+        queue: "/ops/llm/queue_unwatched_batch_20260407.jsonl",
+        plan_stats: { planned: 0, skipped_needs_review: 13 },
+        workflowState: "metadata_review_required",
+        reviewYamlPath: "/ops/llm/program_aliases_review_0001_0013.yaml",
+        reviewYamlPaths: ["/ops/llm/program_aliases_review_0001_0013.yaml"],
+        reviewSummary: { rowsNeedingReview: 13 },
+      }),
+      stderr: "",
+      command: "uv",
+      args: [],
+      cwd: "/ext/py",
+    });
+
+    const api = createMockApi();
+    const cfg = {
+      db: "/ops/db/mediaops.sqlite",
+      sourceRoot: "B:\\Unwatched",
+      destRoot: "B:\\VideoLibrary",
+      windowsOpsRoot: "/ops",
+      defaultMaxFilesPerRun: 200,
+      driveRoutesPath: "",
+    };
+
+    registerToolRun(api as never, () => cfg);
+    const tool = getRegisteredTool(api);
+    const result = await tool.execute("tool-call-1", { apply: false });
+
+    expect(result.reviewYamlPath).toBe("/ops/llm/program_aliases_review_0001_0013.yaml");
+    expect(result.nextStep).toContain("review");
+    expect(result.nextStep).not.toContain("video_pipeline_reextract");
+    expect(result.followUpToolCalls).toEqual([
+      {
+        tool: "video_pipeline_apply_reviewed_metadata",
+        reason: "apply_generated_review_yaml_after_human_review",
+        requiresHumanReview: true,
+        params: { sourceYamlPath: "/ops/llm/program_aliases_review_0001_0013.yaml" },
+      },
+    ]);
+    expect(result.hasFollowUpToolCalls).toBe(true);
+  });
+
+  it("keeps legacy reextract guidance when review YAML was not generated yet", async () => {
+    vi.mocked(runCmd).mockReturnValue({
+      ok: true,
+      code: 0,
+      stdout: JSON.stringify({
+        ok: true,
+        queue: "/ops/llm/queue_unwatched_batch_20260407.jsonl",
+        plan_stats: { planned: 0, skipped_needs_review: 5 },
+      }),
+      stderr: "",
+      command: "uv",
+      args: [],
+      cwd: "/ext/py",
+    });
+
+    const api = createMockApi();
+    const cfg = {
+      db: "/ops/db/mediaops.sqlite",
+      sourceRoot: "B:\\Unwatched",
+      destRoot: "B:\\VideoLibrary",
+      windowsOpsRoot: "/ops",
+      defaultMaxFilesPerRun: 200,
+      driveRoutesPath: "",
+    };
+
+    registerToolRun(api as never, () => cfg);
+    const tool = getRegisteredTool(api);
+    const result = await tool.execute("tool-call-2", { apply: false });
+
+    expect(result.nextStep).toContain("video_pipeline_reextract");
+    expect(result.followUpToolCalls).toEqual([
+      {
+        tool: "video_pipeline_reextract",
+        reason: "extract_metadata_for_needs_review_files",
+        params: { queuePath: "/ops/llm/queue_unwatched_batch_20260407.jsonl" },
+      },
+    ]);
+  });
+});

--- a/src/tools/tool-run.ts
+++ b/src/tools/tool-run.ts
@@ -3,6 +3,11 @@ import { getExtensionRootDir, parseJsonObject, resolvePythonScript, runCmd, toTo
 import type { AnyObj, PluginApi, GetCfgFn } from "./types";
 import { ensureWindowsScripts } from "./windows-scripts-bootstrap";
 
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
 export function registerToolRun(api: PluginApi, getCfg: GetCfgFn) {
   api.registerTool(
     {
@@ -98,12 +103,39 @@ export function registerToolRun(api: PluginApi, getCfg: GetCfgFn) {
           const planned = Number(planStats.planned || 0);
           const apply = params.apply === true;
           const queuePath = String(parsed.queue || "");
+          const reviewYamlPaths = stringArray(parsed.reviewYamlPaths)
+            .concat(typeof parsed.reviewYamlPath === "string" && parsed.reviewYamlPath ? [parsed.reviewYamlPath] : [])
+            .filter((value, index, arr) => arr.indexOf(value) === index);
+          const reviewSummary = parsed.reviewSummary && typeof parsed.reviewSummary === "object"
+            ? parsed.reviewSummary as Record<string, unknown>
+            : null;
+          const reviewRows = Number(reviewSummary?.rowsNeedingReview || 0);
 
           const skipParts: string[] = [];
           if (skippedNeedsReview > 0) skipParts.push(`${skippedNeedsReview} needs_review`);
           if (skippedSubtitleSeparator > 0) skipParts.push(`${skippedSubtitleSeparator} subtitle_separator`);
 
-          if (!apply && (skippedNeedsReview > 0 || skippedSubtitleSeparator > 0)) {
+          if (reviewYamlPaths.length > 0) {
+            out.followUpToolCalls = reviewYamlPaths.map((sourceYamlPath) => ({
+              tool: "video_pipeline_apply_reviewed_metadata",
+              reason: "apply_generated_review_yaml_after_human_review",
+              requiresHumanReview: true,
+              params: { sourceYamlPath },
+            }));
+            out.hasFollowUpToolCalls = out.followUpToolCalls.length > 0;
+            if (typeof parsed.nextStep === "string" && parsed.nextStep.trim()) {
+              out.nextStep = parsed.nextStep;
+            } else if (!apply) {
+              out.nextStep =
+                `Dry-run complete. Generated ${reviewYamlPaths.length} review YAML artifact(s) for ${reviewRows} reviewable rows. ` +
+                "Ask the user to review the YAML, then call video_pipeline_apply_reviewed_metadata with sourceYamlPath from followUpToolCalls. " +
+                "Do NOT restart extraction for this cohort.";
+            } else {
+              out.nextStep =
+                `Moves were applied for ready rows, but ${reviewRows} reviewable rows still require human review. ` +
+                "Use followUpToolCalls after YAML review to apply metadata corrections before the next run.";
+            }
+          } else if (!apply && (skippedNeedsReview > 0 || skippedSubtitleSeparator > 0)) {
             out.nextStep =
               `Dry-run complete. ${planned} files planned for move, ${skipParts.join(" + ")} files skipped. ` +
               `Proceed to Stage 2: call video_pipeline_reextract with the queue path to extract metadata for review. ` +
@@ -126,6 +158,9 @@ export function registerToolRun(api: PluginApi, getCfg: GetCfgFn) {
             out.nextStep =
               "Moves applied. Check moveApplyStats for results. " +
               "Call video_pipeline_logs to verify.";
+          }
+          if (!("hasFollowUpToolCalls" in out)) {
+            out.hasFollowUpToolCalls = Array.isArray(out.followUpToolCalls) && out.followUpToolCalls.length > 0;
           }
         }
 


### PR DESCRIPTION
## Summary
Fix issue #97 by making the unwatched auto-organize path generate and surface review YAML artifacts when re-extraction leaves reviewable rows behind.

## What Changed
- Added a Python review-YAML exporter for extraction outputs.
- Updated `unwatched_pipeline_runner.py` to export `program_aliases_review_*.yaml` automatically after rule-based reextract and return first-class review handoff fields such as `reviewYamlPath`, `reviewYamlPaths`, `reviewSummary`, and `workflowState`.
- Updated `video_pipeline_analyze_and_move_videos` so review-required runs point to `video_pipeline_apply_reviewed_metadata` instead of telling callers to rerun extraction.
- Added Python and Vitest coverage for the new exporter and review-handoff behavior.
- Updated README workflow docs for the automatic YAML handoff.

## Why
The 04:30 pipeline was generating queues and leaving `needs_review` rows behind, but it was not producing the review YAML artifact operators actually need to unblock the flow.

## Root Cause
The Python unwatched runner executed inventory, queue generation, and reextract, then moved directly to plan/apply reporting without exporting the review YAML or surfacing an explicit metadata-review artifact.

## Impact
Operators and agents now get an explicit review artifact and structured handoff when metadata review is still required, instead of having to infer the next step from queue files alone.

## Validation
- `pytest py/tests/test_export_program_yaml.py py/tests/test_unwatched_pipeline_runner.py py/tests/test_clear_stale_review_flags.py py/tests/test_detect_folder_contamination.py py/tests/test_update_program_titles_roots.py`
- `npm test`