### PR TITLE
SourceRoot V2 dry-run workflow service skeleton

### DIFF
--- a/py/tests/test_source_root_workflow.py
+++ b/py/tests/test_source_root_workflow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from video_pipeline.workflows import SourceRootDryRunConfig, SourceRootWorkflowService
 
 
-def make_config(tmp_path: Path, run_id: str = "run_source_root") -> SourceRootDryRunConfig:
+def make_config(tmp_path: Path, run_id: str = "run_source_root", db: str | None = None) -> SourceRootDryRunConfig:
     ops_root = tmp_path / "ops"
     scripts_root = ops_root / "scripts"
     scripts_root.mkdir(parents=True)
@@ -12,7 +12,7 @@ def make_config(tmp_path: Path, run_id: str = "run_source_root") -> SourceRootDr
         windows_ops_root=str(ops_root),
         source_root=r"B:\Unwatched",
         dest_root=r"B:\VideoLibrary",
-        db=str(ops_root / "db" / "mediaops.sqlite"),
+        db=db or str(ops_root / "db" / "mediaops.sqlite"),
         drive_routes=str(tmp_path / "drive_routes.yaml"),
         max_files_per_run=20,
         run_id=run_id,
@@ -130,6 +130,66 @@ def test_source_root_dry_run_registers_core_artifacts(tmp_path) -> None:
         "run_metadata_batches_promptv1.py",
         "make_move_plan_from_inventory.py",
     ]
+
+
+def test_source_root_dry_run_normalizes_windows_db_path_for_python_stages(tmp_path) -> None:
+    cfg = make_config(tmp_path, run_id="run_source_root_windows_db", db=r"B:\_AI_WORK\db\mediaops.sqlite")
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_powershell_runner(_script: str, args: list[str]) -> dict:
+        out_path = Path(args[args.index("-OutJsonl") + 1])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            "\n".join([
+                json.dumps({"_meta": {"kind": "unwatched_inventory"}}, ensure_ascii=False),
+                json.dumps({"path": r"B:\Unwatched\show.mp4", "name": "show.mp4"}, ensure_ascii=False),
+            ])
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"out_jsonl": str(out_path), "warning_count": 0}
+
+    def fake_python_runner(script: Path, args: list[str], _cwd: str | None = None) -> str:
+        calls.append((script.name, list(args)))
+        if script.name == "make_metadata_queue_from_inventory.py":
+            out_path = Path(args[args.index("--out") + 1])
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(
+                "\n".join([
+                    json.dumps({"_meta": {"kind": "metadata_queue"}}, ensure_ascii=False),
+                    json.dumps({"path_id": "p1", "path": r"B:\Unwatched\show.mp4", "name": "show.mp4"}, ensure_ascii=False),
+                ])
+                + "\n",
+                encoding="utf-8",
+            )
+        elif script.name == "run_metadata_batches_promptv1.py":
+            outdir = Path(args[args.index("--outdir") + 1])
+            output_path = outdir / "llm_filename_extract_output_0001_0001.jsonl"
+            output_path.write_text("{}\n", encoding="utf-8")
+            return json.dumps({"ok": True, "outputJsonlPaths": [str(output_path)]}, ensure_ascii=False)
+        elif script.name == "make_move_plan_from_inventory.py":
+            out_path = Path(args[args.index("--out") + 1])
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(json.dumps({"_meta": {"kind": "move_plan_from_inventory"}}) + "\n", encoding="utf-8")
+            return json.dumps({"out": str(out_path), "planned": 0}, ensure_ascii=False)
+        return json.dumps({"ok": True}, ensure_ascii=False)
+
+    service = SourceRootWorkflowService(
+        python_runner=fake_python_runner,
+        powershell_runner=fake_powershell_runner,
+        py_root=tmp_path,
+    )
+
+    result = service.dry_run(cfg)
+
+    assert result.ok is True
+    expected_db = "/mnt/b/_AI_WORK/db/mediaops.sqlite"
+    assert calls
+    assert all(args[args.index("--db") + 1] == expected_db for _name, args in calls)
+
+    manifest_path = Path(cfg.windows_ops_root) / "runs" / "run_source_root_windows_db" / "run.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["configSnapshot"]["db"] == expected_db
 
 
 def test_source_root_dry_run_failure_returns_failed_result_and_diagnostic(tmp_path) -> None:

--- a/py/tests/test_source_root_workflow.py
+++ b/py/tests/test_source_root_workflow.py
@@ -1,0 +1,167 @@
+import json
+from pathlib import Path
+
+from video_pipeline.workflows import SourceRootDryRunConfig, SourceRootWorkflowService
+
+
+def make_config(tmp_path: Path, run_id: str = "run_source_root") -> SourceRootDryRunConfig:
+    ops_root = tmp_path / "ops"
+    scripts_root = ops_root / "scripts"
+    scripts_root.mkdir(parents=True)
+    return SourceRootDryRunConfig(
+        windows_ops_root=str(ops_root),
+        source_root=r"B:\Unwatched",
+        dest_root=r"B:\VideoLibrary",
+        db=str(ops_root / "db" / "mediaops.sqlite"),
+        drive_routes=str(tmp_path / "drive_routes.yaml"),
+        max_files_per_run=20,
+        run_id=run_id,
+    )
+
+
+def test_source_root_dry_run_registers_core_artifacts(tmp_path) -> None:
+    cfg = make_config(tmp_path)
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_powershell_runner(_script: str, args: list[str]) -> dict:
+        out_path = Path(args[args.index("-OutJsonl") + 1])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            "\n".join([
+                json.dumps({"_meta": {"kind": "unwatched_inventory"}}, ensure_ascii=False),
+                json.dumps({"path": r"B:\Unwatched\show.mp4", "name": "show.mp4", "mtimeUtc": "2026-04-25T00:00:00Z"}, ensure_ascii=False),
+            ])
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"out_jsonl": str(out_path), "warning_count": 0}
+
+    def fake_python_runner(script: Path, args: list[str], _cwd: str | None = None) -> str:
+        calls.append((script.name, list(args)))
+        if script.name == "make_metadata_queue_from_inventory.py":
+            out_path = Path(args[args.index("--out") + 1])
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(
+                "\n".join([
+                    json.dumps({"_meta": {"kind": "metadata_queue"}}, ensure_ascii=False),
+                    json.dumps({"path_id": "p1", "path": r"B:\Unwatched\show.mp4", "name": "show.mp4"}, ensure_ascii=False),
+                ])
+                + "\n",
+                encoding="utf-8",
+            )
+            return "OK queue_rows=1\n"
+        if script.name == "run_metadata_batches_promptv1.py":
+            outdir = Path(args[args.index("--outdir") + 1])
+            output_path = outdir / "llm_filename_extract_output_0001_0001.jsonl"
+            output_path.write_text(
+                json.dumps({"path_id": "p1", "program_title": "Show", "air_date": "2026-04-25"}, ensure_ascii=False)
+                + "\n",
+                encoding="utf-8",
+            )
+            return json.dumps(
+                {
+                    "ok": True,
+                    "outputJsonlPaths": [str(output_path)],
+                    "latestOutputJsonlPath": str(output_path),
+                    "processed": 1,
+                },
+                ensure_ascii=False,
+            )
+        if script.name == "make_move_plan_from_inventory.py":
+            out_path = Path(args[args.index("--out") + 1])
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(
+                "\n".join([
+                    json.dumps({"_meta": {"kind": "move_plan_from_inventory"}}, ensure_ascii=False),
+                    json.dumps({"path_id": "p1", "src": r"B:\Unwatched\show.mp4", "dst": r"B:\VideoLibrary\Show\show.mp4"}, ensure_ascii=False),
+                ])
+                + "\n",
+                encoding="utf-8",
+            )
+            return json.dumps({"out": str(out_path), "planned": 1}, ensure_ascii=False)
+        return json.dumps({"ok": True}, ensure_ascii=False)
+
+    service = SourceRootWorkflowService(
+        python_runner=fake_python_runner,
+        powershell_runner=fake_powershell_runner,
+        py_root=tmp_path,
+    )
+
+    result = service.dry_run(cfg)
+
+    assert result.ok is True
+    payload = result.to_dict()
+    assert payload["runId"] == "run_source_root"
+    assert payload["flow"] == "source_root"
+    assert payload["phase"] == "plan_ready"
+    assert payload["outcome"] == "source_root_dry_run_complete"
+    assert payload["gates"] == []
+    assert payload["nextActions"] == [
+        {
+            "action": "review_plan",
+            "label": "Review sourceRoot move plan",
+            "tool": None,
+            "params": {"runId": "run_source_root", "artifactId": "source_root_move_plan"},
+            "requiresHumanInput": True,
+        }
+    ]
+
+    manifest_path = Path(cfg.windows_ops_root) / "runs" / "run_source_root" / "run.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["phase"] == "plan_ready"
+    assert manifest["artifactIds"] == [
+        "source_root_inventory",
+        "metadata_queue",
+        "metadata_extract_output_0001",
+        "source_root_move_plan",
+    ]
+    artifacts = manifest["artifacts"]
+    assert artifacts["source_root_inventory"]["type"] == "source_root_inventory"
+    assert artifacts["metadata_queue"]["inputArtifactIds"] == ["source_root_inventory"]
+    assert artifacts["metadata_extract_output_0001"]["inputArtifactIds"] == ["metadata_queue"]
+    assert artifacts["source_root_move_plan"]["inputArtifactIds"] == [
+        "source_root_inventory",
+        "metadata_queue",
+        "metadata_extract_output_0001",
+    ]
+    assert [name for name, _args in calls] == [
+        "ingest_inventory_jsonl.py",
+        "make_metadata_queue_from_inventory.py",
+        "run_metadata_batches_promptv1.py",
+        "make_move_plan_from_inventory.py",
+    ]
+
+
+def test_source_root_dry_run_failure_returns_failed_result_and_diagnostic(tmp_path) -> None:
+    cfg = make_config(tmp_path, run_id="run_source_root_failed")
+
+    def fake_powershell_runner(_script: str, args: list[str]) -> dict:
+        out_path = Path(args[args.index("-OutJsonl") + 1])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps({"_meta": {"kind": "unwatched_inventory"}}) + "\n", encoding="utf-8")
+        return {"out_jsonl": str(out_path)}
+
+    def fake_python_runner(script: Path, _args: list[str], _cwd: str | None = None) -> str:
+        if script.name == "make_metadata_queue_from_inventory.py":
+            raise RuntimeError("queue generation failed")
+        return json.dumps({"ok": True}, ensure_ascii=False)
+
+    service = SourceRootWorkflowService(
+        python_runner=fake_python_runner,
+        powershell_runner=fake_powershell_runner,
+        py_root=tmp_path,
+    )
+
+    result = service.dry_run(cfg)
+
+    assert result.ok is False
+    payload = result.to_dict()
+    assert payload["phase"] == "failed"
+    assert payload["outcome"] == "source_root_dry_run_failed"
+    assert payload["diagnostics"][0]["code"] == "source_root_dry_run_failed"
+    assert payload["diagnostics"][0]["message"] == "queue generation failed"
+
+    manifest_path = Path(cfg.windows_ops_root) / "runs" / "run_source_root_failed" / "run.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["phase"] == "failed"
+    assert manifest["diagnostics"][0]["message"] == "queue generation failed"

--- a/py/video_pipeline/workflows/__init__.py
+++ b/py/video_pipeline/workflows/__init__.py
@@ -16,6 +16,7 @@ from .models import (
 )
 from .state_machine import InvalidTransitionError, can_transition, validate_transition
 from .store import WorkflowStore
+from .source_root import SourceRootDryRunConfig, SourceRootWorkflowService
 
 __all__ = [
     "ArtifactRef",
@@ -26,6 +27,8 @@ __all__ = [
     "NextAction",
     "ReviewGate",
     "ReviewGateStatus",
+    "SourceRootDryRunConfig",
+    "SourceRootWorkflowService",
     "WorkflowFlow",
     "WorkflowPhase",
     "WorkflowResult",

--- a/py/video_pipeline/workflows/source_root.py
+++ b/py/video_pipeline/workflows/source_root.py
@@ -106,6 +106,7 @@ class SourceRootWorkflowService:
 
     def dry_run(self, config: SourceRootDryRunConfig) -> WorkflowResult:
         store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+        db_path = str(local_path_from_any(config.db))
         run = store.init_run(
             WorkflowFlow.SOURCE_ROOT,
             run_id=config.run_id,
@@ -113,14 +114,14 @@ class SourceRootWorkflowService:
                 "windowsOpsRoot": config.windows_ops_root,
                 "sourceRoot": config.source_root,
                 "destRoot": config.dest_root,
-                "db": config.db,
+                "db": db_path,
                 "driveRoutes": config.drive_routes or "",
                 "maxFilesPerRun": int(config.max_files_per_run),
                 "allowNeedsReview": bool(config.allow_needs_review),
             },
         )
         try:
-            return self._dry_run_existing(run.run_id, config, store)
+            return self._dry_run_existing(run.run_id, config, store, db_path)
         except Exception as exc:
             diagnostic = Diagnostic(
                 code="source_root_dry_run_failed",
@@ -146,6 +147,7 @@ class SourceRootWorkflowService:
         run_id: str,
         config: SourceRootDryRunConfig,
         store: WorkflowStore,
+        db_path: str,
     ) -> WorkflowResult:
         run_dir = store.run_dir(run_id)
         inventory_dir = run_dir / "inventory"
@@ -189,14 +191,14 @@ class SourceRootWorkflowService:
 
         self.python_runner(
             self.py_root / "ingest_inventory_jsonl.py",
-            ["--db", config.db, "--jsonl", str(inventory_path), "--target-root", source_root_win],
+            ["--db", db_path, "--jsonl", str(inventory_path), "--target-root", source_root_win],
             str(self.py_root),
         )
         self.python_runner(
             self.py_root / "make_metadata_queue_from_inventory.py",
             [
                 "--db",
-                config.db,
+                db_path,
                 "--inventory",
                 str(inventory_path),
                 "--source-root",
@@ -222,7 +224,7 @@ class SourceRootWorkflowService:
             self.py_root / "run_metadata_batches_promptv1.py",
             [
                 "--db",
-                config.db,
+                db_path,
                 "--queue",
                 str(queue_path),
                 "--outdir",
@@ -260,7 +262,7 @@ class SourceRootWorkflowService:
 
         plan_args = [
             "--db",
-            config.db,
+            db_path,
             "--inventory",
             str(inventory_path),
             "--source-root",

--- a/py/video_pipeline/workflows/source_root.py
+++ b/py/video_pipeline/workflows/source_root.py
@@ -1,0 +1,320 @@
+"""SourceRoot V2 workflow service skeleton."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from video_pipeline.platform.pathscan_common import (
+    canonicalize_windows_path,
+    windows_to_wsl_path,
+    wsl_to_windows_path,
+)
+
+from .models import (
+    ArtifactRef,
+    Diagnostic,
+    DiagnosticSeverity,
+    NextAction,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowResult,
+)
+from .store import WorkflowStore
+
+PythonRunner = Callable[[Path, list[str], str | None], str]
+PowerShellRunner = Callable[[str, list[str]], dict[str, Any]]
+
+
+@dataclass
+class SourceRootDryRunConfig:
+    windows_ops_root: str
+    source_root: str
+    dest_root: str
+    db: str
+    drive_routes: str = ""
+    max_files_per_run: int = 200
+    allow_needs_review: bool = False
+    run_id: str | None = None
+
+
+def run_py_uv(script: Path, args: list[str], cwd: str | None = None) -> str:
+    env = dict(os.environ)
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    cp = subprocess.run(
+        ["uv", "run", "python", str(script), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=cwd,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stdout.strip() or f"python failed rc={cp.returncode}: {script}")
+    return cp.stdout
+
+
+def parse_last_json_object_line(output: str) -> dict[str, Any]:
+    for line in reversed(str(output or "").splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def string_array(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str) and item]
+
+
+def local_path_from_any(path_str: str) -> Path:
+    return Path(windows_to_wsl_path(str(path_str))).resolve()
+
+
+def path_for_powershell(path: Path) -> str:
+    value = str(path)
+    if value.startswith("/mnt/"):
+        return wsl_to_windows_path(value)
+    return value
+
+
+class SourceRootWorkflowService:
+    def __init__(
+        self,
+        *,
+        python_runner: PythonRunner = run_py_uv,
+        powershell_runner: PowerShellRunner | None = None,
+        py_root: Path | None = None,
+    ) -> None:
+        self.python_runner = python_runner
+        self.powershell_runner = powershell_runner
+        self.py_root = py_root or Path(__file__).resolve().parents[2]
+
+    def dry_run(self, config: SourceRootDryRunConfig) -> WorkflowResult:
+        store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+        run = store.init_run(
+            WorkflowFlow.SOURCE_ROOT,
+            run_id=config.run_id,
+            config_snapshot={
+                "windowsOpsRoot": config.windows_ops_root,
+                "sourceRoot": config.source_root,
+                "destRoot": config.dest_root,
+                "db": config.db,
+                "driveRoutes": config.drive_routes or "",
+                "maxFilesPerRun": int(config.max_files_per_run),
+                "allowNeedsReview": bool(config.allow_needs_review),
+            },
+        )
+        try:
+            return self._dry_run_existing(run.run_id, config, store)
+        except Exception as exc:
+            diagnostic = Diagnostic(
+                code="source_root_dry_run_failed",
+                severity=DiagnosticSeverity.ERROR,
+                message=str(exc),
+                details={"exceptionType": type(exc).__name__},
+            )
+            self._record_failure(store, run.run_id, diagnostic)
+            failed_run = store.read_run(run.run_id)
+            return WorkflowResult(
+                ok=False,
+                run_id=run.run_id,
+                flow=WorkflowFlow.SOURCE_ROOT,
+                phase=failed_run.phase,
+                outcome="source_root_dry_run_failed",
+                artifacts=[failed_run.artifacts[aid] for aid in failed_run.artifact_ids],
+                gates=[failed_run.review_gates[gid] for gid in failed_run.review_gate_ids],
+                diagnostics=failed_run.diagnostics,
+            )
+
+    def _dry_run_existing(
+        self,
+        run_id: str,
+        config: SourceRootDryRunConfig,
+        store: WorkflowStore,
+    ) -> WorkflowResult:
+        run_dir = store.run_dir(run_id)
+        inventory_dir = run_dir / "inventory"
+        metadata_dir = run_dir / "metadata"
+        plan_dir = run_dir / "plan"
+        inventory_path = inventory_dir / "inventory_unwatched.jsonl"
+        queue_path = metadata_dir / "queue_unwatched_batch.jsonl"
+        plan_path = plan_dir / "move_plan_from_inventory.jsonl"
+
+        source_root_win = canonicalize_windows_path(config.source_root)
+        dest_root_win = canonicalize_windows_path(config.dest_root)
+        ops_root_win = canonicalize_windows_path(config.windows_ops_root)
+        scripts_root_win = canonicalize_windows_path(str(local_path_from_any(config.windows_ops_root) / "scripts"))
+
+        if self.powershell_runner is None:
+            from video_pipeline.platform.windows_pwsh_bridge import run_pwsh_json
+
+            powershell_runner = run_pwsh_json
+        else:
+            powershell_runner = self.powershell_runner
+
+        powershell_runner(
+            scripts_root_win + r"\unwatched_inventory.ps1",
+            [
+                "-Root",
+                source_root_win,
+                "-OpsRoot",
+                ops_root_win,
+                "-OutJsonl",
+                path_for_powershell(inventory_path),
+                "-IncludeHash",
+            ],
+        )
+        inventory_artifact = store.register_artifact(
+            run_id,
+            artifact_type="source_root_inventory",
+            path=inventory_path,
+            producer="unwatched_inventory.ps1",
+            artifact_id="source_root_inventory",
+        )
+
+        self.python_runner(
+            self.py_root / "ingest_inventory_jsonl.py",
+            ["--db", config.db, "--jsonl", str(inventory_path), "--target-root", source_root_win],
+            str(self.py_root),
+        )
+        self.python_runner(
+            self.py_root / "make_metadata_queue_from_inventory.py",
+            [
+                "--db",
+                config.db,
+                "--inventory",
+                str(inventory_path),
+                "--source-root",
+                source_root_win,
+                "--out",
+                str(queue_path),
+                "--limit",
+                str(int(config.max_files_per_run)),
+            ],
+            str(self.py_root),
+        )
+        queue_artifact = store.register_artifact(
+            run_id,
+            artifact_type="metadata_queue",
+            path=queue_path,
+            producer="make_metadata_queue_from_inventory.py",
+            artifact_id="metadata_queue",
+            input_artifact_ids=[inventory_artifact.id],
+        )
+        store.transition_run(run_id, WorkflowPhase.INVENTORY_READY)
+
+        reextract_raw = self.python_runner(
+            self.py_root / "run_metadata_batches_promptv1.py",
+            [
+                "--db",
+                config.db,
+                "--queue",
+                str(queue_path),
+                "--outdir",
+                str(metadata_dir),
+                "--hints",
+                str(self.py_root.parent / "rules" / "program_aliases.yaml"),
+                "--batch-size",
+                "50",
+                "--start-batch",
+                "1",
+            ],
+            str(self.py_root),
+        )
+        reextract_summary = parse_last_json_object_line(reextract_raw)
+        output_paths = string_array(reextract_summary.get("outputJsonlPaths"))
+        latest_output = reextract_summary.get("latestOutputJsonlPath")
+        if not output_paths and isinstance(latest_output, str) and latest_output:
+            output_paths = [latest_output]
+
+        metadata_artifacts: list[ArtifactRef] = []
+        for idx, output_path in enumerate(output_paths, start=1):
+            metadata_artifacts.append(
+                store.register_artifact(
+                    run_id,
+                    artifact_type="metadata_extract_output",
+                    path=output_path,
+                    producer="run_metadata_batches_promptv1.py",
+                    artifact_id=f"metadata_extract_output_{idx:04d}",
+                    input_artifact_ids=[queue_artifact.id],
+                    metadata={"summary": reextract_summary},
+                )
+            )
+        store.transition_run(run_id, WorkflowPhase.METADATA_EXTRACTED)
+        store.transition_run(run_id, WorkflowPhase.METADATA_ACCEPTED)
+
+        plan_args = [
+            "--db",
+            config.db,
+            "--inventory",
+            str(inventory_path),
+            "--source-root",
+            source_root_win,
+            "--dest-root",
+            dest_root_win,
+            "--out",
+            str(plan_path),
+            "--limit",
+            str(int(config.max_files_per_run)),
+        ]
+        if config.drive_routes:
+            plan_args.extend(["--drive-routes", config.drive_routes])
+        if config.allow_needs_review:
+            plan_args.append("--allow-needs-review")
+        plan_raw = self.python_runner(self.py_root / "make_move_plan_from_inventory.py", plan_args, str(self.py_root))
+        plan_summary = parse_last_json_object_line(plan_raw)
+        plan_artifact = store.register_artifact(
+            run_id,
+            artifact_type="source_root_move_plan",
+            path=plan_path,
+            producer="make_move_plan_from_inventory.py",
+            artifact_id="source_root_move_plan",
+            input_artifact_ids=[inventory_artifact.id, queue_artifact.id, *[a.id for a in metadata_artifacts]],
+            metadata={"summary": plan_summary},
+        )
+        store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+
+        final_run = store.read_run(run_id)
+        return WorkflowResult(
+            ok=True,
+            run_id=run_id,
+            flow=WorkflowFlow.SOURCE_ROOT,
+            phase=WorkflowPhase.PLAN_READY,
+            outcome="source_root_dry_run_complete",
+            artifacts=[final_run.artifacts[aid] for aid in final_run.artifact_ids],
+            gates=[final_run.review_gates[gid] for gid in final_run.review_gate_ids],
+            next_actions=[
+                NextAction(
+                    action="review_plan",
+                    label="Review sourceRoot move plan",
+                    params={"runId": run_id, "artifactId": plan_artifact.id},
+                    requires_human_input=True,
+                )
+            ],
+            diagnostics=final_run.diagnostics,
+        )
+
+    def _record_failure(self, store: WorkflowStore, run_id: str, diagnostic: Diagnostic) -> None:
+        try:
+            run = store.read_run(run_id)
+            run.diagnostics.append(diagnostic)
+            store.write_run(run)
+            if run.phase != WorkflowPhase.FAILED.value:
+                store.transition_run(run_id, WorkflowPhase.FAILED)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Implements the first SourceRoot V2 service slice for #113.

- Adds a Python `SourceRootWorkflowService` with injectable Python and PowerShell runners.
- Initializes `WorkflowRun` with `flow=source_root` and stores artifacts under `<windowsOpsRoot>/runs/<runId>/`.
- Executes the existing dry-run stages for inventory, queue generation, rule-based extraction, and move planning.
- Registers inventory, metadata queue, extraction output, and move plan artifacts with checksums and input artifact links.
- Returns a TypeScript-compatible `WorkflowResult` with `runId`, phase, outcome, artifacts, diagnostics, and next actions.

## Validation

- `pytest -q py/tests` -> 50 passed

## Notes

- Does not implement review gates or apply safety; those remain for #114 and #115.
- Keeps the unrelated local `src/platform/runtime.ts` modification out of scope and unstaged.

Closes #113