### PR TITLE
SourceRoot V2: enforce run-scoped plan and apply safety

### DIFF
--- a/py/tests/test_source_root_workflow.py
+++ b/py/tests/test_source_root_workflow.py
@@ -516,6 +516,39 @@ def test_source_root_apply_rejects_checksum_mismatch(tmp_path) -> None:
     assert payload["diagnostics"][-1]["code"] == "source_root_apply_plan_checksum_mismatch"
 
 
+def test_source_root_apply_rejects_missing_run_without_crashing(tmp_path) -> None:
+    cfg = SourceRootApplyConfig(windows_ops_root=str(tmp_path / "ops"), run_id="run_missing")
+    service = SourceRootWorkflowService(py_root=tmp_path)
+
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "failed"
+    assert payload["outcome"] == "source_root_apply_rejected"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_rejected"
+    assert payload["diagnostics"][-1]["details"]["exceptionType"] == "FileNotFoundError"
+
+
+def test_source_root_apply_rejects_terminal_run_without_blocked_transition(tmp_path) -> None:
+    cfg, _plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_terminal")
+    store = WorkflowStore(Path(cfg.windows_ops_root))
+    store.transition_run(cfg.run_id, WorkflowPhase.COMPLETE)
+
+    service = SourceRootWorkflowService(py_root=tmp_path)
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "complete"
+    assert payload["outcome"] == "source_root_apply_rejected"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_wrong_phase"
+    manifest_path = Path(cfg.windows_ops_root) / "runs" / cfg.run_id / "run.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["phase"] == "complete"
+    assert manifest["diagnostics"][-1]["code"] == "source_root_apply_wrong_phase"
+
+
 def test_source_root_apply_registers_apply_artifacts_and_completes(tmp_path) -> None:
     cfg, _plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_apply_success")
     calls: list[tuple[str, list[str]]] = []

--- a/py/tests/test_source_root_workflow.py
+++ b/py/tests/test_source_root_workflow.py
@@ -560,6 +560,7 @@ def test_source_root_apply_rejects_other_flow_without_blocking_run(tmp_path) -> 
 
     payload = result.to_dict()
     assert payload["ok"] is False
+    assert payload["flow"] == "relocate"
     assert payload["phase"] == "plan_ready"
     assert payload["outcome"] == "source_root_apply_rejected"
     assert payload["diagnostics"][-1]["code"] == "source_root_apply_wrong_flow"

--- a/py/tests/test_source_root_workflow.py
+++ b/py/tests/test_source_root_workflow.py
@@ -1,7 +1,15 @@
 import json
 from pathlib import Path
 
-from video_pipeline.workflows import SourceRootDryRunConfig, SourceRootWorkflowService
+from video_pipeline.workflows import (
+    SourceRootApplyConfig,
+    SourceRootDryRunConfig,
+    SourceRootWorkflowService,
+    ReviewGateStatus,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowStore,
+)
 
 
 def make_config(tmp_path: Path, run_id: str = "run_source_root", db: str | None = None) -> SourceRootDryRunConfig:
@@ -115,8 +123,12 @@ def test_source_root_dry_run_registers_core_artifacts(tmp_path) -> None:
         {
             "action": "review_plan",
             "label": "Review sourceRoot move plan",
-            "tool": None,
-            "params": {"runId": "run_source_root", "artifactId": "source_root_move_plan"},
+            "tool": "video_pipeline_resume",
+            "params": {
+                "runId": "run_source_root",
+                "artifactId": "source_root_move_plan",
+                "resumeAction": "apply_source_root_move_plan",
+            },
             "requiresHumanInput": True,
         }
     ]
@@ -381,3 +393,189 @@ def test_source_root_dry_run_failure_returns_failed_result_and_diagnostic(tmp_pa
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["phase"] == "failed"
     assert manifest["diagnostics"][0]["message"] == "queue generation failed"
+
+
+def register_plan_ready_run(tmp_path: Path, run_id: str = "run_source_root_apply") -> tuple[SourceRootApplyConfig, Path]:
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(
+        WorkflowFlow.SOURCE_ROOT,
+        run_id=run_id,
+        config_snapshot={"windowsOpsRoot": str(ops_root), "db": str(ops_root / "db" / "mediaops.sqlite")},
+    )
+    plan_path = ops_root / "runs" / run_id / "plan" / "move_plan_from_inventory.jsonl"
+    plan_path.write_text(
+        "\n".join([
+            json.dumps({"_meta": {"kind": "move_plan_from_inventory"}}, ensure_ascii=False),
+            json.dumps(
+                {
+                    "op": "move",
+                    "path_id": "p1",
+                    "src": r"B:\Unwatched\show.mp4",
+                    "dst": r"B:\VideoLibrary\Show\show.mp4",
+                },
+                ensure_ascii=False,
+            ),
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    store.register_artifact(
+        run_id,
+        artifact_type="source_root_move_plan",
+        path=plan_path,
+        producer="make_move_plan_from_inventory.py",
+        artifact_id="source_root_move_plan",
+    )
+    store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+    return SourceRootApplyConfig(windows_ops_root=str(ops_root), run_id=run_id), plan_path
+
+
+def test_source_root_apply_rejects_plan_artifact_from_another_run(tmp_path) -> None:
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_a", config_snapshot={"db": str(ops_root / "db.sqlite")})
+    foreign_plan = ops_root / "runs" / "run_a" / "plan" / "foreign.jsonl"
+    foreign_plan.write_text("{}\n", encoding="utf-8")
+    store.register_artifact(
+        "run_a",
+        artifact_type="source_root_move_plan",
+        path=foreign_plan,
+        producer="test",
+        artifact_id="foreign_plan",
+    )
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_b", config_snapshot={"db": str(ops_root / "db.sqlite")})
+    store.transition_run("run_b", WorkflowPhase.PLAN_READY)
+
+    service = SourceRootWorkflowService(py_root=tmp_path)
+    result = service.apply(SourceRootApplyConfig(windows_ops_root=str(ops_root), run_id="run_b", artifact_id="foreign_plan"))
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["outcome"] == "source_root_apply_rejected"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_plan_not_in_run"
+
+
+def test_source_root_apply_rejects_open_review_gate(tmp_path) -> None:
+    cfg, _plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_gate_blocked")
+    store = WorkflowStore(Path(cfg.windows_ops_root))
+    store.create_review_gate(
+        cfg.run_id,
+        gate_type="metadata_review",
+        artifact_ids=["metadata_review_yaml_0001"],
+        gate_id="metadata_review",
+    )
+
+    service = SourceRootWorkflowService(py_root=tmp_path)
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_review_gate_blocked"
+    assert payload["diagnostics"][-1]["details"]["blockingGateIds"] == ["metadata_review"]
+
+
+def test_source_root_apply_rejects_rejected_review_gate(tmp_path) -> None:
+    cfg, _plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_gate_rejected")
+    store = WorkflowStore(Path(cfg.windows_ops_root))
+    store.create_review_gate(
+        cfg.run_id,
+        gate_type="metadata_review",
+        artifact_ids=["metadata_review_yaml_0001"],
+        gate_id="metadata_review",
+    )
+    store.update_review_gate(
+        cfg.run_id,
+        "metadata_review",
+        status=ReviewGateStatus.REJECTED,
+        resolution={"reason": "bad metadata"},
+    )
+
+    service = SourceRootWorkflowService(py_root=tmp_path)
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_review_gate_blocked"
+    assert payload["diagnostics"][-1]["details"]["blockingGateStatuses"] == {"metadata_review": "rejected"}
+
+
+def test_source_root_apply_rejects_checksum_mismatch(tmp_path) -> None:
+    cfg, plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_stale_plan")
+    plan_path.write_text("{}\n", encoding="utf-8")
+
+    service = SourceRootWorkflowService(py_root=tmp_path)
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_plan_checksum_mismatch"
+
+
+def test_source_root_apply_registers_apply_artifacts_and_completes(tmp_path) -> None:
+    cfg, _plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_apply_success")
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_powershell_runner(script: str, args: list[str]) -> dict:
+        assert script.endswith(r"\apply_move_plan.ps1")
+        assert "-PlanJsonl" in args
+        out_path = Path(cfg.windows_ops_root) / "move" / "move_apply_test.jsonl"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            "\n".join([
+                json.dumps({"_meta": {"kind": "move_apply"}}, ensure_ascii=False),
+                json.dumps(
+                    {
+                        "op": "move",
+                        "ts": "2026-04-25T00:00:00Z",
+                        "path_id": "p1",
+                        "src": r"B:\Unwatched\show.mp4",
+                        "dst": r"B:\VideoLibrary\Show\show.mp4",
+                        "ok": True,
+                    },
+                    ensure_ascii=False,
+                ),
+            ])
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"out_jsonl": str(out_path), "run_id": "apply_test"}
+
+    def fake_python_runner(script: Path, args: list[str], _cwd: str | None = None) -> str:
+        calls.append((script.name, list(args)))
+        assert script.name == "update_db_paths_from_move_apply.py"
+        assert "--db" in args
+        assert "--applied" in args
+        return json.dumps({"updated": 1, "events": 1, "run_kind": "source_root_apply"}, ensure_ascii=False)
+
+    service = SourceRootWorkflowService(
+        python_runner=fake_python_runner,
+        powershell_runner=fake_powershell_runner,
+        py_root=tmp_path,
+    )
+
+    result = service.resume(cfg, action="apply_source_root_move_plan")
+
+    payload = result.to_dict()
+    assert payload["ok"] is True
+    assert payload["phase"] == "complete"
+    assert payload["outcome"] == "source_root_apply_complete"
+    assert [name for name, _args in calls] == ["update_db_paths_from_move_apply.py"]
+
+    manifest_path = Path(cfg.windows_ops_root) / "runs" / cfg.run_id / "run.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["phase"] == "complete"
+    assert manifest["status"] == "complete"
+    assert manifest["artifactIds"] == [
+        "source_root_move_plan",
+        "source_root_move_apply_log",
+        "source_root_db_update",
+        "source_root_move_apply_stats",
+    ]
+    assert manifest["artifacts"]["source_root_move_apply_log"]["inputArtifactIds"] == ["source_root_move_plan"]
+    assert manifest["artifacts"]["source_root_db_update"]["inputArtifactIds"] == ["source_root_move_apply_log"]
+    assert manifest["artifacts"]["source_root_move_apply_stats"]["metadata"]["summary"]["succeeded"] == 1

--- a/py/tests/test_source_root_workflow.py
+++ b/py/tests/test_source_root_workflow.py
@@ -549,6 +549,27 @@ def test_source_root_apply_rejects_terminal_run_without_blocked_transition(tmp_p
     assert manifest["diagnostics"][-1]["code"] == "source_root_apply_wrong_phase"
 
 
+def test_source_root_apply_rejects_other_flow_without_blocking_run(tmp_path) -> None:
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_relocate", config_snapshot={"db": str(ops_root / "db.sqlite")})
+    store.transition_run("run_relocate", WorkflowPhase.PLAN_READY)
+
+    service = SourceRootWorkflowService(py_root=tmp_path)
+    result = service.apply(SourceRootApplyConfig(windows_ops_root=str(ops_root), run_id="run_relocate"))
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "plan_ready"
+    assert payload["outcome"] == "source_root_apply_rejected"
+    assert payload["diagnostics"][-1]["code"] == "source_root_apply_wrong_flow"
+    manifest_path = ops_root / "runs" / "run_relocate" / "run.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["flow"] == "relocate"
+    assert manifest["phase"] == "plan_ready"
+    assert manifest["diagnostics"][-1]["code"] == "source_root_apply_wrong_flow"
+
+
 def test_source_root_apply_registers_apply_artifacts_and_completes(tmp_path) -> None:
     cfg, _plan_path = register_plan_ready_run(tmp_path, run_id="run_source_root_apply_success")
     calls: list[tuple[str, list[str]]] = []

--- a/py/video_pipeline/workflows/__init__.py
+++ b/py/video_pipeline/workflows/__init__.py
@@ -16,7 +16,7 @@ from .models import (
 )
 from .state_machine import InvalidTransitionError, can_transition, validate_transition
 from .store import WorkflowStore
-from .source_root import SourceRootDryRunConfig, SourceRootWorkflowService
+from .source_root import SourceRootApplyConfig, SourceRootDryRunConfig, SourceRootWorkflowService
 
 __all__ = [
     "ArtifactRef",
@@ -27,6 +27,7 @@ __all__ = [
     "NextAction",
     "ReviewGate",
     "ReviewGateStatus",
+    "SourceRootApplyConfig",
     "SourceRootDryRunConfig",
     "SourceRootWorkflowService",
     "WorkflowFlow",

--- a/py/video_pipeline/workflows/source_root.py
+++ b/py/video_pipeline/workflows/source_root.py
@@ -691,7 +691,7 @@ class SourceRootWorkflowService:
 
         run.diagnostics.append(diagnostic)
         store.write_run(run)
-        if run.phase not in {
+        if run.flow == WorkflowFlow.SOURCE_ROOT.value and run.phase not in {
             WorkflowPhase.BLOCKED.value,
             WorkflowPhase.COMPLETE.value,
             WorkflowPhase.FAILED.value,

--- a/py/video_pipeline/workflows/source_root.py
+++ b/py/video_pipeline/workflows/source_root.py
@@ -677,10 +677,25 @@ class SourceRootWorkflowService:
         outcome: str,
         diagnostic: Diagnostic,
     ) -> WorkflowResult:
-        run = store.read_run(run_id)
+        try:
+            run = store.read_run(run_id)
+        except Exception:
+            return WorkflowResult(
+                ok=False,
+                run_id=run_id,
+                flow=WorkflowFlow.SOURCE_ROOT,
+                phase=WorkflowPhase.FAILED,
+                outcome=outcome,
+                diagnostics=[diagnostic],
+            )
+
         run.diagnostics.append(diagnostic)
         store.write_run(run)
-        if run.phase != WorkflowPhase.BLOCKED.value:
+        if run.phase not in {
+            WorkflowPhase.BLOCKED.value,
+            WorkflowPhase.COMPLETE.value,
+            WorkflowPhase.FAILED.value,
+        }:
             store.transition_run(run_id, WorkflowPhase.BLOCKED)
         final_run = store.read_run(run_id)
         return WorkflowResult(

--- a/py/video_pipeline/workflows/source_root.py
+++ b/py/video_pipeline/workflows/source_root.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from video_pipeline.domain.move_apply_stats import aggregate_move_apply
 from video_pipeline.platform.pathscan_common import (
     canonicalize_windows_path,
     windows_to_wsl_path,
@@ -17,17 +18,25 @@ from video_pipeline.platform.pathscan_common import (
 
 from .models import (
     ArtifactRef,
+    ArtifactStatus,
     Diagnostic,
     DiagnosticSeverity,
     NextAction,
+    ReviewGateStatus,
     WorkflowFlow,
     WorkflowPhase,
     WorkflowResult,
 )
-from .store import WorkflowStore
+from .store import WorkflowStore, sha256_file
 
 PythonRunner = Callable[[Path, list[str], str | None], str]
 PowerShellRunner = Callable[[str, list[str]], dict[str, Any]]
+
+
+class SourceRootApplyRejected(Exception):
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(diagnostic.message)
 
 
 @dataclass
@@ -40,6 +49,14 @@ class SourceRootDryRunConfig:
     max_files_per_run: int = 200
     allow_needs_review: bool = False
     run_id: str | None = None
+
+
+@dataclass
+class SourceRootApplyConfig:
+    windows_ops_root: str
+    run_id: str
+    artifact_id: str = "source_root_move_plan"
+    db: str | None = None
 
 
 def run_py_uv(script: Path, args: list[str], cwd: str | None = None) -> str:
@@ -92,6 +109,11 @@ def path_for_powershell(path: Path) -> str:
     return value
 
 
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 class SourceRootWorkflowService:
     def __init__(
         self,
@@ -140,6 +162,162 @@ class SourceRootWorkflowService:
                 artifacts=[failed_run.artifacts[aid] for aid in failed_run.artifact_ids],
                 gates=[failed_run.review_gates[gid] for gid in failed_run.review_gate_ids],
                 diagnostics=failed_run.diagnostics,
+            )
+
+    def resume(self, config: SourceRootApplyConfig, *, action: str = "apply_source_root_move_plan") -> WorkflowResult:
+        if action != "apply_source_root_move_plan":
+            store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+            diagnostic = Diagnostic(
+                code="source_root_resume_action_unsupported",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"unsupported sourceRoot resume action: {action}",
+                details={"action": action},
+            )
+            return self._block_apply(store, config.run_id, "source_root_resume_action_unsupported", diagnostic)
+        return self.apply(config)
+
+    def apply(self, config: SourceRootApplyConfig) -> WorkflowResult:
+        store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+        try:
+            plan_artifact = self._validate_apply_plan(store, config.run_id, config.artifact_id)
+        except SourceRootApplyRejected as exc:
+            return self._block_apply(store, config.run_id, "source_root_apply_rejected", exc.diagnostic)
+        except Exception as exc:
+            diagnostic = Diagnostic(
+                code="source_root_apply_rejected",
+                severity=DiagnosticSeverity.ERROR,
+                message=str(exc),
+                details={"exceptionType": type(exc).__name__, "artifactId": config.artifact_id},
+            )
+            return self._block_apply(store, config.run_id, "source_root_apply_rejected", diagnostic)
+
+        run = store.read_run(config.run_id)
+        db_path = str(local_path_from_any(config.db or str(run.config_snapshot.get("db") or "")))
+        run_dir = store.run_dir(config.run_id)
+        apply_dir = run_dir / "apply"
+        logs_dir = run_dir / "logs"
+        ops_root_win = canonicalize_windows_path(str(local_path_from_any(config.windows_ops_root)))
+        scripts_root_win = canonicalize_windows_path(str(local_path_from_any(config.windows_ops_root) / "scripts"))
+
+        if self.powershell_runner is None:
+            from video_pipeline.platform.windows_pwsh_bridge import run_pwsh_json
+
+            powershell_runner = run_pwsh_json
+        else:
+            powershell_runner = self.powershell_runner
+
+        try:
+            apply_meta = powershell_runner(
+                scripts_root_win + r"\apply_move_plan.ps1",
+                ["-PlanJsonl", path_for_powershell(Path(plan_artifact.path)), "-OpsRoot", ops_root_win],
+            )
+            applied_out = str(apply_meta.get("out_jsonl") or "")
+            if not applied_out:
+                raise RuntimeError("apply_move_plan.ps1 did not return out_jsonl")
+            applied_path = local_path_from_any(applied_out)
+            apply_log_artifact = store.register_artifact(
+                config.run_id,
+                artifact_type="source_root_move_apply_log",
+                path=applied_path,
+                producer="apply_move_plan.ps1",
+                artifact_id="source_root_move_apply_log",
+                input_artifact_ids=[plan_artifact.id],
+                metadata={"summary": apply_meta},
+            )
+
+            db_update_raw = self.python_runner(
+                self.py_root / "update_db_paths_from_move_apply.py",
+                [
+                    "--db",
+                    db_path,
+                    "--applied",
+                    str(applied_path),
+                    "--run-kind",
+                    "source_root_apply",
+                    "--event-kind",
+                    "move",
+                    "--detail-source",
+                    "SourceRootWorkflowService.apply",
+                ],
+                str(self.py_root),
+            )
+            db_update_summary = parse_last_json_object_line(db_update_raw)
+            db_update_path = logs_dir / "source_root_db_update.json"
+            write_json(db_update_path, db_update_summary or {"raw": db_update_raw})
+            db_update_artifact = store.register_artifact(
+                config.run_id,
+                artifact_type="source_root_db_update",
+                path=db_update_path,
+                producer="update_db_paths_from_move_apply.py",
+                artifact_id="source_root_db_update",
+                input_artifact_ids=[apply_log_artifact.id],
+                metadata={"summary": db_update_summary},
+            )
+
+            move_stats = aggregate_move_apply(applied_path)
+            stats_path = apply_dir / "source_root_move_apply_stats.json"
+            write_json(stats_path, move_stats)
+            stats_artifact = store.register_artifact(
+                config.run_id,
+                artifact_type="source_root_move_apply_stats",
+                path=stats_path,
+                producer="move_apply_stats.py",
+                artifact_id="source_root_move_apply_stats",
+                input_artifact_ids=[apply_log_artifact.id],
+                metadata={"summary": move_stats},
+            )
+
+            if int(move_stats.get("failed") or 0) > 0:
+                diagnostic = Diagnostic(
+                    code="source_root_apply_move_failures",
+                    severity=DiagnosticSeverity.ERROR,
+                    message="one or more move operations failed during sourceRoot apply",
+                    details={"moveApplyStats": move_stats},
+                )
+                self._record_failure(store, config.run_id, diagnostic)
+                final_run = store.read_run(config.run_id)
+                return WorkflowResult(
+                    ok=False,
+                    run_id=config.run_id,
+                    flow=WorkflowFlow.SOURCE_ROOT,
+                    phase=final_run.phase,
+                    outcome="source_root_apply_failed",
+                    artifacts=[final_run.artifacts[aid] for aid in final_run.artifact_ids],
+                    gates=[final_run.review_gates[gid] for gid in final_run.review_gate_ids],
+                    diagnostics=final_run.diagnostics,
+                )
+
+            store.transition_run(config.run_id, WorkflowPhase.APPLIED)
+            store.transition_run(config.run_id, WorkflowPhase.COMPLETE)
+            final_run = store.read_run(config.run_id)
+            return WorkflowResult(
+                ok=True,
+                run_id=config.run_id,
+                flow=WorkflowFlow.SOURCE_ROOT,
+                phase=WorkflowPhase.COMPLETE,
+                outcome="source_root_apply_complete",
+                artifacts=[final_run.artifacts[aid] for aid in final_run.artifact_ids],
+                gates=[final_run.review_gates[gid] for gid in final_run.review_gate_ids],
+                diagnostics=final_run.diagnostics,
+            )
+        except Exception as exc:
+            diagnostic = Diagnostic(
+                code="source_root_apply_failed",
+                severity=DiagnosticSeverity.ERROR,
+                message=str(exc),
+                details={"exceptionType": type(exc).__name__, "artifactId": config.artifact_id},
+            )
+            self._record_failure(store, config.run_id, diagnostic)
+            final_run = store.read_run(config.run_id)
+            return WorkflowResult(
+                ok=False,
+                run_id=config.run_id,
+                flow=WorkflowFlow.SOURCE_ROOT,
+                phase=final_run.phase,
+                outcome="source_root_apply_failed",
+                artifacts=[final_run.artifacts[aid] for aid in final_run.artifact_ids],
+                gates=[final_run.review_gates[gid] for gid in final_run.review_gate_ids],
+                diagnostics=final_run.diagnostics,
             )
 
     def _dry_run_existing(
@@ -381,10 +559,138 @@ class SourceRootWorkflowService:
                 NextAction(
                     action="review_plan",
                     label="Review sourceRoot move plan",
-                    params={"runId": run_id, "artifactId": plan_artifact.id},
+                    tool="video_pipeline_resume",
+                    params={
+                        "runId": run_id,
+                        "artifactId": plan_artifact.id,
+                        "resumeAction": "apply_source_root_move_plan",
+                    },
                     requires_human_input=True,
                 )
             ],
+            diagnostics=final_run.diagnostics,
+        )
+
+    def _validate_apply_plan(self, store: WorkflowStore, run_id: str, artifact_id: str) -> ArtifactRef:
+        run = store.read_run(run_id)
+        if run.flow != WorkflowFlow.SOURCE_ROOT.value:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_wrong_flow",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"run is not a sourceRoot workflow: {run.flow}",
+                details={"runId": run_id, "flow": run.flow},
+            ))
+        if run.phase != WorkflowPhase.PLAN_READY.value:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_wrong_phase",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"sourceRoot apply requires phase plan_ready, got {run.phase}",
+                details={"runId": run_id, "phase": run.phase},
+            ))
+
+        blocking_gates = [
+            gate
+            for gate in run.review_gates.values()
+            if gate.requires_human_review
+            and gate.status in {ReviewGateStatus.OPEN.value, ReviewGateStatus.REJECTED.value}
+        ]
+        if blocking_gates:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_review_gate_blocked",
+                severity=DiagnosticSeverity.ERROR,
+                message="sourceRoot apply is blocked by unresolved or rejected review gates",
+                details={
+                    "runId": run_id,
+                    "blockingGateIds": [gate.id for gate in blocking_gates],
+                    "blockingGateStatuses": {gate.id: gate.status for gate in blocking_gates},
+                },
+            ))
+
+        plan_artifact = run.artifacts.get(artifact_id)
+        if plan_artifact is None:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_plan_not_in_run",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"move plan artifact does not belong to run {run_id}: {artifact_id}",
+                details={"runId": run_id, "artifactId": artifact_id},
+            ))
+        if plan_artifact.type != "source_root_move_plan":
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_invalid_artifact_type",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"artifact is not a sourceRoot move plan: {plan_artifact.type}",
+                details={"runId": run_id, "artifactId": artifact_id, "artifactType": plan_artifact.type},
+            ))
+        if plan_artifact.status != ArtifactStatus.AVAILABLE.value:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_plan_not_available",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"move plan artifact is not available: {plan_artifact.status}",
+                details={"runId": run_id, "artifactId": artifact_id, "artifactStatus": plan_artifact.status},
+            ))
+
+        plan_artifact_ids = [
+            aid
+            for aid in run.artifact_ids
+            if aid in run.artifacts and run.artifacts[aid].type == "source_root_move_plan"
+        ]
+        if not plan_artifact_ids or plan_artifact_ids[-1] != artifact_id:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_plan_not_current",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"move plan artifact is not current for run {run_id}: {artifact_id}",
+                details={
+                    "runId": run_id,
+                    "artifactId": artifact_id,
+                    "currentArtifactId": plan_artifact_ids[-1] if plan_artifact_ids else None,
+                },
+            ))
+
+        plan_path = Path(plan_artifact.path)
+        if not plan_path.exists():
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_plan_missing",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"move plan artifact file is missing: {plan_path}",
+                details={"runId": run_id, "artifactId": artifact_id, "path": str(plan_path)},
+            ))
+        current_sha = sha256_file(plan_path)
+        if current_sha != plan_artifact.sha256:
+            raise SourceRootApplyRejected(Diagnostic(
+                code="source_root_apply_plan_checksum_mismatch",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"move plan artifact checksum changed: {plan_path}",
+                details={
+                    "runId": run_id,
+                    "artifactId": artifact_id,
+                    "path": str(plan_path),
+                    "expectedSha256": plan_artifact.sha256,
+                    "actualSha256": current_sha,
+                },
+            ))
+        return plan_artifact
+
+    def _block_apply(
+        self,
+        store: WorkflowStore,
+        run_id: str,
+        outcome: str,
+        diagnostic: Diagnostic,
+    ) -> WorkflowResult:
+        run = store.read_run(run_id)
+        run.diagnostics.append(diagnostic)
+        store.write_run(run)
+        if run.phase != WorkflowPhase.BLOCKED.value:
+            store.transition_run(run_id, WorkflowPhase.BLOCKED)
+        final_run = store.read_run(run_id)
+        return WorkflowResult(
+            ok=False,
+            run_id=run_id,
+            flow=WorkflowFlow.SOURCE_ROOT,
+            phase=final_run.phase,
+            outcome=outcome,
+            artifacts=[final_run.artifacts[aid] for aid in final_run.artifact_ids],
+            gates=[final_run.review_gates[gid] for gid in final_run.review_gate_ids],
             diagnostics=final_run.diagnostics,
         )
 

--- a/py/video_pipeline/workflows/source_root.py
+++ b/py/video_pipeline/workflows/source_root.py
@@ -701,7 +701,7 @@ class SourceRootWorkflowService:
         return WorkflowResult(
             ok=False,
             run_id=run_id,
-            flow=WorkflowFlow.SOURCE_ROOT,
+            flow=final_run.flow,
             phase=final_run.phase,
             outcome=outcome,
             artifacts=[final_run.artifacts[aid] for aid in final_run.artifact_ids],


### PR DESCRIPTION
## Summary

- Add SourceRoot V2 apply/resume behavior for run-scoped move plans.
- Reject apply when the selected plan is cross-run, stale, missing, mutated, unavailable, or blocked by open/rejected review gates.
- Execute the existing PowerShell apply boundary and DB update path when validation passes, then register apply log, DB update, and stats artifacts.

## Validation

- `pytest -q py/tests/test_source_root_workflow.py py/tests/test_workflows.py`
- `pytest -q py/tests`
- `git diff --check`

Closes #115