### PR TITLE
[codex] Add relocate V2 workflow service

### DIFF
--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -251,7 +251,12 @@ def test_relocate_dry_run_already_correct_requires_explicit_count(tmp_path) -> N
     assert payload["outcome"] == "relocate_already_correct"
 
 
-def register_relocate_plan_ready_run(tmp_path: Path, run_id: str = "run_relocate_apply") -> tuple[RelocateApplyConfig, Path]:
+def register_relocate_plan_ready_run(
+    tmp_path: Path,
+    run_id: str = "run_relocate_apply",
+    *,
+    on_dst_exists: str = "error",
+) -> tuple[RelocateApplyConfig, Path]:
     ops_root = tmp_path / "ops"
     db_path = ops_root / "db" / "mediaops.sqlite"
     db_path.parent.mkdir(parents=True)
@@ -261,7 +266,7 @@ def register_relocate_plan_ready_run(tmp_path: Path, run_id: str = "run_relocate
     store.init_run(
         WorkflowFlow.RELOCATE,
         run_id=run_id,
-        config_snapshot={"windowsOpsRoot": str(ops_root), "db": str(db_path), "onDstExists": "error"},
+        config_snapshot={"windowsOpsRoot": str(ops_root), "db": str(db_path), "onDstExists": on_dst_exists},
     )
     plan_path = ops_root / "runs" / run_id / "plan" / "relocate_plan.jsonl"
     plan_path.write_text(
@@ -431,3 +436,56 @@ def test_relocate_apply_registers_artifacts_after_backup_and_completes(tmp_path)
         "relocate_plan",
         "relocate_db_backup",
     ]
+
+
+def test_relocate_apply_uses_run_scoped_on_dst_exists_policy(tmp_path) -> None:
+    cfg, _plan_path = register_relocate_plan_ready_run(
+        tmp_path,
+        run_id="run_relocate_apply_rename_suffix",
+        on_dst_exists="rename_suffix",
+    )
+
+    def fake_python_runner(script: Path, args: list[str], _cwd: str | None = None) -> str:
+        if script.name == "backup_mediaops_db.py" and args[args.index("--action") + 1] == "backup":
+            backup_path = Path(cfg.windows_ops_root) / "db" / "mediaops.sqlite.bak_20260426_pre_relocate_apply"
+            backup_path.write_text("db backup", encoding="utf-8")
+            return json.dumps({"ok": True, "action": "backup", "backup_path": str(backup_path), "error": ""}, ensure_ascii=False)
+        if script.name == "backup_mediaops_db.py" and args[args.index("--action") + 1] == "rotate":
+            return json.dumps({"ok": True, "action": "rotate", "deleted_count": 0}, ensure_ascii=False)
+        if script.name == "update_db_paths_from_move_apply.py":
+            return json.dumps({"updated": 1, "events": 1, "run_kind": "relocate"}, ensure_ascii=False)
+        return json.dumps({"ok": True}, ensure_ascii=False)
+
+    def fake_powershell_runner(_script: str, args: list[str]) -> dict:
+        assert args[args.index("-OnDstExists") + 1] == "rename_suffix"
+        out_path = Path(cfg.windows_ops_root) / "move" / "relocate_apply_rename_suffix.jsonl"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            "\n".join([
+                json.dumps({"_meta": {"kind": "move_apply"}}, ensure_ascii=False),
+                json.dumps(
+                    {
+                        "op": "move",
+                        "ts": "2026-04-26T00:00:00Z",
+                        "path_id": "p1",
+                        "src": r"B:\VideoLibrary\Old\show.mp4",
+                        "dst": r"B:\VideoLibrary\Show\show.mp4",
+                        "ok": True,
+                    },
+                    ensure_ascii=False,
+                ),
+            ])
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"out_jsonl": str(out_path), "run_id": "apply_test"}
+
+    service = RelocateWorkflowService(
+        python_runner=fake_python_runner,
+        powershell_runner=fake_powershell_runner,
+        py_root=tmp_path,
+    )
+
+    result = service.apply(cfg)
+
+    assert result.to_dict()["outcome"] == "relocate_apply_complete"

--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -1,0 +1,392 @@
+import json
+from pathlib import Path
+
+from video_pipeline.workflows import (
+    RelocateApplyConfig,
+    RelocateDryRunConfig,
+    RelocateWorkflowService,
+    ReviewGateStatus,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowStore,
+)
+
+
+def make_config(tmp_path: Path, *, run_id: str = "run_relocate", scenario: str = "plan_ready") -> RelocateDryRunConfig:
+    ops_root = tmp_path / "ops"
+    (ops_root / "scripts").mkdir(parents=True)
+    db_path = ops_root / "db" / "mediaops.sqlite"
+    db_path.parent.mkdir(parents=True)
+    db_path.write_text("db", encoding="utf-8")
+    return RelocateDryRunConfig(
+        windows_ops_root=str(ops_root),
+        dest_root=r"B:\VideoLibrary",
+        db=str(db_path),
+        roots=[r"B:\VideoLibrary"],
+        extensions=[".mp4"],
+        run_id=run_id,
+        limit=20,
+        queue_missing_metadata=True,
+        write_metadata_queue_on_dry_run=True,
+    )
+
+
+class RelocateWorkflowHarness:
+    def __init__(self, tmp_path: Path, *, run_id: str, scenario: str = "plan_ready") -> None:
+        self.tmp_path = tmp_path
+        self.cfg = make_config(tmp_path, run_id=run_id, scenario=scenario)
+        self.scenario = scenario
+        self.calls: list[tuple[str, list[str]]] = []
+
+    def python_runner(self, script: Path, args: list[str], _cwd: str | None = None) -> str:
+        self.calls.append((script.name, list(args)))
+        if script.name == "relocate_existing_files.py":
+            ops_root = Path(args[args.index("--windows-ops-root") + 1])
+            move_dir = ops_root / "move"
+            llm_dir = ops_root / "llm"
+            move_dir.mkdir(parents=True, exist_ok=True)
+            llm_dir.mkdir(parents=True, exist_ok=True)
+            plan_path = move_dir / f"{self.scenario}_relocate_plan.jsonl"
+            queue_path = llm_dir / f"{self.scenario}_relocate_queue.jsonl"
+
+            summary = {
+                "ok": True,
+                "tool": "video_pipeline_relocate_existing_files",
+                "apply": False,
+                "planPath": str(plan_path),
+                "metadataQueuePath": None,
+                "plannedMoves": 0,
+                "alreadyCorrect": 0,
+                "metadataMissingSkipped": 0,
+                "metadataQueuePlannedCount": 0,
+                "suspiciousProgramTitleSkipped": 0,
+                "needsReviewSkipped": 0,
+                "unreviewedMetadataSkipped": 0,
+                "outcomeType": "no_action_needed",
+                "errors": [],
+            }
+            rows = [{"_meta": {"kind": "relocate_plan"}}]
+            if self.scenario == "plan_ready":
+                summary["plannedMoves"] = 1
+                summary["outcomeType"] = "plan_ready_for_apply"
+                rows.append(
+                    {
+                        "path_id": "p1",
+                        "src": r"B:\VideoLibrary\Old\show.mp4",
+                        "dst": r"B:\VideoLibrary\Show\show.mp4",
+                        "status": "planned",
+                        "reason": "recompute_destination",
+                    }
+                )
+            elif self.scenario == "metadata_gap":
+                summary["metadataQueuePath"] = str(queue_path)
+                summary["metadataMissingSkipped"] = 1
+                summary["metadataQueuePlannedCount"] = 1
+                summary["requiresMetadataPreparation"] = True
+                summary["outcomeType"] = "metadata_preparation_required"
+                rows.append({"path_id": "p1", "src": r"B:\VideoLibrary\Unknown\show.mp4", "status": "skipped", "reason": "missing_metadata"})
+                queue_path.write_text(
+                    json.dumps({"_meta": {"kind": "relocate_metadata_queue"}}, ensure_ascii=False)
+                    + "\n"
+                    + json.dumps({"path_id": "p1", "path": r"B:\VideoLibrary\Unknown\show.mp4"}, ensure_ascii=False)
+                    + "\n",
+                    encoding="utf-8",
+                )
+            elif self.scenario == "suspicious":
+                summary["suspiciousProgramTitleSkipped"] = 1
+                summary["outcomeType"] = "metadata_preparation_required"
+                rows.append(
+                    {
+                        "path_id": "p1",
+                        "src": r"B:\VideoLibrary\Show\show.mp4",
+                        "status": "skipped",
+                        "reason": "suspicious_program_title",
+                        "program_title": "Show▽Episode",
+                    }
+                )
+            elif self.scenario == "already_correct":
+                summary["alreadyCorrect"] = 1
+                summary["outcomeType"] = "already_correct_or_no_action_needed"
+                rows.append(
+                    {
+                        "path_id": "p1",
+                        "src": r"B:\VideoLibrary\Show\show.mp4",
+                        "dst": r"B:\VideoLibrary\Show\show.mp4",
+                        "status": "skipped",
+                        "reason": "already_correct",
+                    }
+                )
+
+            plan_path.write_text(
+                "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+                encoding="utf-8",
+            )
+            return json.dumps(summary, ensure_ascii=False)
+        return json.dumps({"ok": True}, ensure_ascii=False)
+
+    def dry_run(self):
+        service = RelocateWorkflowService(python_runner=self.python_runner, py_root=self.tmp_path)
+        return service.dry_run(self.cfg)
+
+    def manifest(self) -> dict:
+        manifest_path = Path(self.cfg.windows_ops_root) / "runs" / self.cfg.run_id / "run.json"
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def assert_json_shape(payload: dict) -> None:
+    json.dumps(payload, ensure_ascii=False)
+    assert {"ok", "runId", "flow", "phase", "outcome", "artifacts", "gates", "nextActions", "diagnostics"} <= set(payload)
+    for artifact in payload["artifacts"]:
+        assert {"id", "type", "path", "sha256", "createdAt", "producer", "status", "inputArtifactIds", "metadata"} <= set(artifact)
+
+
+def test_relocate_dry_run_plan_ready_registers_plan_and_next_action(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_plan", scenario="plan_ready")
+
+    payload = harness.dry_run().to_dict()
+
+    assert_json_shape(payload)
+    assert payload["ok"] is True
+    assert payload["flow"] == "relocate"
+    assert payload["phase"] == "plan_ready"
+    assert payload["outcome"] == "relocate_plan_ready"
+    assert [artifact["id"] for artifact in payload["artifacts"]] == ["relocate_diagnostics", "relocate_plan"]
+    assert payload["nextActions"] == [
+        {
+            "action": "review_plan",
+            "label": "Review relocate move plan",
+            "tool": "video_pipeline_resume",
+            "params": {
+                "runId": "run_relocate_plan",
+                "artifactId": "relocate_plan",
+                "resumeAction": "apply_relocate_move_plan",
+            },
+            "requiresHumanInput": True,
+        }
+    ]
+
+    manifest = harness.manifest()
+    assert manifest["artifacts"]["relocate_plan"]["inputArtifactIds"] == ["relocate_diagnostics"]
+
+
+def test_relocate_dry_run_metadata_gap_registers_queue_without_already_correct(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_gap", scenario="metadata_gap")
+
+    payload = harness.dry_run().to_dict()
+
+    assert payload["ok"] is False
+    assert payload["phase"] == "review_required"
+    assert payload["outcome"] == "relocate_metadata_preparation_required"
+    assert [artifact["id"] for artifact in payload["artifacts"]] == [
+        "relocate_diagnostics",
+        "relocate_plan",
+        "relocate_metadata_queue",
+    ]
+    assert payload["outcome"] != "relocate_already_correct"
+    assert payload["diagnostics"][-1]["code"] == "relocate_metadata_preparation_required"
+    assert payload["nextActions"][0]["action"] == "prepare_relocate_metadata"
+
+
+def test_relocate_dry_run_suspicious_title_creates_review_gate(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_suspicious", scenario="suspicious")
+
+    payload = harness.dry_run().to_dict()
+
+    assert payload["ok"] is False
+    assert payload["phase"] == "review_required"
+    assert payload["outcome"] == "relocate_review_required"
+    assert payload["diagnostics"][-1]["code"] == "relocate_suspicious_program_titles"
+    assert payload["gates"][0]["id"] == "relocate_metadata_review"
+    assert payload["gates"][0]["artifactIds"] == ["relocate_diagnostics"]
+
+
+def test_relocate_dry_run_already_correct_requires_explicit_count(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_already", scenario="already_correct")
+
+    payload = harness.dry_run().to_dict()
+
+    assert payload["ok"] is True
+    assert payload["phase"] == "complete"
+    assert payload["outcome"] == "relocate_already_correct"
+
+
+def register_relocate_plan_ready_run(tmp_path: Path, run_id: str = "run_relocate_apply") -> tuple[RelocateApplyConfig, Path]:
+    ops_root = tmp_path / "ops"
+    db_path = ops_root / "db" / "mediaops.sqlite"
+    db_path.parent.mkdir(parents=True)
+    db_path.write_text("db", encoding="utf-8")
+    (ops_root / "scripts").mkdir(parents=True)
+    store = WorkflowStore(ops_root)
+    store.init_run(
+        WorkflowFlow.RELOCATE,
+        run_id=run_id,
+        config_snapshot={"windowsOpsRoot": str(ops_root), "db": str(db_path), "onDstExists": "error"},
+    )
+    plan_path = ops_root / "runs" / run_id / "plan" / "relocate_plan.jsonl"
+    plan_path.write_text(
+        "\n".join([
+            json.dumps({"_meta": {"kind": "relocate_plan"}}, ensure_ascii=False),
+            json.dumps(
+                {
+                    "path_id": "p1",
+                    "src": r"B:\VideoLibrary\Old\show.mp4",
+                    "dst": r"B:\VideoLibrary\Show\show.mp4",
+                    "status": "planned",
+                    "reason": "recompute_destination",
+                },
+                ensure_ascii=False,
+            ),
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    store.register_artifact(
+        run_id,
+        artifact_type="relocate_plan",
+        path=plan_path,
+        producer="relocate_existing_files.py",
+        artifact_id="relocate_plan",
+    )
+    store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+    return RelocateApplyConfig(windows_ops_root=str(ops_root), run_id=run_id), plan_path
+
+
+def test_relocate_apply_rejects_cross_run_plan(tmp_path) -> None:
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_a", config_snapshot={"db": str(ops_root / "db.sqlite")})
+    foreign_plan = ops_root / "runs" / "run_a" / "plan" / "foreign.jsonl"
+    foreign_plan.write_text("{}\n", encoding="utf-8")
+    store.register_artifact("run_a", artifact_type="relocate_plan", path=foreign_plan, producer="test", artifact_id="foreign_plan")
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_b", config_snapshot={"db": str(ops_root / "db.sqlite")})
+    store.transition_run("run_b", WorkflowPhase.PLAN_READY)
+
+    service = RelocateWorkflowService(py_root=tmp_path)
+    result = service.apply(RelocateApplyConfig(windows_ops_root=str(ops_root), run_id="run_b", artifact_id="foreign_plan"))
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["diagnostics"][-1]["code"] == "relocate_apply_plan_not_in_run"
+
+
+def test_relocate_apply_rejects_open_review_gate(tmp_path) -> None:
+    cfg, _plan_path = register_relocate_plan_ready_run(tmp_path, run_id="run_relocate_gate")
+    store = WorkflowStore(Path(cfg.windows_ops_root))
+    store.create_review_gate(
+        cfg.run_id,
+        gate_type="relocate_metadata_review",
+        artifact_ids=["relocate_diagnostics"],
+        gate_id="relocate_metadata_review",
+    )
+
+    service = RelocateWorkflowService(py_root=tmp_path)
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["diagnostics"][-1]["code"] == "relocate_apply_review_gate_blocked"
+
+
+def test_relocate_apply_rejects_checksum_mismatch(tmp_path) -> None:
+    cfg, plan_path = register_relocate_plan_ready_run(tmp_path, run_id="run_relocate_checksum")
+    plan_path.write_text("{}\n", encoding="utf-8")
+
+    service = RelocateWorkflowService(py_root=tmp_path)
+    result = service.apply(cfg)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "blocked"
+    assert payload["diagnostics"][-1]["code"] == "relocate_apply_plan_checksum_mismatch"
+
+
+def test_relocate_apply_rejects_other_flow_without_blocking_run(tmp_path) -> None:
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_source_root", config_snapshot={"db": str(ops_root / "db.sqlite")})
+    store.transition_run("run_source_root", WorkflowPhase.PLAN_READY)
+
+    service = RelocateWorkflowService(py_root=tmp_path)
+    result = service.apply(RelocateApplyConfig(windows_ops_root=str(ops_root), run_id="run_source_root"))
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["flow"] == "source_root"
+    assert payload["phase"] == "plan_ready"
+    assert payload["diagnostics"][-1]["code"] == "relocate_apply_wrong_flow"
+
+
+def test_relocate_apply_registers_artifacts_after_backup_and_completes(tmp_path) -> None:
+    cfg, _plan_path = register_relocate_plan_ready_run(tmp_path, run_id="run_relocate_apply_success")
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_python_runner(script: Path, args: list[str], _cwd: str | None = None) -> str:
+        calls.append((script.name, list(args)))
+        if script.name == "backup_mediaops_db.py" and args[args.index("--action") + 1] == "backup":
+            backup_path = Path(cfg.windows_ops_root) / "db" / "mediaops.sqlite.bak_20260426_pre_relocate_apply"
+            backup_path.write_text("db backup", encoding="utf-8")
+            return json.dumps({"ok": True, "action": "backup", "backup_path": str(backup_path), "error": ""}, ensure_ascii=False)
+        if script.name == "backup_mediaops_db.py" and args[args.index("--action") + 1] == "rotate":
+            return json.dumps({"ok": True, "action": "rotate", "deleted_count": 0}, ensure_ascii=False)
+        if script.name == "update_db_paths_from_move_apply.py":
+            return json.dumps({"updated": 1, "events": 1, "run_kind": "relocate"}, ensure_ascii=False)
+        return json.dumps({"ok": True}, ensure_ascii=False)
+
+    def fake_powershell_runner(script: str, args: list[str]) -> dict:
+        assert script.endswith(r"\apply_move_plan.ps1")
+        internal_plan = Path(args[args.index("-PlanJsonl") + 1])
+        assert internal_plan.read_text(encoding="utf-8").count('"status"') == 0
+        out_path = Path(cfg.windows_ops_root) / "move" / "relocate_apply.jsonl"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            "\n".join([
+                json.dumps({"_meta": {"kind": "move_apply"}}, ensure_ascii=False),
+                json.dumps(
+                    {
+                        "op": "move",
+                        "ts": "2026-04-26T00:00:00Z",
+                        "path_id": "p1",
+                        "src": r"B:\VideoLibrary\Old\show.mp4",
+                        "dst": r"B:\VideoLibrary\Show\show.mp4",
+                        "ok": True,
+                    },
+                    ensure_ascii=False,
+                ),
+            ])
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"out_jsonl": str(out_path), "run_id": "apply_test"}
+
+    service = RelocateWorkflowService(
+        python_runner=fake_python_runner,
+        powershell_runner=fake_powershell_runner,
+        py_root=tmp_path,
+    )
+
+    result = service.resume(cfg, action="apply_relocate_move_plan")
+
+    payload = result.to_dict()
+    assert payload["ok"] is True
+    assert payload["phase"] == "complete"
+    assert payload["outcome"] == "relocate_apply_complete"
+    assert [name for name, _args in calls] == [
+        "backup_mediaops_db.py",
+        "backup_mediaops_db.py",
+        "update_db_paths_from_move_apply.py",
+    ]
+    manifest = json.loads((Path(cfg.windows_ops_root) / "runs" / cfg.run_id / "run.json").read_text(encoding="utf-8"))
+    assert manifest["artifactIds"] == [
+        "relocate_plan",
+        "relocate_db_backup",
+        "relocate_internal_move_plan",
+        "relocate_move_apply_log",
+        "relocate_db_update",
+        "relocate_move_apply_stats",
+    ]
+    assert manifest["artifacts"]["relocate_internal_move_plan"]["inputArtifactIds"] == [
+        "relocate_plan",
+        "relocate_db_backup",
+    ]

--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -200,6 +200,47 @@ def test_relocate_dry_run_suspicious_title_creates_review_gate(tmp_path) -> None
     assert payload["gates"][0]["artifactIds"] == ["relocate_diagnostics"]
 
 
+def test_relocate_metadata_resume_actions_do_not_block_review_required_run(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_resume_gap", scenario="metadata_gap")
+    harness.dry_run()
+    service = RelocateWorkflowService(py_root=tmp_path)
+
+    result = service.resume(
+        RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
+        action="prepare_relocate_metadata",
+    )
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "review_required"
+    assert payload["outcome"] == "relocate_metadata_preparation_pending"
+    assert payload["nextActions"][0]["action"] == "prepare_relocate_metadata"
+    manifest = harness.manifest()
+    assert manifest["phase"] == "review_required"
+    assert payload["diagnostics"][-1]["code"] == "relocate_metadata_preparation_required"
+
+
+def test_relocate_review_resume_action_keeps_gate_open_without_blocking(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_resume_review", scenario="suspicious")
+    harness.dry_run()
+    service = RelocateWorkflowService(py_root=tmp_path)
+
+    result = service.resume(
+        RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
+        action="review_relocate_metadata",
+    )
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "review_required"
+    assert payload["outcome"] == "relocate_metadata_review_pending"
+    assert payload["nextActions"][0]["action"] == "review_relocate_metadata"
+    assert payload["nextActions"][0]["params"]["gateId"] == "relocate_metadata_review"
+    manifest = harness.manifest()
+    assert manifest["phase"] == "review_required"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "open"
+
+
 def test_relocate_dry_run_already_correct_requires_explicit_count(tmp_path) -> None:
     harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_already", scenario="already_correct")
 

--- a/py/video_pipeline/workflows/__init__.py
+++ b/py/video_pipeline/workflows/__init__.py
@@ -16,6 +16,7 @@ from .models import (
 )
 from .state_machine import InvalidTransitionError, can_transition, validate_transition
 from .store import WorkflowStore
+from .relocate import RelocateApplyConfig, RelocateDryRunConfig, RelocateWorkflowService
 from .source_root import SourceRootApplyConfig, SourceRootDryRunConfig, SourceRootWorkflowService
 
 __all__ = [
@@ -25,6 +26,9 @@ __all__ = [
     "DiagnosticSeverity",
     "InvalidTransitionError",
     "NextAction",
+    "RelocateApplyConfig",
+    "RelocateDryRunConfig",
+    "RelocateWorkflowService",
     "ReviewGate",
     "ReviewGateStatus",
     "SourceRootApplyConfig",

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -141,8 +141,10 @@ class RelocateWorkflowService:
             )
 
     def resume(self, config: RelocateApplyConfig, *, action: str = "apply_relocate_move_plan") -> WorkflowResult:
+        store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+        if action in {"prepare_relocate_metadata", "review_relocate_metadata"}:
+            return self._resume_metadata_action(store, config.run_id, action)
         if action != "apply_relocate_move_plan":
-            store = WorkflowStore(local_path_from_any(config.windows_ops_root))
             diagnostic = Diagnostic(
                 code="relocate_resume_action_unsupported",
                 severity=DiagnosticSeverity.ERROR,
@@ -720,6 +722,100 @@ class RelocateWorkflowService:
         run = store.read_run(run_id)
         run.diagnostics.append(diagnostic)
         store.write_run(run)
+
+    def _resume_metadata_action(self, store: WorkflowStore, run_id: str, action: str) -> WorkflowResult:
+        try:
+            run = store.read_run(run_id)
+        except Exception as exc:
+            return WorkflowResult(
+                ok=False,
+                run_id=run_id,
+                flow=WorkflowFlow.RELOCATE,
+                phase=WorkflowPhase.FAILED,
+                outcome="relocate_resume_action_failed",
+                diagnostics=[
+                    Diagnostic(
+                        code="relocate_resume_run_missing",
+                        severity=DiagnosticSeverity.ERROR,
+                        message=str(exc),
+                        details={"exceptionType": type(exc).__name__, "action": action},
+                    )
+                ],
+            )
+        if run.flow != WorkflowFlow.RELOCATE.value:
+            diagnostic = Diagnostic(
+                code="relocate_resume_wrong_flow",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"run is not a relocate workflow: {run.flow}",
+                details={"runId": run_id, "flow": run.flow, "action": action},
+            )
+            run.diagnostics.append(diagnostic)
+            store.write_run(run)
+            return self._result(
+                ok=False,
+                store=store,
+                run_id=run_id,
+                phase=run.phase,
+                outcome="relocate_resume_action_rejected",
+            )
+        if run.phase != WorkflowPhase.REVIEW_REQUIRED.value:
+            diagnostic = Diagnostic(
+                code="relocate_resume_wrong_phase",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate metadata resume requires phase review_required, got {run.phase}",
+                details={"runId": run_id, "phase": run.phase, "action": action},
+            )
+            run.diagnostics.append(diagnostic)
+            store.write_run(run)
+            return self._result(
+                ok=False,
+                store=store,
+                run_id=run_id,
+                phase=run.phase,
+                outcome="relocate_resume_action_rejected",
+            )
+
+        params: dict[str, Any] = {"runId": run_id}
+        queue_artifacts = [aid for aid in run.artifact_ids if run.artifacts.get(aid) and run.artifacts[aid].type == "relocate_metadata_queue"]
+        diagnostics_artifacts = [aid for aid in run.artifact_ids if run.artifacts.get(aid) and run.artifacts[aid].type == "relocate_diagnostics"]
+        if action == "prepare_relocate_metadata":
+            params["artifactIds"] = queue_artifacts or diagnostics_artifacts
+            next_action = NextAction(
+                action="prepare_relocate_metadata",
+                label="Prepare missing or blocked relocate metadata",
+                tool="video_pipeline_resume",
+                params=params,
+                requires_human_input=False,
+            )
+            outcome = "relocate_metadata_preparation_pending"
+        else:
+            gate_ids = [
+                gid
+                for gid in run.review_gate_ids
+                if gid in run.review_gates and run.review_gates[gid].status == ReviewGateStatus.OPEN.value
+            ]
+            if gate_ids:
+                params["gateId"] = gate_ids[0]
+                params["artifactIds"] = run.review_gates[gate_ids[0]].artifact_ids
+            else:
+                params["artifactIds"] = diagnostics_artifacts
+            next_action = NextAction(
+                action="review_relocate_metadata",
+                label="Review blocked relocate metadata",
+                tool="video_pipeline_resume",
+                params=params,
+                requires_human_input=True,
+            )
+            outcome = "relocate_metadata_review_pending"
+
+        return self._result(
+            ok=False,
+            store=store,
+            run_id=run_id,
+            phase=run.phase,
+            outcome=outcome,
+            next_actions=[next_action],
+        )
 
     def _block_apply(
         self,

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -68,7 +68,7 @@ class RelocateApplyConfig:
     run_id: str
     artifact_id: str = "relocate_plan"
     db: str | None = None
-    on_dst_exists: str = "error"
+    on_dst_exists: str | None = None
 
 
 def local_path_from_any(path_str: str) -> Path:

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -1,0 +1,790 @@
+"""Relocate V2 workflow service."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from video_pipeline.domain.move_apply_stats import aggregate_move_apply
+from video_pipeline.platform.pathscan_common import (
+    canonicalize_windows_path,
+    iter_jsonl,
+    windows_to_wsl_path,
+    wsl_to_windows_path,
+)
+
+from .models import (
+    ArtifactRef,
+    ArtifactStatus,
+    Diagnostic,
+    DiagnosticSeverity,
+    NextAction,
+    ReviewGateStatus,
+    WorkflowFlow,
+    WorkflowPhase,
+    WorkflowResult,
+)
+from .source_root import parse_last_json_object_line, path_for_powershell, run_py_uv, write_json
+from .store import WorkflowStore, sha256_file
+
+PythonRunner = Callable[[Path, list[str], str | None], str]
+PowerShellRunner = Callable[[str, list[str]], dict[str, Any]]
+
+
+class RelocateApplyRejected(Exception):
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(diagnostic.message)
+
+
+@dataclass
+class RelocateDryRunConfig:
+    windows_ops_root: str
+    dest_root: str
+    db: str
+    roots: list[str] | None = None
+    roots_file_path: str = ""
+    extensions: list[str] | None = None
+    drive_routes: str = ""
+    limit: int = 0
+    allow_needs_review: bool = False
+    allow_unreviewed_metadata: bool = False
+    queue_missing_metadata: bool = True
+    write_metadata_queue_on_dry_run: bool = True
+    scan_error_policy: str = "warn"
+    scan_error_threshold: int = 0
+    scan_retry_count: int = 1
+    on_dst_exists: str = "error"
+    skip_suspicious_title_check: bool = False
+    run_id: str | None = None
+
+
+@dataclass
+class RelocateApplyConfig:
+    windows_ops_root: str
+    run_id: str
+    artifact_id: str = "relocate_plan"
+    db: str | None = None
+    on_dst_exists: str = "error"
+
+
+def local_path_from_any(path_str: str) -> Path:
+    return Path(windows_to_wsl_path(str(path_str))).resolve()
+
+
+def read_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for rec in iter_jsonl(str(path)):
+        if isinstance(rec, dict):
+            rows.append(rec)
+    return rows
+
+
+class RelocateWorkflowService:
+    def __init__(
+        self,
+        *,
+        python_runner: PythonRunner = run_py_uv,
+        powershell_runner: PowerShellRunner | None = None,
+        py_root: Path | None = None,
+    ) -> None:
+        self.python_runner = python_runner
+        self.powershell_runner = powershell_runner
+        self.py_root = py_root or Path(__file__).resolve().parents[2]
+
+    def dry_run(self, config: RelocateDryRunConfig) -> WorkflowResult:
+        store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+        db_path = str(local_path_from_any(config.db))
+        run = store.init_run(
+            WorkflowFlow.RELOCATE,
+            run_id=config.run_id,
+            config_snapshot={
+                "windowsOpsRoot": config.windows_ops_root,
+                "destRoot": config.dest_root,
+                "db": db_path,
+                "roots": list(config.roots or []),
+                "rootsFilePath": config.roots_file_path,
+                "extensions": list(config.extensions or []),
+                "driveRoutes": config.drive_routes,
+                "limit": int(config.limit),
+                "allowNeedsReview": bool(config.allow_needs_review),
+                "allowUnreviewedMetadata": bool(config.allow_unreviewed_metadata),
+                "queueMissingMetadata": bool(config.queue_missing_metadata),
+                "writeMetadataQueueOnDryRun": bool(config.write_metadata_queue_on_dry_run),
+                "scanErrorPolicy": config.scan_error_policy,
+                "scanErrorThreshold": int(config.scan_error_threshold),
+                "scanRetryCount": int(config.scan_retry_count),
+                "onDstExists": config.on_dst_exists,
+                "skipSuspiciousTitleCheck": bool(config.skip_suspicious_title_check),
+            },
+        )
+        try:
+            return self._dry_run_existing(run.run_id, config, store, db_path)
+        except Exception as exc:
+            diagnostic = Diagnostic(
+                code="relocate_dry_run_failed",
+                severity=DiagnosticSeverity.ERROR,
+                message=str(exc),
+                details={"exceptionType": type(exc).__name__},
+            )
+            self._record_failure(store, run.run_id, diagnostic)
+            failed_run = store.read_run(run.run_id)
+            return self._result(
+                ok=False,
+                store=store,
+                run_id=run.run_id,
+                phase=failed_run.phase,
+                outcome="relocate_dry_run_failed",
+            )
+
+    def resume(self, config: RelocateApplyConfig, *, action: str = "apply_relocate_move_plan") -> WorkflowResult:
+        if action != "apply_relocate_move_plan":
+            store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+            diagnostic = Diagnostic(
+                code="relocate_resume_action_unsupported",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"unsupported relocate resume action: {action}",
+                details={"action": action},
+            )
+            return self._block_apply(store, config.run_id, "relocate_resume_action_unsupported", diagnostic)
+        return self.apply(config)
+
+    def apply(self, config: RelocateApplyConfig) -> WorkflowResult:
+        store = WorkflowStore(local_path_from_any(config.windows_ops_root))
+        try:
+            plan_artifact = self._validate_apply_plan(store, config.run_id, config.artifact_id)
+        except RelocateApplyRejected as exc:
+            return self._block_apply(store, config.run_id, "relocate_apply_rejected", exc.diagnostic)
+        except Exception as exc:
+            diagnostic = Diagnostic(
+                code="relocate_apply_rejected",
+                severity=DiagnosticSeverity.ERROR,
+                message=str(exc),
+                details={"exceptionType": type(exc).__name__, "artifactId": config.artifact_id},
+            )
+            return self._block_apply(store, config.run_id, "relocate_apply_rejected", diagnostic)
+
+        run = store.read_run(config.run_id)
+        db_path = str(local_path_from_any(config.db or str(run.config_snapshot.get("db") or "")))
+        run_dir = store.run_dir(config.run_id)
+        apply_dir = run_dir / "apply"
+        logs_dir = run_dir / "logs"
+        ops_root_win = canonicalize_windows_path(str(local_path_from_any(config.windows_ops_root)))
+        scripts_root_win = canonicalize_windows_path(str(local_path_from_any(config.windows_ops_root) / "scripts"))
+
+        if self.powershell_runner is None:
+            from video_pipeline.platform.windows_pwsh_bridge import run_pwsh_json
+
+            powershell_runner = run_pwsh_json
+        else:
+            powershell_runner = self.powershell_runner
+
+        try:
+            backup_raw = self.python_runner(
+                self.py_root / "backup_mediaops_db.py",
+                ["--db", db_path, "--action", "backup", "--descriptor", "pre_relocate_apply"],
+                str(self.py_root),
+            )
+            backup_summary = parse_last_json_object_line(backup_raw)
+            if backup_summary.get("ok") is not True:
+                raise RelocateApplyRejected(
+                    Diagnostic(
+                        code="relocate_apply_backup_failed",
+                        severity=DiagnosticSeverity.ERROR,
+                        message=str(backup_summary.get("error") or backup_raw or "pre-relocate DB backup failed"),
+                        details={"summary": backup_summary},
+                    )
+                )
+            backup_path_raw = str(backup_summary.get("backup_path") or "")
+            backup_path = local_path_from_any(backup_path_raw) if backup_path_raw else None
+            backup_artifact = None
+            if backup_path and backup_path.exists():
+                backup_artifact = store.register_artifact(
+                    config.run_id,
+                    artifact_type="relocate_db_backup",
+                    path=backup_path,
+                    producer="backup_mediaops_db.py",
+                    artifact_id="relocate_db_backup",
+                    input_artifact_ids=[plan_artifact.id],
+                    metadata={"summary": backup_summary},
+                )
+            else:
+                backup_summary_path = logs_dir / "relocate_db_backup.json"
+                write_json(backup_summary_path, backup_summary)
+                backup_artifact = store.register_artifact(
+                    config.run_id,
+                    artifact_type="relocate_db_backup",
+                    path=backup_summary_path,
+                    producer="backup_mediaops_db.py",
+                    artifact_id="relocate_db_backup",
+                    input_artifact_ids=[plan_artifact.id],
+                    metadata={"summary": backup_summary, "backupFileMissing": True},
+                )
+            try:
+                self.python_runner(
+                    self.py_root / "backup_mediaops_db.py",
+                    ["--db", db_path, "--action", "rotate", "--keep", "10"],
+                    str(self.py_root),
+                )
+            except Exception as exc:
+                self._append_diagnostic(
+                    store,
+                    config.run_id,
+                    Diagnostic(
+                        code="relocate_apply_backup_rotate_failed",
+                        severity=DiagnosticSeverity.WARNING,
+                        message=str(exc),
+                        details={"exceptionType": type(exc).__name__},
+                    ),
+                )
+
+            internal_plan_path = apply_dir / "relocate_internal_move_plan.jsonl"
+            planned_rows = [
+                row
+                for row in read_jsonl_rows(Path(plan_artifact.path))
+                if row.get("status") == "planned" and row.get("src") and row.get("dst")
+            ]
+            with internal_plan_path.open("w", encoding="utf-8") as f:
+                f.write(json.dumps({"_meta": {"kind": "relocate_move_plan_internal"}}, ensure_ascii=False) + "\n")
+                for row in planned_rows:
+                    f.write(
+                        json.dumps(
+                            {"path_id": row.get("path_id"), "src": row.get("src"), "dst": row.get("dst")},
+                            ensure_ascii=False,
+                        )
+                        + "\n"
+                    )
+            internal_plan_artifact = store.register_artifact(
+                config.run_id,
+                artifact_type="relocate_internal_move_plan",
+                path=internal_plan_path,
+                producer="RelocateWorkflowService.apply",
+                artifact_id="relocate_internal_move_plan",
+                input_artifact_ids=[plan_artifact.id, backup_artifact.id],
+                metadata={"plannedRows": len(planned_rows)},
+            )
+
+            apply_meta = powershell_runner(
+                scripts_root_win + r"\apply_move_plan.ps1",
+                [
+                    "-PlanJsonl",
+                    path_for_powershell(internal_plan_path),
+                    "-OpsRoot",
+                    ops_root_win,
+                    "-OnDstExists",
+                    str(config.on_dst_exists or run.config_snapshot.get("onDstExists") or "error"),
+                ],
+            )
+            applied_out = str(apply_meta.get("out_jsonl") or "")
+            if not applied_out:
+                raise RuntimeError("apply_move_plan.ps1 did not return out_jsonl")
+            applied_path = local_path_from_any(applied_out)
+            apply_log_artifact = store.register_artifact(
+                config.run_id,
+                artifact_type="relocate_move_apply_log",
+                path=applied_path,
+                producer="apply_move_plan.ps1",
+                artifact_id="relocate_move_apply_log",
+                input_artifact_ids=[internal_plan_artifact.id],
+                metadata={"summary": apply_meta},
+            )
+
+            db_update_raw = self.python_runner(
+                self.py_root / "update_db_paths_from_move_apply.py",
+                [
+                    "--db",
+                    db_path,
+                    "--applied",
+                    str(applied_path),
+                    "--run-kind",
+                    "relocate",
+                    "--event-kind",
+                    "move",
+                    "--detail-source",
+                    "RelocateWorkflowService.apply",
+                ],
+                str(self.py_root),
+            )
+            db_update_summary = parse_last_json_object_line(db_update_raw)
+            db_update_path = logs_dir / "relocate_db_update.json"
+            write_json(db_update_path, db_update_summary or {"raw": db_update_raw})
+            store.register_artifact(
+                config.run_id,
+                artifact_type="relocate_db_update",
+                path=db_update_path,
+                producer="update_db_paths_from_move_apply.py",
+                artifact_id="relocate_db_update",
+                input_artifact_ids=[apply_log_artifact.id],
+                metadata={"summary": db_update_summary},
+            )
+
+            move_stats = aggregate_move_apply(applied_path)
+            stats_path = apply_dir / "relocate_move_apply_stats.json"
+            write_json(stats_path, move_stats)
+            store.register_artifact(
+                config.run_id,
+                artifact_type="relocate_move_apply_stats",
+                path=stats_path,
+                producer="move_apply_stats.py",
+                artifact_id="relocate_move_apply_stats",
+                input_artifact_ids=[apply_log_artifact.id],
+                metadata={"summary": move_stats},
+            )
+
+            if int(move_stats.get("failed") or 0) > 0:
+                diagnostic = Diagnostic(
+                    code="relocate_apply_move_failures",
+                    severity=DiagnosticSeverity.ERROR,
+                    message="one or more move operations failed during relocate apply",
+                    details={"moveApplyStats": move_stats},
+                )
+                self._record_failure(store, config.run_id, diagnostic)
+                final_run = store.read_run(config.run_id)
+                return self._result(
+                    ok=False,
+                    store=store,
+                    run_id=config.run_id,
+                    phase=final_run.phase,
+                    outcome="relocate_apply_failed",
+                )
+
+            store.transition_run(config.run_id, WorkflowPhase.APPLIED)
+            store.transition_run(config.run_id, WorkflowPhase.COMPLETE)
+            return self._result(
+                ok=True,
+                store=store,
+                run_id=config.run_id,
+                phase=WorkflowPhase.COMPLETE,
+                outcome="relocate_apply_complete",
+            )
+        except RelocateApplyRejected as exc:
+            return self._block_apply(store, config.run_id, "relocate_apply_rejected", exc.diagnostic)
+        except Exception as exc:
+            diagnostic = Diagnostic(
+                code="relocate_apply_failed",
+                severity=DiagnosticSeverity.ERROR,
+                message=str(exc),
+                details={"exceptionType": type(exc).__name__, "artifactId": config.artifact_id},
+            )
+            self._record_failure(store, config.run_id, diagnostic)
+            final_run = store.read_run(config.run_id)
+            return self._result(
+                ok=False,
+                store=store,
+                run_id=config.run_id,
+                phase=final_run.phase,
+                outcome="relocate_apply_failed",
+            )
+
+    def _dry_run_existing(
+        self,
+        run_id: str,
+        config: RelocateDryRunConfig,
+        store: WorkflowStore,
+        db_path: str,
+    ) -> WorkflowResult:
+        run_dir = store.run_dir(run_id)
+        plan_dir = run_dir / "plan"
+        metadata_dir = run_dir / "metadata"
+        logs_dir = run_dir / "logs"
+        summary_path = logs_dir / "relocate_summary.json"
+
+        args = [
+            "--db",
+            db_path,
+            "--windows-ops-root",
+            config.windows_ops_root,
+            "--dest-root",
+            canonicalize_windows_path(config.dest_root),
+            "--allow-needs-review",
+            str(bool(config.allow_needs_review)).lower(),
+            "--allow-unreviewed-metadata",
+            str(bool(config.allow_unreviewed_metadata)).lower(),
+            "--queue-missing-metadata",
+            str(bool(config.queue_missing_metadata)).lower(),
+            "--write-metadata-queue-on-dry-run",
+            str(bool(config.write_metadata_queue_on_dry_run)).lower(),
+            "--scan-error-policy",
+            str(config.scan_error_policy),
+            "--scan-retry-count",
+            str(int(config.scan_retry_count)),
+            "--on-dst-exists",
+            str(config.on_dst_exists),
+            "--skip-suspicious-title-check",
+            str(bool(config.skip_suspicious_title_check)).lower(),
+        ]
+        if config.roots:
+            args.extend(["--roots-json", json.dumps(list(config.roots), ensure_ascii=False)])
+        elif config.roots_file_path:
+            args.extend(["--roots-file-path", config.roots_file_path])
+        if config.extensions:
+            args.extend(["--extensions-json", json.dumps(list(config.extensions), ensure_ascii=False)])
+        if config.limit:
+            args.extend(["--limit", str(int(config.limit))])
+        if config.scan_error_threshold:
+            args.extend(["--scan-error-threshold", str(int(config.scan_error_threshold))])
+        if config.drive_routes:
+            args.extend(["--drive-routes", config.drive_routes])
+
+        raw = self.python_runner(self.py_root / "relocate_existing_files.py", args, str(self.py_root))
+        summary = parse_last_json_object_line(raw)
+        if not summary:
+            raise RuntimeError("relocate_existing_files.py did not emit a JSON summary")
+        write_json(summary_path, summary)
+        diagnostics_artifact = store.register_artifact(
+            run_id,
+            artifact_type="relocate_diagnostics",
+            path=summary_path,
+            producer="relocate_existing_files.py",
+            artifact_id="relocate_diagnostics",
+            metadata={"summary": summary},
+        )
+
+        plan_artifact: ArtifactRef | None = None
+        plan_path_raw = summary.get("planPath")
+        if isinstance(plan_path_raw, str) and plan_path_raw:
+            plan_source = local_path_from_any(plan_path_raw)
+            plan_target = plan_dir / "relocate_plan.jsonl"
+            if plan_source.resolve() != plan_target.resolve():
+                shutil.copyfile(plan_source, plan_target)
+            plan_artifact = store.register_artifact(
+                run_id,
+                artifact_type="relocate_plan",
+                path=plan_target,
+                producer="relocate_existing_files.py",
+                artifact_id="relocate_plan",
+                input_artifact_ids=[diagnostics_artifact.id],
+                metadata={"summary": summary},
+            )
+
+        queue_artifact: ArtifactRef | None = None
+        queue_path_raw = summary.get("metadataQueuePath")
+        if isinstance(queue_path_raw, str) and queue_path_raw:
+            queue_source = local_path_from_any(queue_path_raw)
+            queue_target = metadata_dir / "relocate_metadata_queue.jsonl"
+            if queue_source.resolve() != queue_target.resolve():
+                shutil.copyfile(queue_source, queue_target)
+            queue_artifact = store.register_artifact(
+                run_id,
+                artifact_type="relocate_metadata_queue",
+                path=queue_target,
+                producer="relocate_existing_files.py",
+                artifact_id="relocate_metadata_queue",
+                input_artifact_ids=[diagnostics_artifact.id],
+                metadata={"summary": summary},
+            )
+
+        self._append_summary_diagnostics(store, run_id, summary)
+
+        planned_moves = int(summary.get("plannedMoves") or 0)
+        already_correct = int(summary.get("alreadyCorrect") or 0)
+        metadata_queue_count = int(summary.get("metadataQueuePlannedCount") or 0)
+        metadata_missing = int(summary.get("metadataMissingSkipped") or 0)
+        suspicious = int(summary.get("suspiciousProgramTitleSkipped") or 0)
+        needs_review = int(summary.get("needsReviewSkipped") or 0)
+        unreviewed = int(summary.get("unreviewedMetadataSkipped") or 0)
+        has_metadata_gap = metadata_queue_count > 0 or metadata_missing > 0 or unreviewed > 0
+        has_review_blocker = suspicious > 0 or needs_review > 0 or unreviewed > 0
+
+        if planned_moves > 0 and plan_artifact is not None:
+            store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            return self._result(
+                ok=True,
+                store=store,
+                run_id=run_id,
+                phase=WorkflowPhase.PLAN_READY,
+                outcome="relocate_plan_ready",
+                next_actions=[
+                    NextAction(
+                        action="review_plan",
+                        label="Review relocate move plan",
+                        tool="video_pipeline_resume",
+                        params={
+                            "runId": run_id,
+                            "artifactId": plan_artifact.id,
+                            "resumeAction": "apply_relocate_move_plan",
+                        },
+                        requires_human_input=True,
+                    )
+                ],
+            )
+
+        if has_metadata_gap or metadata_queue_count > 0:
+            artifact_ids = [queue_artifact.id] if queue_artifact is not None else [diagnostics_artifact.id]
+            if has_review_blocker:
+                store.create_review_gate(
+                    run_id,
+                    gate_type="relocate_metadata_review",
+                    artifact_ids=artifact_ids,
+                    gate_id="relocate_metadata_review",
+                )
+            store.transition_run(run_id, WorkflowPhase.METADATA_EXTRACTED)
+            store.transition_run(run_id, WorkflowPhase.REVIEW_REQUIRED)
+            return self._result(
+                ok=False,
+                store=store,
+                run_id=run_id,
+                phase=WorkflowPhase.REVIEW_REQUIRED,
+                outcome="relocate_metadata_preparation_required",
+                next_actions=[
+                    NextAction(
+                        action="prepare_relocate_metadata",
+                        label="Prepare missing or blocked relocate metadata",
+                        tool="video_pipeline_resume",
+                        params={"runId": run_id, "artifactIds": artifact_ids},
+                        requires_human_input=has_review_blocker,
+                    )
+                ],
+            )
+
+        if has_review_blocker:
+            store.create_review_gate(
+                run_id,
+                gate_type="relocate_metadata_review",
+                artifact_ids=[diagnostics_artifact.id],
+                gate_id="relocate_metadata_review",
+            )
+            store.transition_run(run_id, WorkflowPhase.METADATA_EXTRACTED)
+            store.transition_run(run_id, WorkflowPhase.REVIEW_REQUIRED)
+            return self._result(
+                ok=False,
+                store=store,
+                run_id=run_id,
+                phase=WorkflowPhase.REVIEW_REQUIRED,
+                outcome="relocate_review_required",
+                next_actions=[
+                    NextAction(
+                        action="review_relocate_metadata",
+                        label="Review blocked relocate metadata",
+                        tool="video_pipeline_resume",
+                        params={
+                            "runId": run_id,
+                            "gateId": "relocate_metadata_review",
+                            "artifactIds": [diagnostics_artifact.id],
+                        },
+                        requires_human_input=True,
+                    )
+                ],
+            )
+
+        if already_correct > 0 and planned_moves == 0:
+            store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            store.transition_run(run_id, WorkflowPhase.COMPLETE)
+            return self._result(
+                ok=True,
+                store=store,
+                run_id=run_id,
+                phase=WorkflowPhase.COMPLETE,
+                outcome="relocate_already_correct",
+            )
+
+        store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+        store.transition_run(run_id, WorkflowPhase.COMPLETE)
+        return self._result(
+            ok=True,
+            store=store,
+            run_id=run_id,
+            phase=WorkflowPhase.COMPLETE,
+            outcome="relocate_no_action_needed",
+        )
+
+    def _validate_apply_plan(self, store: WorkflowStore, run_id: str, artifact_id: str) -> ArtifactRef:
+        run = store.read_run(run_id)
+        if run.flow != WorkflowFlow.RELOCATE.value:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_wrong_flow",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"run is not a relocate workflow: {run.flow}",
+                details={"runId": run_id, "flow": run.flow},
+            ))
+        if run.phase != WorkflowPhase.PLAN_READY.value:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_wrong_phase",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate apply requires phase plan_ready, got {run.phase}",
+                details={"runId": run_id, "phase": run.phase},
+            ))
+        blocking_gates = [
+            gate
+            for gate in run.review_gates.values()
+            if gate.requires_human_review
+            and gate.status in {ReviewGateStatus.OPEN.value, ReviewGateStatus.REJECTED.value}
+        ]
+        if blocking_gates:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_review_gate_blocked",
+                severity=DiagnosticSeverity.ERROR,
+                message="relocate apply is blocked by unresolved or rejected review gates",
+                details={
+                    "runId": run_id,
+                    "blockingGateIds": [gate.id for gate in blocking_gates],
+                    "blockingGateStatuses": {gate.id: gate.status for gate in blocking_gates},
+                },
+            ))
+        plan_artifact = run.artifacts.get(artifact_id)
+        if plan_artifact is None:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_plan_not_in_run",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate plan artifact does not belong to run {run_id}: {artifact_id}",
+                details={"runId": run_id, "artifactId": artifact_id},
+            ))
+        if plan_artifact.type != "relocate_plan":
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_invalid_artifact_type",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"artifact is not a relocate plan: {plan_artifact.type}",
+                details={"runId": run_id, "artifactId": artifact_id, "artifactType": plan_artifact.type},
+            ))
+        if plan_artifact.status != ArtifactStatus.AVAILABLE.value:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_plan_not_available",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate plan artifact is not available: {plan_artifact.status}",
+                details={"runId": run_id, "artifactId": artifact_id, "artifactStatus": plan_artifact.status},
+            ))
+        plan_artifact_ids = [
+            aid
+            for aid in run.artifact_ids
+            if aid in run.artifacts and run.artifacts[aid].type == "relocate_plan"
+        ]
+        if not plan_artifact_ids or plan_artifact_ids[-1] != artifact_id:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_plan_not_current",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate plan artifact is not current for run {run_id}: {artifact_id}",
+                details={
+                    "runId": run_id,
+                    "artifactId": artifact_id,
+                    "currentArtifactId": plan_artifact_ids[-1] if plan_artifact_ids else None,
+                },
+            ))
+        plan_path = Path(plan_artifact.path)
+        if not plan_path.exists():
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_plan_missing",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate plan artifact file is missing: {plan_path}",
+                details={"runId": run_id, "artifactId": artifact_id, "path": str(plan_path)},
+            ))
+        current_sha = sha256_file(plan_path)
+        if current_sha != plan_artifact.sha256:
+            raise RelocateApplyRejected(Diagnostic(
+                code="relocate_apply_plan_checksum_mismatch",
+                severity=DiagnosticSeverity.ERROR,
+                message=f"relocate plan artifact checksum changed: {plan_path}",
+                details={
+                    "runId": run_id,
+                    "artifactId": artifact_id,
+                    "path": str(plan_path),
+                    "expectedSha256": plan_artifact.sha256,
+                    "actualSha256": current_sha,
+                },
+            ))
+        return plan_artifact
+
+    def _append_summary_diagnostics(self, store: WorkflowStore, run_id: str, summary: dict[str, Any]) -> None:
+        diagnostics: list[Diagnostic] = []
+        if int(summary.get("suspiciousProgramTitleSkipped") or 0) > 0:
+            diagnostics.append(Diagnostic(
+                code="relocate_suspicious_program_titles",
+                severity=DiagnosticSeverity.WARNING,
+                message="some relocate candidates have suspicious program titles",
+                details={"suspiciousProgramTitleSkipped": int(summary.get("suspiciousProgramTitleSkipped") or 0)},
+            ))
+        if int(summary.get("metadataMissingSkipped") or 0) > 0 or int(summary.get("metadataQueuePlannedCount") or 0) > 0:
+            diagnostics.append(Diagnostic(
+                code="relocate_metadata_preparation_required",
+                severity=DiagnosticSeverity.INFO,
+                message="metadata preparation is required before relocating some files",
+                details={
+                    "metadataMissingSkipped": int(summary.get("metadataMissingSkipped") or 0),
+                    "metadataQueuePlannedCount": int(summary.get("metadataQueuePlannedCount") or 0),
+                },
+            ))
+        errors = summary.get("errors")
+        if isinstance(errors, list) and errors:
+            diagnostics.append(Diagnostic(
+                code="relocate_summary_errors",
+                severity=DiagnosticSeverity.ERROR,
+                message="relocate_existing_files.py reported errors",
+                details={"errors": errors},
+            ))
+        for diagnostic in diagnostics:
+            self._append_diagnostic(store, run_id, diagnostic)
+
+    def _append_diagnostic(self, store: WorkflowStore, run_id: str, diagnostic: Diagnostic) -> None:
+        run = store.read_run(run_id)
+        run.diagnostics.append(diagnostic)
+        store.write_run(run)
+
+    def _block_apply(
+        self,
+        store: WorkflowStore,
+        run_id: str,
+        outcome: str,
+        diagnostic: Diagnostic,
+    ) -> WorkflowResult:
+        try:
+            run = store.read_run(run_id)
+        except Exception:
+            return WorkflowResult(
+                ok=False,
+                run_id=run_id,
+                flow=WorkflowFlow.RELOCATE,
+                phase=WorkflowPhase.FAILED,
+                outcome=outcome,
+                diagnostics=[diagnostic],
+            )
+        run.diagnostics.append(diagnostic)
+        store.write_run(run)
+        if run.flow == WorkflowFlow.RELOCATE.value and run.phase not in {
+            WorkflowPhase.BLOCKED.value,
+            WorkflowPhase.COMPLETE.value,
+            WorkflowPhase.FAILED.value,
+        }:
+            store.transition_run(run_id, WorkflowPhase.BLOCKED)
+        final_run = store.read_run(run_id)
+        return self._result(
+            ok=False,
+            store=store,
+            run_id=run_id,
+            phase=final_run.phase,
+            outcome=outcome,
+        )
+
+    def _record_failure(self, store: WorkflowStore, run_id: str, diagnostic: Diagnostic) -> None:
+        try:
+            run = store.read_run(run_id)
+            run.diagnostics.append(diagnostic)
+            store.write_run(run)
+            if run.phase != WorkflowPhase.FAILED.value:
+                store.transition_run(run_id, WorkflowPhase.FAILED)
+        except Exception:
+            pass
+
+    def _result(
+        self,
+        *,
+        ok: bool,
+        store: WorkflowStore,
+        run_id: str,
+        phase: WorkflowPhase | str,
+        outcome: str,
+        next_actions: list[NextAction] | None = None,
+    ) -> WorkflowResult:
+        run = store.read_run(run_id)
+        return WorkflowResult(
+            ok=ok,
+            run_id=run_id,
+            flow=run.flow,
+            phase=phase,
+            outcome=outcome,
+            artifacts=[run.artifacts[aid] for aid in run.artifact_ids],
+            gates=[run.review_gates[gid] for gid in run.review_gate_ids],
+            next_actions=list(next_actions or []),
+            diagnostics=run.diagnostics,
+        )


### PR DESCRIPTION
## Summary
- Add a Relocate V2 workflow service that wraps existing relocate dry-run behavior into WorkflowRun / WorkflowResult outputs.
- Register run-scoped relocate artifacts for plans, metadata queues, diagnostics, DB backups, apply logs, DB updates, and move stats.
- Enforce run-scoped relocate apply validation before invoking the PowerShell move boundary.

## Impact
- Keeps the existing public OpenClaw tools unchanged for #106.
- Prepares relocate for the shared V2 translator and public command surface in #107/#108.

## Validation
- pytest -q py/tests
- git diff --check

Closes #106