### PR TITLE
Introduce Python workflow models and run artifact store

### DIFF
--- a/py/tests/test_workflows.py
+++ b/py/tests/test_workflows.py
@@ -131,6 +131,37 @@ def test_register_artifact_records_checksum_and_provenance(tmp_path) -> None:
     assert loaded.artifacts["artifact_inventory"].producer == "test_runner"
 
 
+def test_register_artifact_rejects_duplicate_artifact_id_without_clobbering(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_artifact_duplicate")
+    first_file = tmp_path / "runs" / "run_artifact_duplicate" / "inventory" / "first.jsonl"
+    second_file = tmp_path / "runs" / "run_artifact_duplicate" / "inventory" / "second.jsonl"
+    first_file.write_text("first\n", encoding="utf-8")
+    second_file.write_text("second\n", encoding="utf-8")
+    first = store.register_artifact(
+        "run_artifact_duplicate",
+        artifact_type="inventory",
+        path=first_file,
+        producer="first_step",
+        artifact_id="artifact_inventory",
+    )
+
+    with pytest.raises(FileExistsError):
+        store.register_artifact(
+            "run_artifact_duplicate",
+            artifact_type="inventory",
+            path=second_file,
+            producer="second_step",
+            artifact_id="artifact_inventory",
+        )
+
+    loaded = store.read_run("run_artifact_duplicate")
+    assert loaded.artifact_ids == ["artifact_inventory"]
+    assert loaded.artifacts["artifact_inventory"].path == str(first_file)
+    assert loaded.artifacts["artifact_inventory"].sha256 == first.sha256
+    assert loaded.artifacts["artifact_inventory"].producer == "first_step"
+
+
 def test_register_missing_artifact_adds_diagnostic(tmp_path) -> None:
     store = WorkflowStore(tmp_path)
     store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_missing")
@@ -171,6 +202,39 @@ def test_review_gate_create_and_update_round_trip(tmp_path) -> None:
     assert updated.resolved_at is not None
     assert updated.resolution == {"approvedBy": "tester"}
     assert store.read_run("run_gate").review_gate_ids == ["gate_metadata"]
+
+
+def test_create_review_gate_rejects_duplicate_gate_id_without_clobbering(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_gate_duplicate")
+    store.create_review_gate(
+        "run_gate_duplicate",
+        gate_type="metadata_review",
+        artifact_ids=["artifact_first"],
+        gate_id="gate_metadata",
+    )
+    approved = store.update_review_gate(
+        "run_gate_duplicate",
+        "gate_metadata",
+        status=ReviewGateStatus.APPROVED,
+        resolution={"approvedBy": "tester"},
+    )
+
+    with pytest.raises(FileExistsError):
+        store.create_review_gate(
+            "run_gate_duplicate",
+            gate_type="metadata_review",
+            artifact_ids=["artifact_second"],
+            gate_id="gate_metadata",
+        )
+
+    loaded = store.read_run("run_gate_duplicate")
+    gate = loaded.review_gates["gate_metadata"]
+    assert loaded.review_gate_ids == ["gate_metadata"]
+    assert gate.status == "approved"
+    assert gate.artifact_ids == ["artifact_first"]
+    assert gate.resolved_at == approved.resolved_at
+    assert gate.resolution == {"approvedBy": "tester"}
 
 
 def test_workflow_result_serializes_for_typescript_consumption(tmp_path) -> None:

--- a/py/tests/test_workflows.py
+++ b/py/tests/test_workflows.py
@@ -27,18 +27,19 @@ def test_valid_adr_transitions_are_accepted() -> None:
 
 def test_invalid_transition_reports_structured_diagnostic() -> None:
     with pytest.raises(InvalidTransitionError) as excinfo:
-        validate_transition(WorkflowPhase.CREATED, WorkflowPhase.PLAN_READY)
+        validate_transition(WorkflowPhase.CREATED, WorkflowPhase.APPLIED)
 
     diagnostic = excinfo.value.diagnostic
     assert diagnostic.code == "workflow_invalid_phase_transition"
     assert diagnostic.severity == DiagnosticSeverity.ERROR
     assert diagnostic.details["fromPhase"] == "created"
-    assert diagnostic.details["toPhase"] == "plan_ready"
+    assert diagnostic.details["toPhase"] == "applied"
     assert diagnostic.details["allowedNextPhases"] == [
         "blocked",
         "failed",
         "inventory_ready",
         "metadata_extracted",
+        "plan_ready",
     ]
 
 

--- a/py/tests/test_workflows.py
+++ b/py/tests/test_workflows.py
@@ -94,6 +94,15 @@ def test_init_run_fails_for_existing_run_id_without_clobbering_manifest(tmp_path
     assert after["flow"] == "source_root"
 
 
+def test_init_run_validates_flow_before_creating_run_directory(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+
+    with pytest.raises(ValueError):
+        store.init_run("bad_flow", run_id="run_bad_flow")
+
+    assert not (tmp_path / "runs" / "run_bad_flow").exists()
+
+
 def test_transition_run_updates_phase_status_and_manifest(tmp_path) -> None:
     store = WorkflowStore(tmp_path)
     store.init_run(WorkflowFlow.RELOCATE, run_id="run_transition")

--- a/py/tests/test_workflows.py
+++ b/py/tests/test_workflows.py
@@ -1,0 +1,203 @@
+import hashlib
+import json
+
+import pytest
+
+from video_pipeline.workflows import (
+    Diagnostic,
+    DiagnosticSeverity,
+    InvalidTransitionError,
+    NextAction,
+    ReviewGateStatus,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowResult,
+    WorkflowStore,
+    WorkflowStatus,
+    validate_transition,
+)
+from video_pipeline.workflows.state_machine import VALID_TRANSITIONS
+
+
+def test_valid_adr_transitions_are_accepted() -> None:
+    for source, targets in VALID_TRANSITIONS.items():
+        for target in targets:
+            validate_transition(source, target)
+
+
+def test_invalid_transition_reports_structured_diagnostic() -> None:
+    with pytest.raises(InvalidTransitionError) as excinfo:
+        validate_transition(WorkflowPhase.CREATED, WorkflowPhase.PLAN_READY)
+
+    diagnostic = excinfo.value.diagnostic
+    assert diagnostic.code == "workflow_invalid_phase_transition"
+    assert diagnostic.severity == DiagnosticSeverity.ERROR
+    assert diagnostic.details["fromPhase"] == "created"
+    assert diagnostic.details["toPhase"] == "plan_ready"
+    assert diagnostic.details["allowedNextPhases"] == [
+        "blocked",
+        "failed",
+        "inventory_ready",
+        "metadata_extracted",
+    ]
+
+
+def test_terminal_transition_is_rejected() -> None:
+    with pytest.raises(InvalidTransitionError) as excinfo:
+        validate_transition(WorkflowPhase.COMPLETE, WorkflowPhase.FAILED)
+
+    assert excinfo.value.diagnostic.code == "workflow_terminal_phase_transition"
+
+
+def test_init_run_creates_manifest_and_standard_directories(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    run = store.init_run(
+        WorkflowFlow.SOURCE_ROOT,
+        run_id="run_test",
+        config_snapshot={"windowsOpsRoot": str(tmp_path)},
+    )
+
+    run_dir = tmp_path / "runs" / "run_test"
+    assert run.run_id == "run_test"
+    assert run.phase == "created"
+    assert run.status == "active"
+    assert (run_dir / "run.json").exists()
+    for name in ("inventory", "metadata", "review", "plan", "apply", "logs"):
+        assert (run_dir / name).is_dir()
+
+    loaded = store.read_run("run_test")
+    assert loaded.to_dict()["runId"] == "run_test"
+    assert loaded.to_dict()["configSnapshot"] == {"windowsOpsRoot": str(tmp_path)}
+
+
+def test_transition_run_updates_phase_status_and_manifest(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_transition")
+
+    run = store.transition_run("run_transition", WorkflowPhase.METADATA_EXTRACTED)
+
+    assert run.phase == "metadata_extracted"
+    assert run.status == WorkflowStatus.ACTIVE
+    assert store.read_run("run_transition").phase == "metadata_extracted"
+
+
+def test_register_artifact_records_checksum_and_provenance(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_artifact")
+    artifact_file = tmp_path / "runs" / "run_artifact" / "inventory" / "input.jsonl"
+    artifact_file.write_text('{"path":"x"}\n', encoding="utf-8")
+
+    artifact = store.register_artifact(
+        "run_artifact",
+        artifact_type="inventory",
+        path=artifact_file,
+        producer="test_runner",
+        artifact_id="artifact_inventory",
+        input_artifact_ids=["seed"],
+        metadata={"rows": 1},
+    )
+
+    expected_hash = hashlib.sha256(artifact_file.read_bytes()).hexdigest()
+    assert artifact.sha256 == expected_hash
+    assert artifact.input_artifact_ids == ["seed"]
+    assert artifact.metadata == {"rows": 1}
+
+    loaded = store.read_run("run_artifact")
+    assert loaded.artifact_ids == ["artifact_inventory"]
+    assert loaded.artifacts["artifact_inventory"].producer == "test_runner"
+
+
+def test_register_missing_artifact_adds_diagnostic(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_missing")
+
+    with pytest.raises(FileNotFoundError):
+        store.register_artifact(
+            "run_missing",
+            artifact_type="inventory",
+            path=tmp_path / "missing.jsonl",
+            producer="test_runner",
+        )
+
+    loaded = store.read_run("run_missing")
+    assert loaded.diagnostics[-1].code == "workflow_artifact_missing"
+
+
+def test_review_gate_create_and_update_round_trip(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_gate")
+    gate = store.create_review_gate(
+        "run_gate",
+        gate_type="metadata_review",
+        artifact_ids=["artifact_metadata"],
+        gate_id="gate_metadata",
+    )
+
+    assert gate.status == ReviewGateStatus.OPEN
+    assert gate.resolved_at is None
+
+    updated = store.update_review_gate(
+        "run_gate",
+        "gate_metadata",
+        status=ReviewGateStatus.APPROVED,
+        resolution={"approvedBy": "tester"},
+    )
+
+    assert updated.status == "approved"
+    assert updated.resolved_at is not None
+    assert updated.resolution == {"approvedBy": "tester"}
+    assert store.read_run("run_gate").review_gate_ids == ["gate_metadata"]
+
+
+def test_workflow_result_serializes_for_typescript_consumption(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_result")
+    artifact_file = tmp_path / "runs" / "run_result" / "metadata" / "output.jsonl"
+    artifact_file.write_text("{}", encoding="utf-8")
+    artifact = store.register_artifact(
+        "run_result",
+        artifact_type="metadata",
+        path=artifact_file,
+        producer="metadata_step",
+        artifact_id="artifact_metadata",
+    )
+    gate = store.create_review_gate(
+        "run_result",
+        gate_type="metadata_review",
+        artifact_ids=["artifact_metadata"],
+        gate_id="gate_metadata",
+    )
+
+    result = WorkflowResult(
+        ok=False,
+        run_id="run_result",
+        flow=WorkflowFlow.SOURCE_ROOT,
+        phase=WorkflowPhase.REVIEW_REQUIRED,
+        outcome="review_required",
+        artifacts=[artifact],
+        gates=[gate],
+        next_actions=[
+            NextAction(
+                action="review_metadata",
+                label="Review metadata",
+                tool="video_pipeline_resume",
+                params={"runId": "run_result"},
+                requires_human_input=True,
+            )
+        ],
+        diagnostics=[
+            Diagnostic(
+                code="review_gate_open",
+                severity=DiagnosticSeverity.INFO,
+                message="metadata review is required",
+            )
+        ],
+    )
+
+    payload = result.to_dict()
+    json.dumps(payload, ensure_ascii=False)
+    assert payload["runId"] == "run_result"
+    assert payload["phase"] == "review_required"
+    assert payload["artifacts"][0]["inputArtifactIds"] == []
+    assert payload["gates"][0]["requiresHumanReview"] is True
+    assert payload["nextActions"][0]["requiresHumanInput"] is True

--- a/py/tests/test_workflows.py
+++ b/py/tests/test_workflows.py
@@ -114,6 +114,24 @@ def test_transition_run_updates_phase_status_and_manifest(tmp_path) -> None:
     assert store.read_run("run_transition").phase == "metadata_extracted"
 
 
+def test_read_run_rejects_manifest_run_id_mismatch_without_cross_run_write(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_a")
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_b")
+    run_a_manifest = tmp_path / "runs" / "run_a" / "run.json"
+    run_b_manifest = tmp_path / "runs" / "run_b" / "run.json"
+    run_a_data = json.loads(run_a_manifest.read_text(encoding="utf-8"))
+    run_a_data["runId"] = "run_b"
+    run_a_manifest.write_text(json.dumps(run_a_data, ensure_ascii=False), encoding="utf-8")
+    run_b_before = json.loads(run_b_manifest.read_text(encoding="utf-8"))
+
+    with pytest.raises(ValueError, match="runId mismatch"):
+        store.transition_run("run_a", WorkflowPhase.METADATA_EXTRACTED)
+
+    run_b_after = json.loads(run_b_manifest.read_text(encoding="utf-8"))
+    assert run_b_after == run_b_before
+
+
 def test_register_artifact_records_checksum_and_provenance(tmp_path) -> None:
     store = WorkflowStore(tmp_path)
     store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_artifact")

--- a/py/tests/test_workflows.py
+++ b/py/tests/test_workflows.py
@@ -70,6 +70,30 @@ def test_init_run_creates_manifest_and_standard_directories(tmp_path) -> None:
     assert loaded.to_dict()["configSnapshot"] == {"windowsOpsRoot": str(tmp_path)}
 
 
+def test_run_id_rejects_path_traversal(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+
+    for run_id in ("../escape", r"..\escape", "/tmp/escape", "run/escape", r"run\escape", "run..escape"):
+        with pytest.raises(ValueError):
+            store.run_dir(run_id)
+
+    assert not (tmp_path / "escape").exists()
+
+
+def test_init_run_fails_for_existing_run_id_without_clobbering_manifest(tmp_path) -> None:
+    store = WorkflowStore(tmp_path)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_existing")
+    run_path = tmp_path / "runs" / "run_existing" / "run.json"
+    before = json.loads(run_path.read_text(encoding="utf-8"))
+
+    with pytest.raises(FileExistsError):
+        store.init_run(WorkflowFlow.RELOCATE, run_id="run_existing")
+
+    after = json.loads(run_path.read_text(encoding="utf-8"))
+    assert after == before
+    assert after["flow"] == "source_root"
+
+
 def test_transition_run_updates_phase_status_and_manifest(tmp_path) -> None:
     store = WorkflowStore(tmp_path)
     store.init_run(WorkflowFlow.RELOCATE, run_id="run_transition")

--- a/py/video_pipeline/workflows/__init__.py
+++ b/py/video_pipeline/workflows/__init__.py
@@ -1,1 +1,37 @@
-"""Workflow entrypoint modules."""
+"""V2 run-based workflow substrate."""
+
+from .models import (
+    ArtifactRef,
+    ArtifactStatus,
+    Diagnostic,
+    DiagnosticSeverity,
+    NextAction,
+    ReviewGate,
+    ReviewGateStatus,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowResult,
+    WorkflowRun,
+    WorkflowStatus,
+)
+from .state_machine import InvalidTransitionError, can_transition, validate_transition
+from .store import WorkflowStore
+
+__all__ = [
+    "ArtifactRef",
+    "ArtifactStatus",
+    "Diagnostic",
+    "DiagnosticSeverity",
+    "InvalidTransitionError",
+    "NextAction",
+    "ReviewGate",
+    "ReviewGateStatus",
+    "WorkflowFlow",
+    "WorkflowPhase",
+    "WorkflowResult",
+    "WorkflowRun",
+    "WorkflowStatus",
+    "WorkflowStore",
+    "can_transition",
+    "validate_transition",
+]

--- a/py/video_pipeline/workflows/models.py
+++ b/py/video_pipeline/workflows/models.py
@@ -1,0 +1,289 @@
+"""Typed models for the V2 run-based workflow substrate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class WorkflowFlow(str, Enum):
+    SOURCE_ROOT = "source_root"
+    RELOCATE = "relocate"
+
+
+class WorkflowPhase(str, Enum):
+    CREATED = "created"
+    INVENTORY_READY = "inventory_ready"
+    METADATA_EXTRACTED = "metadata_extracted"
+    REVIEW_REQUIRED = "review_required"
+    METADATA_ACCEPTED = "metadata_accepted"
+    PLAN_READY = "plan_ready"
+    APPLIED = "applied"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class WorkflowStatus(str, Enum):
+    ACTIVE = "active"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class ArtifactStatus(str, Enum):
+    AVAILABLE = "available"
+    SUPERSEDED = "superseded"
+    DELETED = "deleted"
+    MISSING = "missing"
+
+
+class ReviewGateStatus(str, Enum):
+    OPEN = "open"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"
+    CANCELLED = "cancelled"
+
+
+class DiagnosticSeverity(str, Enum):
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+def enum_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def phase_status(phase: WorkflowPhase | str) -> WorkflowStatus:
+    phase_value = WorkflowPhase(phase)
+    if phase_value == WorkflowPhase.COMPLETE:
+        return WorkflowStatus.COMPLETE
+    if phase_value == WorkflowPhase.BLOCKED:
+        return WorkflowStatus.BLOCKED
+    if phase_value == WorkflowPhase.FAILED:
+        return WorkflowStatus.FAILED
+    return WorkflowStatus.ACTIVE
+
+
+@dataclass
+class Diagnostic:
+    code: str
+    severity: DiagnosticSeverity | str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": enum_value(self.severity),
+            "message": self.message,
+            "details": self.details,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Diagnostic":
+        return cls(
+            code=str(data["code"]),
+            severity=str(data["severity"]),
+            message=str(data["message"]),
+            details=dict(data.get("details") or {}),
+        )
+
+
+@dataclass
+class ArtifactRef:
+    id: str
+    type: str
+    path: str
+    sha256: str
+    created_at: str
+    producer: str
+    status: ArtifactStatus | str = ArtifactStatus.AVAILABLE
+    input_artifact_ids: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "path": self.path,
+            "sha256": self.sha256,
+            "createdAt": self.created_at,
+            "producer": self.producer,
+            "status": enum_value(self.status),
+            "inputArtifactIds": list(self.input_artifact_ids),
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ArtifactRef":
+        return cls(
+            id=str(data["id"]),
+            type=str(data["type"]),
+            path=str(data["path"]),
+            sha256=str(data["sha256"]),
+            created_at=str(data["createdAt"]),
+            producer=str(data["producer"]),
+            status=str(data.get("status") or ArtifactStatus.AVAILABLE.value),
+            input_artifact_ids=[str(v) for v in data.get("inputArtifactIds") or []],
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+@dataclass
+class ReviewGate:
+    id: str
+    type: str
+    status: ReviewGateStatus | str
+    artifact_ids: list[str]
+    requires_human_review: bool
+    opened_at: str
+    resolved_at: str | None = None
+    resolution: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "status": enum_value(self.status),
+            "artifactIds": list(self.artifact_ids),
+            "requiresHumanReview": self.requires_human_review,
+            "openedAt": self.opened_at,
+            "resolvedAt": self.resolved_at,
+            "resolution": self.resolution,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ReviewGate":
+        return cls(
+            id=str(data["id"]),
+            type=str(data["type"]),
+            status=str(data["status"]),
+            artifact_ids=[str(v) for v in data.get("artifactIds") or []],
+            requires_human_review=bool(data["requiresHumanReview"]),
+            opened_at=str(data["openedAt"]),
+            resolved_at=data.get("resolvedAt"),
+            resolution=dict(data.get("resolution") or {}),
+        )
+
+
+@dataclass
+class NextAction:
+    action: str
+    label: str
+    tool: str | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+    requires_human_input: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "label": self.label,
+            "tool": self.tool,
+            "params": self.params,
+            "requiresHumanInput": self.requires_human_input,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "NextAction":
+        return cls(
+            action=str(data["action"]),
+            label=str(data["label"]),
+            tool=data.get("tool"),
+            params=dict(data.get("params") or {}),
+            requires_human_input=bool(data.get("requiresHumanInput", False)),
+        )
+
+
+@dataclass
+class WorkflowRun:
+    run_id: str
+    flow: WorkflowFlow | str
+    phase: WorkflowPhase | str
+    status: WorkflowStatus | str
+    created_at: str
+    updated_at: str
+    config_snapshot: dict[str, Any] = field(default_factory=dict)
+    artifact_ids: list[str] = field(default_factory=list)
+    review_gate_ids: list[str] = field(default_factory=list)
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+    artifacts: dict[str, ArtifactRef] = field(default_factory=dict)
+    review_gates: dict[str, ReviewGate] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "runId": self.run_id,
+            "flow": enum_value(self.flow),
+            "phase": enum_value(self.phase),
+            "status": enum_value(self.status),
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+            "configSnapshot": self.config_snapshot,
+            "artifactIds": list(self.artifact_ids),
+            "reviewGateIds": list(self.review_gate_ids),
+            "diagnostics": [d.to_dict() for d in self.diagnostics],
+            "artifacts": {k: v.to_dict() for k, v in self.artifacts.items()},
+            "reviewGates": {k: v.to_dict() for k, v in self.review_gates.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WorkflowRun":
+        diagnostics = [Diagnostic.from_dict(v) for v in data.get("diagnostics") or []]
+        artifacts = {
+            str(k): ArtifactRef.from_dict(v)
+            for k, v in dict(data.get("artifacts") or {}).items()
+        }
+        review_gates = {
+            str(k): ReviewGate.from_dict(v)
+            for k, v in dict(data.get("reviewGates") or {}).items()
+        }
+        return cls(
+            run_id=str(data["runId"]),
+            flow=str(data["flow"]),
+            phase=str(data["phase"]),
+            status=str(data["status"]),
+            created_at=str(data["createdAt"]),
+            updated_at=str(data["updatedAt"]),
+            config_snapshot=dict(data.get("configSnapshot") or {}),
+            artifact_ids=[str(v) for v in data.get("artifactIds") or []],
+            review_gate_ids=[str(v) for v in data.get("reviewGateIds") or []],
+            diagnostics=diagnostics,
+            artifacts=artifacts,
+            review_gates=review_gates,
+        )
+
+
+@dataclass
+class WorkflowResult:
+    ok: bool
+    run_id: str
+    flow: WorkflowFlow | str
+    phase: WorkflowPhase | str
+    outcome: str
+    artifacts: list[ArtifactRef] = field(default_factory=list)
+    gates: list[ReviewGate] = field(default_factory=list)
+    next_actions: list[NextAction] = field(default_factory=list)
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "runId": self.run_id,
+            "flow": enum_value(self.flow),
+            "phase": enum_value(self.phase),
+            "outcome": self.outcome,
+            "artifacts": [a.to_dict() for a in self.artifacts],
+            "gates": [g.to_dict() for g in self.gates],
+            "nextActions": [a.to_dict() for a in self.next_actions],
+            "diagnostics": [d.to_dict() for d in self.diagnostics],
+        }

--- a/py/video_pipeline/workflows/state_machine.py
+++ b/py/video_pipeline/workflows/state_machine.py
@@ -9,6 +9,7 @@ VALID_TRANSITIONS: dict[WorkflowPhase, set[WorkflowPhase]] = {
     WorkflowPhase.CREATED: {
         WorkflowPhase.INVENTORY_READY,
         WorkflowPhase.METADATA_EXTRACTED,
+        WorkflowPhase.PLAN_READY,
         WorkflowPhase.BLOCKED,
         WorkflowPhase.FAILED,
     },

--- a/py/video_pipeline/workflows/state_machine.py
+++ b/py/video_pipeline/workflows/state_machine.py
@@ -1,0 +1,94 @@
+"""State transition validation for V2 workflow runs."""
+
+from __future__ import annotations
+
+from .models import Diagnostic, DiagnosticSeverity, WorkflowPhase
+
+
+VALID_TRANSITIONS: dict[WorkflowPhase, set[WorkflowPhase]] = {
+    WorkflowPhase.CREATED: {
+        WorkflowPhase.INVENTORY_READY,
+        WorkflowPhase.METADATA_EXTRACTED,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.INVENTORY_READY: {
+        WorkflowPhase.METADATA_EXTRACTED,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.METADATA_EXTRACTED: {
+        WorkflowPhase.REVIEW_REQUIRED,
+        WorkflowPhase.METADATA_ACCEPTED,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.REVIEW_REQUIRED: {
+        WorkflowPhase.METADATA_ACCEPTED,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.METADATA_ACCEPTED: {
+        WorkflowPhase.PLAN_READY,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.PLAN_READY: {
+        WorkflowPhase.APPLIED,
+        WorkflowPhase.COMPLETE,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.APPLIED: {
+        WorkflowPhase.COMPLETE,
+        WorkflowPhase.BLOCKED,
+        WorkflowPhase.FAILED,
+    },
+    WorkflowPhase.COMPLETE: set(),
+    WorkflowPhase.BLOCKED: set(),
+    WorkflowPhase.FAILED: set(),
+}
+
+TERMINAL_PHASES = {
+    WorkflowPhase.COMPLETE,
+    WorkflowPhase.BLOCKED,
+    WorkflowPhase.FAILED,
+}
+
+
+class InvalidTransitionError(ValueError):
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(diagnostic.message)
+
+
+def transition_diagnostic(from_phase: WorkflowPhase | str, to_phase: WorkflowPhase | str) -> Diagnostic:
+    source = WorkflowPhase(from_phase)
+    target = WorkflowPhase(to_phase)
+    if source in TERMINAL_PHASES:
+        code = "workflow_terminal_phase_transition"
+        message = f"cannot transition from terminal phase '{source.value}' to '{target.value}'"
+    else:
+        code = "workflow_invalid_phase_transition"
+        message = f"invalid workflow transition from '{source.value}' to '{target.value}'"
+    return Diagnostic(
+        code=code,
+        severity=DiagnosticSeverity.ERROR,
+        message=message,
+        details={
+            "fromPhase": source.value,
+            "toPhase": target.value,
+            "allowedNextPhases": sorted(p.value for p in VALID_TRANSITIONS[source]),
+        },
+    )
+
+
+def can_transition(from_phase: WorkflowPhase | str, to_phase: WorkflowPhase | str) -> bool:
+    source = WorkflowPhase(from_phase)
+    target = WorkflowPhase(to_phase)
+    return target in VALID_TRANSITIONS[source]
+
+
+def validate_transition(from_phase: WorkflowPhase | str, to_phase: WorkflowPhase | str) -> None:
+    if not can_transition(from_phase, to_phase):
+        raise InvalidTransitionError(transition_diagnostic(from_phase, to_phase))

--- a/py/video_pipeline/workflows/store.py
+++ b/py/video_pipeline/workflows/store.py
@@ -1,0 +1,188 @@
+"""Run-scoped manifest and artifact store for V2 workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    ArtifactRef,
+    ArtifactStatus,
+    Diagnostic,
+    DiagnosticSeverity,
+    ReviewGate,
+    ReviewGateStatus,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowRun,
+    now_iso,
+    phase_status,
+)
+from .state_machine import validate_transition
+
+RUN_SUBDIRS = ("inventory", "metadata", "review", "plan", "apply", "logs")
+
+
+def generate_run_id() -> str:
+    compact = now_iso().replace("-", "").replace(":", "").split(".")[0]
+    compact = compact.replace("+0000", "Z")
+    return f"run_{compact}_{uuid.uuid4().hex[:8]}"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+class WorkflowStore:
+    def __init__(self, windows_ops_root: str | Path) -> None:
+        self.windows_ops_root = Path(windows_ops_root)
+        self.runs_root = self.windows_ops_root / "runs"
+
+    def run_dir(self, run_id: str) -> Path:
+        return self.runs_root / run_id
+
+    def manifest_path(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / "run.json"
+
+    def init_run(
+        self,
+        flow: WorkflowFlow | str,
+        *,
+        run_id: str | None = None,
+        config_snapshot: dict[str, Any] | None = None,
+    ) -> WorkflowRun:
+        rid = run_id or generate_run_id()
+        run_path = self.run_dir(rid)
+        run_path.mkdir(parents=True, exist_ok=True)
+        for subdir in RUN_SUBDIRS:
+            (run_path / subdir).mkdir(exist_ok=True)
+        now = now_iso()
+        run = WorkflowRun(
+            run_id=rid,
+            flow=WorkflowFlow(flow).value,
+            phase=WorkflowPhase.CREATED.value,
+            status=phase_status(WorkflowPhase.CREATED).value,
+            created_at=now,
+            updated_at=now,
+            config_snapshot=dict(config_snapshot or {}),
+        )
+        self.write_run(run)
+        return run
+
+    def read_run(self, run_id: str) -> WorkflowRun:
+        with self.manifest_path(run_id).open("r", encoding="utf-8") as f:
+            return WorkflowRun.from_dict(json.load(f))
+
+    def write_run(self, run: WorkflowRun) -> None:
+        path = self.manifest_path(run.run_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(run.to_dict(), f, ensure_ascii=False, indent=2, sort_keys=True)
+            f.write("\n")
+
+    def transition_run(self, run_id: str, to_phase: WorkflowPhase | str) -> WorkflowRun:
+        run = self.read_run(run_id)
+        validate_transition(run.phase, to_phase)
+        now = now_iso()
+        run.phase = WorkflowPhase(to_phase).value
+        run.status = phase_status(to_phase).value
+        run.updated_at = now
+        self.write_run(run)
+        return run
+
+    def register_artifact(
+        self,
+        run_id: str,
+        *,
+        artifact_type: str,
+        path: str | Path,
+        producer: str,
+        artifact_id: str | None = None,
+        status: ArtifactStatus | str = ArtifactStatus.AVAILABLE,
+        input_artifact_ids: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> ArtifactRef:
+        run = self.read_run(run_id)
+        artifact_path = Path(path)
+        if not artifact_path.exists():
+            diagnostic = Diagnostic(
+                code="workflow_artifact_missing",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"artifact file does not exist: {artifact_path}",
+                details={"path": str(artifact_path)},
+            )
+            run.diagnostics.append(diagnostic)
+            run.updated_at = now_iso()
+            self.write_run(run)
+            raise FileNotFoundError(diagnostic.message)
+
+        aid = artifact_id or f"{artifact_type}_{uuid.uuid4().hex[:12]}"
+        artifact = ArtifactRef(
+            id=aid,
+            type=artifact_type,
+            path=str(artifact_path),
+            sha256=sha256_file(artifact_path),
+            created_at=now_iso(),
+            producer=producer,
+            status=status,
+            input_artifact_ids=list(input_artifact_ids or []),
+            metadata=dict(metadata or {}),
+        )
+        run.artifacts[aid] = artifact
+        if aid not in run.artifact_ids:
+            run.artifact_ids.append(aid)
+        run.updated_at = now_iso()
+        self.write_run(run)
+        return artifact
+
+    def create_review_gate(
+        self,
+        run_id: str,
+        *,
+        gate_type: str,
+        artifact_ids: list[str],
+        requires_human_review: bool = True,
+        gate_id: str | None = None,
+    ) -> ReviewGate:
+        run = self.read_run(run_id)
+        gid = gate_id or f"{gate_type}_{uuid.uuid4().hex[:12]}"
+        gate = ReviewGate(
+            id=gid,
+            type=gate_type,
+            status=ReviewGateStatus.OPEN,
+            artifact_ids=list(artifact_ids),
+            requires_human_review=requires_human_review,
+            opened_at=now_iso(),
+        )
+        run.review_gates[gid] = gate
+        if gid not in run.review_gate_ids:
+            run.review_gate_ids.append(gid)
+        run.updated_at = now_iso()
+        self.write_run(run)
+        return gate
+
+    def update_review_gate(
+        self,
+        run_id: str,
+        gate_id: str,
+        *,
+        status: ReviewGateStatus | str,
+        resolution: dict[str, Any] | None = None,
+    ) -> ReviewGate:
+        run = self.read_run(run_id)
+        gate = run.review_gates[gate_id]
+        target_status = ReviewGateStatus(status)
+        gate.status = target_status.value
+        gate.resolution = dict(resolution or {})
+        gate.resolved_at = None if target_status == ReviewGateStatus.OPEN else now_iso()
+        run.review_gates[gate_id] = gate
+        run.updated_at = now_iso()
+        self.write_run(run)
+        return gate

--- a/py/video_pipeline/workflows/store.py
+++ b/py/video_pipeline/workflows/store.py
@@ -135,6 +135,8 @@ class WorkflowStore:
             raise FileNotFoundError(diagnostic.message)
 
         aid = artifact_id or f"{artifact_type}_{uuid.uuid4().hex[:12]}"
+        if aid in run.artifacts:
+            raise FileExistsError(f"workflow artifact already exists: {aid}")
         artifact = ArtifactRef(
             id=aid,
             type=artifact_type,
@@ -164,6 +166,8 @@ class WorkflowStore:
     ) -> ReviewGate:
         run = self.read_run(run_id)
         gid = gate_id or f"{gate_type}_{uuid.uuid4().hex[:12]}"
+        if gid in run.review_gates:
+            raise FileExistsError(f"workflow review gate already exists: {gid}")
         gate = ReviewGate(
             id=gid,
             type=gate_type,

--- a/py/video_pipeline/workflows/store.py
+++ b/py/video_pipeline/workflows/store.py
@@ -68,6 +68,7 @@ class WorkflowStore:
         config_snapshot: dict[str, Any] | None = None,
     ) -> WorkflowRun:
         rid = validate_run_id(run_id or generate_run_id())
+        flow_value = WorkflowFlow(flow).value
         run_path = self.run_dir(rid)
         if run_path.exists():
             raise FileExistsError(f"workflow run already exists: {rid}")
@@ -77,7 +78,7 @@ class WorkflowStore:
         now = now_iso()
         run = WorkflowRun(
             run_id=rid,
-            flow=WorkflowFlow(flow).value,
+            flow=flow_value,
             phase=WorkflowPhase.CREATED.value,
             status=phase_status(WorkflowPhase.CREATED).value,
             created_at=now,

--- a/py/video_pipeline/workflows/store.py
+++ b/py/video_pipeline/workflows/store.py
@@ -89,8 +89,14 @@ class WorkflowStore:
         return run
 
     def read_run(self, run_id: str) -> WorkflowRun:
+        expected_run_id = validate_run_id(run_id)
         with self.manifest_path(run_id).open("r", encoding="utf-8") as f:
-            return WorkflowRun.from_dict(json.load(f))
+            run = WorkflowRun.from_dict(json.load(f))
+        if run.run_id != expected_run_id:
+            raise ValueError(
+                f"workflow manifest runId mismatch: expected {expected_run_id!r}, got {run.run_id!r}"
+            )
+        return run
 
     def write_run(self, run: WorkflowRun) -> None:
         path = self.manifest_path(run.run_id)

--- a/py/video_pipeline/workflows/store.py
+++ b/py/video_pipeline/workflows/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import uuid
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,7 @@ from .models import (
 from .state_machine import validate_transition
 
 RUN_SUBDIRS = ("inventory", "metadata", "review", "plan", "apply", "logs")
+RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
 def generate_run_id() -> str:
@@ -40,13 +42,20 @@ def sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def validate_run_id(run_id: str) -> str:
+    rid = str(run_id or "")
+    if not RUN_ID_PATTERN.fullmatch(rid) or ".." in rid:
+        raise ValueError(f"invalid workflow run_id: {run_id!r}")
+    return rid
+
+
 class WorkflowStore:
     def __init__(self, windows_ops_root: str | Path) -> None:
         self.windows_ops_root = Path(windows_ops_root)
         self.runs_root = self.windows_ops_root / "runs"
 
     def run_dir(self, run_id: str) -> Path:
-        return self.runs_root / run_id
+        return self.runs_root / validate_run_id(run_id)
 
     def manifest_path(self, run_id: str) -> Path:
         return self.run_dir(run_id) / "run.json"
@@ -58,9 +67,11 @@ class WorkflowStore:
         run_id: str | None = None,
         config_snapshot: dict[str, Any] | None = None,
     ) -> WorkflowRun:
-        rid = run_id or generate_run_id()
+        rid = validate_run_id(run_id or generate_run_id())
         run_path = self.run_dir(rid)
-        run_path.mkdir(parents=True, exist_ok=True)
+        if run_path.exists():
+            raise FileExistsError(f"workflow run already exists: {rid}")
+        run_path.mkdir(parents=True)
         for subdir in RUN_SUBDIRS:
             (run_path / subdir).mkdir(exist_ok=True)
         now = now_iso()


### PR DESCRIPTION
## Summary

Implements the Python V2 workflow substrate for #104.

- Adds typed workflow dataclasses/enums for runs, artifacts, review gates, results, next actions, and diagnostics.
- Adds ADR-0008 phase transition validation with structured diagnostics for invalid transitions.
- Adds a run-scoped manifest store under `<windowsOpsRoot>/runs/<runId>/` with artifact checksum registration and review gate persistence.
- Exposes the workflow substrate through `py/video_pipeline/workflows/__init__.py` without changing existing public tools or V1 behavior.

## Validation

- `pytest -q py/tests` -> 42 passed

## Notes

- Keeps existing `src/platform/runtime.ts` local modification out of scope and unstaged.

Closes #104