### PR TITLE
Collapse public tools to V2 workflows

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,29 +2,7 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerCli } from "./src/plugin/cli";
 import { pluginId, getCfg } from "./src/plugin/plugin-meta";
 import { registerPluginHooks } from "./src/plugin/plugin-hooks";
-import { registerToolApplyReviewedMetadata } from "./src/tools/tool-apply-reviewed-metadata";
-import { registerToolDbBackup, registerToolDbRestore } from "./src/tools/tool-db-backup";
-import { registerToolBackfill } from "./src/tools/tool-backfill";
-import { registerToolDedup } from "./src/tools/tool-dedup";
-import { registerToolDedupBroadcasterReview } from "./src/tools/tool-dedup-broadcaster-review";
-import { registerToolDedupDropReview } from "./src/tools/tool-dedup-drop-review";
-import { registerToolDedupRebroadcasts } from "./src/tools/tool-dedup-rebroadcasts";
-import { registerToolLogs } from "./src/tools/tool-logs";
-import { registerToolExportProgramYaml } from "./src/tools/tool-export-program-yaml";
-import { registerToolDetectFolderContamination } from "./src/tools/tool-detect-folder-contamination";
-import { registerToolDetectRebroadcasts } from "./src/tools/tool-detect-rebroadcasts";
-import { registerToolIngestEpg } from "./src/tools/tool-ingest-epg";
-import { registerToolPrepareRelocateMetadata } from "./src/tools/tool-prepare-relocate-metadata";
-import { registerToolRelocate } from "./src/tools/tool-relocate";
-import { registerToolNormalizeFolderCase } from "./src/tools/tool-normalize-folder-case";
-import { registerToolReextract } from "./src/tools/tool-reextract";
-import { registerToolLlmExtract } from "./src/tools/tool-llm-extract";
-import { registerToolLlmExtractStatus } from "./src/tools/tool-llm-extract-status";
-import { registerToolRepairDb } from "./src/tools/tool-repair-db";
-import { registerToolUpdateProgramTitles } from "./src/tools/tool-update-program-titles";
-import { registerToolRun } from "./src/tools/tool-run";
-import { registerToolStatus } from "./src/tools/tool-status";
-import { registerToolValidate } from "./src/tools/tool-validate";
+import { registerWorkflowTools } from "./src/tools/tool-workflows";
 
 export default definePluginEntry({
   id: pluginId,
@@ -46,30 +24,7 @@ export default definePluginEntry({
       }
     });
 
-    registerToolRun(api, getCfg);
-    registerToolBackfill(api, getCfg);
-    registerToolDedup(api, getCfg);
-    registerToolDedupBroadcasterReview(api, getCfg);
-    registerToolDedupDropReview(api, getCfg);
-    registerToolDedupRebroadcasts(api, getCfg);
-    registerToolRelocate(api, getCfg);
-    registerToolNormalizeFolderCase(api, getCfg);
-    registerToolPrepareRelocateMetadata(api, getCfg);
-    registerToolStatus(api, getCfg);
-    registerToolValidate(api, getCfg);
-    registerToolApplyReviewedMetadata(api, getCfg);
-    registerToolDbBackup(api, getCfg);
-    registerToolDbRestore(api, getCfg);
-    registerToolRepairDb(api, getCfg);
-    registerToolUpdateProgramTitles(api, getCfg);
-    registerToolReextract(api, getCfg);
-    registerToolLlmExtract(api, getCfg);
-    registerToolLlmExtractStatus(api, getCfg);
-    registerToolExportProgramYaml(api, getCfg);
-    registerToolIngestEpg(api, getCfg);
-    registerToolDetectFolderContamination(api, getCfg);
-    registerToolDetectRebroadcasts(api, getCfg);
-    registerToolLogs(api, getCfg);
+    registerWorkflowTools(api, getCfg);
     registerPluginHooks(api, getCfg);
     registerCli(api, pluginId, getCfg);
   },

--- a/py/tests/test_workflow_cli.py
+++ b/py/tests/test_workflow_cli.py
@@ -1,0 +1,70 @@
+import argparse
+
+from video_pipeline.workflows import WorkflowFlow, WorkflowPhase, WorkflowStore
+from workflow_cli import _cmd_inspect_artifact, _cmd_status
+
+
+def test_workflow_cli_status_lists_recent_runs(tmp_path):
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_source")
+    store.transition_run("run_source", WorkflowPhase.INVENTORY_READY)
+    store.create_review_gate(
+        "run_source",
+        gate_type="metadata_review",
+        artifact_ids=["metadata_review_yaml_0001"],
+        gate_id="metadata_review",
+    )
+
+    payload = _cmd_status(
+        argparse.Namespace(
+            windows_ops_root=str(ops_root),
+            run_id="",
+            limit=10,
+            include_artifacts=False,
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["runs"][0]["runId"] == "run_source"
+    assert payload["runs"][0]["phase"] == "inventory_ready"
+    assert "artifacts" not in payload["runs"][0]
+    assert payload["openGates"][0]["runId"] == "run_source"
+    assert payload["openGates"][0]["id"] == "metadata_review"
+
+
+def test_workflow_cli_inspect_artifact_returns_related_gates_and_preview(tmp_path):
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_relocate")
+    artifact_path = ops_root / "runs" / "run_relocate" / "plan" / "relocate_plan.jsonl"
+    artifact_path.write_text('{"ok": true}\n', encoding="utf-8")
+    store.register_artifact(
+        "run_relocate",
+        artifact_type="relocate_plan",
+        path=artifact_path,
+        producer="test",
+        artifact_id="relocate_plan",
+    )
+    store.create_review_gate(
+        "run_relocate",
+        gate_type="relocate_plan_review",
+        artifact_ids=["relocate_plan"],
+        gate_id="relocate_plan_review",
+    )
+
+    payload = _cmd_inspect_artifact(
+        argparse.Namespace(
+            windows_ops_root=str(ops_root),
+            run_id="run_relocate",
+            artifact_id="relocate_plan",
+            include_content_preview=True,
+            preview_bytes=20,
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["artifact"]["id"] == "relocate_plan"
+    assert payload["exists"] is True
+    assert payload["relatedGates"][0]["id"] == "relocate_plan_review"
+    assert payload["contentPreview"] == '{"ok": true}\n'

--- a/py/workflow_cli.py
+++ b/py/workflow_cli.py
@@ -1,0 +1,251 @@
+"""Thin CLI dispatcher for V2 run-based workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from video_pipeline.platform.pathscan_common import windows_to_wsl_path
+from video_pipeline.workflows import (
+    RelocateApplyConfig,
+    RelocateDryRunConfig,
+    RelocateWorkflowService,
+    SourceRootApplyConfig,
+    SourceRootDryRunConfig,
+    SourceRootWorkflowService,
+    WorkflowStore,
+)
+
+
+def _json_out(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+def _local_path(value: str) -> Path:
+    return Path(windows_to_wsl_path(str(value))).resolve()
+
+
+def _parse_json_array(value: str) -> list[str]:
+    if not value:
+        return []
+    parsed = json.loads(value)
+    if not isinstance(parsed, list):
+        raise ValueError("expected JSON array")
+    return [str(item) for item in parsed if isinstance(item, str) and item]
+
+
+def _store(windows_ops_root: str) -> WorkflowStore:
+    return WorkflowStore(_local_path(windows_ops_root))
+
+
+def _run_to_status(run: Any, *, include_artifacts: bool) -> dict[str, Any]:
+    payload = run.to_dict()
+    if not include_artifacts:
+        payload.pop("artifacts", None)
+        payload.pop("reviewGates", None)
+    return payload
+
+
+def _cmd_start(args: argparse.Namespace) -> dict[str, Any]:
+    if args.flow == "source_root":
+        result = SourceRootWorkflowService().dry_run(
+            SourceRootDryRunConfig(
+                windows_ops_root=args.windows_ops_root,
+                source_root=args.source_root,
+                dest_root=args.dest_root,
+                db=args.db,
+                drive_routes=args.drive_routes_path,
+                max_files_per_run=args.max_files_per_run,
+                allow_needs_review=args.allow_needs_review,
+                run_id=args.run_id or None,
+            )
+        )
+        return result.to_dict()
+    if args.flow == "relocate":
+        result = RelocateWorkflowService().dry_run(
+            RelocateDryRunConfig(
+                windows_ops_root=args.windows_ops_root,
+                dest_root=args.dest_root,
+                db=args.db,
+                roots=_parse_json_array(args.roots_json),
+                roots_file_path=args.roots_file_path,
+                extensions=_parse_json_array(args.extensions_json),
+                drive_routes=args.drive_routes_path,
+                limit=args.limit,
+                allow_needs_review=args.allow_needs_review,
+                allow_unreviewed_metadata=args.allow_unreviewed_metadata,
+                queue_missing_metadata=args.queue_missing_metadata,
+                write_metadata_queue_on_dry_run=args.write_metadata_queue_on_dry_run,
+                scan_error_policy=args.scan_error_policy,
+                scan_error_threshold=args.scan_error_threshold,
+                scan_retry_count=args.scan_retry_count,
+                on_dst_exists=args.on_dst_exists,
+                skip_suspicious_title_check=args.skip_suspicious_title_check,
+                run_id=args.run_id or None,
+            )
+        )
+        return result.to_dict()
+    raise ValueError(f"unsupported flow: {args.flow}")
+
+
+def _cmd_resume(args: argparse.Namespace) -> dict[str, Any]:
+    store = _store(args.windows_ops_root)
+    run = store.read_run(args.run_id)
+    action = args.action or None
+    artifact_id = args.artifact_id or None
+    if run.flow == "source_root":
+        result = SourceRootWorkflowService().resume(
+            SourceRootApplyConfig(
+                windows_ops_root=args.windows_ops_root,
+                run_id=args.run_id,
+                artifact_id=artifact_id or "source_root_move_plan",
+                db=args.db or None,
+            ),
+            action=action or "apply_source_root_move_plan",
+        )
+        return result.to_dict()
+    if run.flow == "relocate":
+        result = RelocateWorkflowService().resume(
+            RelocateApplyConfig(
+                windows_ops_root=args.windows_ops_root,
+                run_id=args.run_id,
+                artifact_id=artifact_id or "relocate_plan",
+                db=args.db or None,
+                on_dst_exists=args.on_dst_exists or None,
+            ),
+            action=action or "apply_relocate_move_plan",
+        )
+        return result.to_dict()
+    raise ValueError(f"unsupported run flow: {run.flow}")
+
+
+def _cmd_status(args: argparse.Namespace) -> dict[str, Any]:
+    store = _store(args.windows_ops_root)
+    if args.run_id:
+        return {
+            "ok": True,
+            "run": _run_to_status(store.read_run(args.run_id), include_artifacts=args.include_artifacts),
+        }
+
+    runs_root = store.runs_root
+    runs: list[dict[str, Any]] = []
+    full_runs: list[dict[str, Any]] = []
+    if runs_root.exists():
+        manifests = sorted(runs_root.glob("*/run.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+        for manifest in manifests[: args.limit]:
+            run = store.read_run(manifest.parent.name)
+            full_runs.append(run.to_dict())
+            runs.append(_run_to_status(run, include_artifacts=args.include_artifacts))
+    open_gates = []
+    latest_artifacts = []
+    for run in full_runs:
+        review_gates = run.get("reviewGates") if isinstance(run.get("reviewGates"), dict) else {}
+        for gate in review_gates.values():
+            if isinstance(gate, dict) and gate.get("status") == "open":
+                open_gates.append({"runId": run.get("runId"), **gate})
+        artifacts = run.get("artifacts") if isinstance(run.get("artifacts"), dict) else {}
+        for artifact in artifacts.values():
+            if isinstance(artifact, dict):
+                latest_artifacts.append({"runId": run.get("runId"), **artifact})
+    return {"ok": True, "runs": runs, "openGates": open_gates, "latestArtifacts": latest_artifacts[: args.limit]}
+
+
+def _cmd_inspect_artifact(args: argparse.Namespace) -> dict[str, Any]:
+    store = _store(args.windows_ops_root)
+    run = store.read_run(args.run_id)
+    artifact = run.artifacts.get(args.artifact_id)
+    if artifact is None:
+        return {"ok": False, "error": f"artifact not found: {args.artifact_id}", "runId": args.run_id}
+    payload = artifact.to_dict()
+    path = Path(artifact.path)
+    related_gates = [
+        gate.to_dict()
+        for gate in run.review_gates.values()
+        if args.artifact_id in gate.artifact_ids
+    ]
+    out: dict[str, Any] = {
+        "ok": True,
+        "runId": args.run_id,
+        "artifact": payload,
+        "exists": path.exists(),
+        "relatedGates": related_gates,
+    }
+    if args.include_content_preview and path.exists() and path.is_file():
+        out["contentPreview"] = path.read_text(encoding="utf-8", errors="replace")[: args.preview_bytes]
+    return out
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start")
+    start.add_argument("--flow", choices=["source_root", "relocate"], required=True)
+    start.add_argument("--windows-ops-root", required=True)
+    start.add_argument("--source-root", default="")
+    start.add_argument("--dest-root", required=True)
+    start.add_argument("--db", required=True)
+    start.add_argument("--drive-routes-path", default="")
+    start.add_argument("--run-id", default="")
+    start.add_argument("--max-files-per-run", type=int, default=200)
+    start.add_argument("--allow-needs-review", action="store_true")
+    start.add_argument("--roots-json", default="[]")
+    start.add_argument("--roots-file-path", default="")
+    start.add_argument("--extensions-json", default="[]")
+    start.add_argument("--limit", type=int, default=0)
+    start.add_argument("--allow-unreviewed-metadata", action="store_true")
+    start.add_argument("--queue-missing-metadata", action="store_true")
+    start.add_argument("--write-metadata-queue-on-dry-run", action="store_true")
+    start.add_argument("--scan-error-policy", choices=["warn", "fail", "threshold"], default="warn")
+    start.add_argument("--scan-error-threshold", type=int, default=0)
+    start.add_argument("--scan-retry-count", type=int, default=1)
+    start.add_argument("--on-dst-exists", choices=["error", "rename_suffix"], default="error")
+    start.add_argument("--skip-suspicious-title-check", action="store_true")
+
+    resume = sub.add_parser("resume")
+    resume.add_argument("--windows-ops-root", required=True)
+    resume.add_argument("--db", default="")
+    resume.add_argument("--run-id", required=True)
+    resume.add_argument("--action", default="")
+    resume.add_argument("--artifact-id", default="")
+    resume.add_argument("--on-dst-exists", choices=["error", "rename_suffix"], default="")
+
+    status = sub.add_parser("status")
+    status.add_argument("--windows-ops-root", required=True)
+    status.add_argument("--run-id", default="")
+    status.add_argument("--limit", type=int, default=10)
+    status.add_argument("--include-artifacts", action="store_true")
+
+    inspect = sub.add_parser("inspect-artifact")
+    inspect.add_argument("--windows-ops-root", required=True)
+    inspect.add_argument("--run-id", required=True)
+    inspect.add_argument("--artifact-id", required=True)
+    inspect.add_argument("--include-content-preview", action="store_true")
+    inspect.add_argument("--preview-bytes", type=int, default=4096)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "start":
+            _json_out(_cmd_start(args))
+        elif args.command == "resume":
+            _json_out(_cmd_resume(args))
+        elif args.command == "status":
+            _json_out(_cmd_status(args))
+        elif args.command == "inspect-artifact":
+            _json_out(_cmd_inspect_artifact(args))
+        else:
+            parser.error(f"unsupported command: {args.command}")
+    except Exception as exc:
+        _json_out({"ok": False, "error": str(exc), "exceptionType": type(exc).__name__})
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/plugin-entry.test.ts
+++ b/src/plugin-entry.test.ts
@@ -11,32 +11,10 @@ vi.mock("openclaw/plugin-sdk/plugin-entry", () => ({
 import pluginEntry from "../index";
 
 const EXPECTED_TOOL_NAMES = [
-  "video_pipeline_analyze_and_move_videos",
-  "video_pipeline_apply_llm_extract_output",
-  "video_pipeline_apply_reviewed_metadata",
-  "video_pipeline_backfill_moved_files",
-  "video_pipeline_db_backup",
-  "video_pipeline_db_restore",
-  "video_pipeline_dedup_apply_broadcaster_yaml",
-  "video_pipeline_dedup_apply_drop_review_yaml",
-  "video_pipeline_dedup_generate_broadcaster_yaml",
-  "video_pipeline_dedup_generate_drop_review_yaml",
-  "video_pipeline_dedup_rebroadcasts",
-  "video_pipeline_dedup_recordings",
-  "video_pipeline_detect_folder_contamination",
-  "video_pipeline_detect_rebroadcasts",
-  "video_pipeline_export_program_yaml",
-  "video_pipeline_ingest_epg",
-  "video_pipeline_llm_extract_status",
-  "video_pipeline_logs",
-  "video_pipeline_normalize_folder_case",
-  "video_pipeline_prepare_relocate_metadata",
-  "video_pipeline_reextract",
-  "video_pipeline_relocate_existing_files",
-  "video_pipeline_repair_db",
+  "video_pipeline_inspect_artifact",
+  "video_pipeline_resume",
+  "video_pipeline_start",
   "video_pipeline_status",
-  "video_pipeline_update_program_titles",
-  "video_pipeline_validate",
 ].sort();
 
 function createMockApi() {
@@ -189,37 +167,58 @@ describe("plugin entry", () => {
     expect(payload.error).toContain("windowsOpsRoot is required");
   });
 
-  it("keeps high-signal tool parameter schemas stable", () => {
+  it("keeps high-signal V2 tool parameter schemas stable", () => {
     const api = createMockApi();
 
     pluginEntry.register(api);
 
-    const applyReviewed = getRegisteredTool(api, "video_pipeline_apply_reviewed_metadata");
-    expect(applyReviewed.parameters).toMatchObject({
+    const start = getRegisteredTool(api, "video_pipeline_start");
+    expect(start.parameters).toMatchObject({
       type: "object",
       additionalProperties: false,
+      required: ["flow"],
       properties: {
-        sourceJsonlPath: { type: "string" },
-        sourceYamlPath: { type: "string" },
-        markHumanReviewed: { type: "boolean", default: true },
-        allowNoContentChanges: { type: "boolean", default: false },
-        reviewedBy: { type: "string" },
-        source: { type: "string", default: "human_reviewed" },
+        flow: { type: "string", enum: ["source_root", "relocate"] },
+        runId: { type: "string" },
+        maxFilesPerRun: { type: "integer", minimum: 1, maximum: 5000 },
+        roots: { type: "array", items: { type: "string" } },
+        onDstExists: { type: "string", enum: ["error", "rename_suffix"], default: "error" },
       },
     });
 
-    const repairDb = getRegisteredTool(api, "video_pipeline_repair_db");
-    expect(repairDb.parameters).toMatchObject({
+    const resume = getRegisteredTool(api, "video_pipeline_resume");
+    expect(resume.parameters).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: ["runId"],
+      properties: {
+        runId: { type: "string" },
+        action: { type: "string" },
+        resumeAction: { type: "string" },
+        artifactId: { type: "string" },
+      },
+    });
+
+    const status = getRegisteredTool(api, "video_pipeline_status");
+    expect(status.parameters).toMatchObject({
       type: "object",
       additionalProperties: false,
       properties: {
-        action: {
-          type: "string",
-          enum: ["repair_paths", "clear_review_flags"],
-          default: "repair_paths",
-        },
-        dryRun: { type: "boolean", default: true },
-        limit: { type: "integer", minimum: 1, maximum: 5000 },
+        runId: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        includeArtifacts: { type: "boolean", default: false },
+      },
+    });
+
+    const inspect = getRegisteredTool(api, "video_pipeline_inspect_artifact");
+    expect(inspect.parameters).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: ["runId", "artifactId"],
+      properties: {
+        runId: { type: "string" },
+        artifactId: { type: "string" },
+        includeContentPreview: { type: "boolean", default: false },
       },
     });
   });

--- a/src/tools/tool-workflows.test.ts
+++ b/src/tools/tool-workflows.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime", async () => {
+  const actual = await vi.importActual<typeof import("./runtime")>("./runtime");
+  return {
+    ...actual,
+    resolvePythonScript: vi.fn(() => ({ scriptPath: "/ext/py/workflow_cli.py", cwd: "/ext/py", source: "extension" })),
+    runCmd: vi.fn(),
+    toToolResult: vi.fn((obj: Record<string, unknown>) => obj),
+  };
+});
+
+import { registerWorkflowTools } from "./tool-workflows";
+import { runCmd } from "./runtime";
+
+function createMockApi() {
+  return { registerTool: vi.fn() };
+}
+
+function cfg() {
+  return {
+    db: "/ops/db/mediaops.sqlite",
+    sourceRoot: "/mnt/b/Unwatched",
+    destRoot: "/mnt/b/VideoLibrary",
+    windowsOpsRoot: "/ops",
+    defaultMaxFilesPerRun: 200,
+    tsRoot: "",
+    driveRoutesPath: "/rules/drive_routes.yaml",
+  };
+}
+
+function getRegisteredTool(api: ReturnType<typeof createMockApi>, name: string) {
+  const toolDefs = api.registerTool.mock.calls.map(([def]) => def);
+  const tool = toolDefs.find((def: { name: string }) => def.name === name);
+  expect(tool).toBeTruthy();
+  return tool;
+}
+
+function cmdResult(stdout: Record<string, unknown>, ok = true) {
+  return {
+    ok,
+    code: ok ? 0 : 1,
+    stdout: JSON.stringify(stdout),
+    stderr: "",
+    command: "uv",
+    args: [],
+    cwd: "/ext/py",
+  };
+}
+
+describe("V2 workflow tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts sourceRoot through workflow_cli.py and translates WorkflowResult", async () => {
+    vi.mocked(runCmd).mockReturnValue(cmdResult({
+      ok: true,
+      runId: "run_source",
+      flow: "source_root",
+      phase: "plan_ready",
+      outcome: "source_root_dry_run_complete",
+      artifacts: [],
+      gates: [],
+      nextActions: [
+        {
+          action: "review_plan",
+          tool: "video_pipeline_resume",
+          params: {
+            runId: "run_source",
+            artifactId: "source_root_move_plan",
+            resumeAction: "apply_source_root_move_plan",
+          },
+          requiresHumanInput: true,
+        },
+      ],
+      diagnostics: [],
+    }));
+    const api = createMockApi();
+    registerWorkflowTools(api as never, () => cfg());
+
+    const result = await getRegisteredTool(api, "video_pipeline_start").execute("call-1", {
+      flow: "source_root",
+      runId: "run_source",
+      maxFilesPerRun: 25,
+      allowNeedsReview: true,
+    });
+
+    expect(runCmd).toHaveBeenCalledWith("uv", expect.arrayContaining([
+      "run",
+      "python",
+      "/ext/py/workflow_cli.py",
+      "start",
+      "--flow",
+      "source_root",
+      "--run-id",
+      "run_source",
+      "--max-files-per-run",
+      "25",
+      "--allow-needs-review",
+    ]), "/ext/py");
+    expect(result.followUpToolCalls).toEqual([
+      {
+        tool: "video_pipeline_resume",
+        reason: "review_plan",
+        params: {
+          runId: "run_source",
+          artifactId: "source_root_move_plan",
+          resumeAction: "apply_source_root_move_plan",
+        },
+        requiresHumanReview: true,
+      },
+    ]);
+  });
+
+  it("starts relocate with relocate-specific options", async () => {
+    vi.mocked(runCmd).mockReturnValue(cmdResult({
+      ok: true,
+      runId: "run_relocate",
+      flow: "relocate",
+      phase: "complete",
+      outcome: "relocate_already_correct",
+      artifacts: [],
+      gates: [],
+      nextActions: [],
+      diagnostics: [],
+    }));
+    const api = createMockApi();
+    registerWorkflowTools(api as never, () => cfg());
+
+    await getRegisteredTool(api, "video_pipeline_start").execute("call-2", {
+      flow: "relocate",
+      roots: ["B:\\VideoLibrary"],
+      extensions: [".mp4", ".mkv"],
+      limit: 100,
+      allowUnreviewedMetadata: true,
+      queueMissingMetadata: true,
+      writeMetadataQueueOnDryRun: true,
+      scanErrorPolicy: "threshold",
+      scanErrorThreshold: 5,
+      scanRetryCount: 2,
+      onDstExists: "rename_suffix",
+      skipSuspiciousTitleCheck: true,
+    });
+
+    expect(runCmd).toHaveBeenCalledWith("uv", expect.arrayContaining([
+      "--flow",
+      "relocate",
+      "--roots-json",
+      JSON.stringify(["B:\\VideoLibrary"]),
+      "--extensions-json",
+      JSON.stringify([".mp4", ".mkv"]),
+      "--limit",
+      "100",
+      "--allow-unreviewed-metadata",
+      "--queue-missing-metadata",
+      "--write-metadata-queue-on-dry-run",
+      "--scan-error-policy",
+      "threshold",
+      "--scan-error-threshold",
+      "5",
+      "--scan-retry-count",
+      "2",
+      "--on-dst-exists",
+      "rename_suffix",
+      "--skip-suspicious-title-check",
+    ]), "/ext/py");
+  });
+
+  it("resumes using resumeAction alias and translates WorkflowResult", async () => {
+    vi.mocked(runCmd).mockReturnValue(cmdResult({
+      ok: true,
+      runId: "run_relocate",
+      flow: "relocate",
+      phase: "complete",
+      outcome: "relocate_apply_complete",
+      artifacts: [],
+      gates: [],
+      nextActions: [],
+      diagnostics: [],
+    }));
+    const api = createMockApi();
+    registerWorkflowTools(api as never, () => cfg());
+
+    const result = await getRegisteredTool(api, "video_pipeline_resume").execute("call-3", {
+      runId: "run_relocate",
+      resumeAction: "apply_relocate_move_plan",
+      artifactId: "relocate_plan",
+      onDstExists: "rename_suffix",
+    });
+
+    expect(runCmd).toHaveBeenCalledWith("uv", expect.arrayContaining([
+      "resume",
+      "--run-id",
+      "run_relocate",
+      "--action",
+      "apply_relocate_move_plan",
+      "--artifact-id",
+      "relocate_plan",
+      "--on-dst-exists",
+      "rename_suffix",
+    ]), "/ext/py");
+    expect(result).toMatchObject({
+      ok: true,
+      hasFollowUpToolCalls: false,
+      followUpToolCalls: [],
+    });
+  });
+
+  it("returns status and inspect JSON without WorkflowResult translation", async () => {
+    const api = createMockApi();
+    registerWorkflowTools(api as never, () => cfg());
+    vi.mocked(runCmd).mockReturnValueOnce(cmdResult({ ok: true, runs: [{ runId: "run_a" }] }));
+    const status = await getRegisteredTool(api, "video_pipeline_status").execute("call-4", {
+      limit: 5,
+      includeArtifacts: true,
+    });
+    expect(status).toEqual({ ok: true, runs: [{ runId: "run_a" }] });
+    expect(runCmd).toHaveBeenLastCalledWith("uv", expect.arrayContaining([
+      "status",
+      "--limit",
+      "5",
+      "--include-artifacts",
+    ]), "/ext/py");
+
+    vi.mocked(runCmd).mockReturnValueOnce(cmdResult({ ok: true, artifact: { id: "relocate_plan" } }));
+    const inspected = await getRegisteredTool(api, "video_pipeline_inspect_artifact").execute("call-5", {
+      runId: "run_a",
+      artifactId: "relocate_plan",
+      includeContentPreview: true,
+      previewBytes: 128,
+    });
+    expect(inspected).toEqual({ ok: true, artifact: { id: "relocate_plan" } });
+    expect(runCmd).toHaveBeenLastCalledWith("uv", expect.arrayContaining([
+      "inspect-artifact",
+      "--run-id",
+      "run_a",
+      "--artifact-id",
+      "relocate_plan",
+      "--include-content-preview",
+      "--preview-bytes",
+      "128",
+    ]), "/ext/py");
+  });
+
+  it("returns structured failure when workflow_cli.py emits malformed JSON", async () => {
+    vi.mocked(runCmd).mockReturnValue({
+      ok: false,
+      code: 1,
+      stdout: "not json",
+      stderr: "boom",
+      command: "uv",
+      args: [],
+      cwd: "/ext/py",
+    });
+    const api = createMockApi();
+    registerWorkflowTools(api as never, () => cfg());
+
+    const result = await getRegisteredTool(api, "video_pipeline_start").execute("call-6", { flow: "source_root" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "workflow_cli.py did not return a JSON object",
+      exitCode: 1,
+      stdout: "not json",
+      stderr: "boom",
+    });
+  });
+});

--- a/src/tools/tool-workflows.ts
+++ b/src/tools/tool-workflows.ts
@@ -1,0 +1,209 @@
+import { parseJsonObject, resolvePythonScript, runCmd, toToolResult } from "./runtime";
+import type { AnyObj, GetCfgFn, PluginApi } from "./types";
+import { translateWorkflowResult, type WorkflowResultPayload } from "../workflows/workflow-result-translator";
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
+function finiteInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.trunc(value);
+}
+
+function addFlag(args: string[], flag: string, enabled: unknown) {
+  if (enabled === true) args.push(flag);
+}
+
+function runWorkflowCli(command: string, args: string[], okPayload: (parsed: AnyObj) => AnyObj) {
+  const resolved = resolvePythonScript("workflow_cli.py");
+  const result = runCmd("uv", ["run", "python", resolved.scriptPath, command, ...args], resolved.cwd);
+  const parsed = parseJsonObject(result.stdout);
+  if (parsed) {
+    return toToolResult(okPayload(parsed));
+  }
+    return toToolResult({
+      ok: false,
+      tool: command === "inspect-artifact" ? "video_pipeline_inspect_artifact" : `video_pipeline_${command}`,
+      error: "workflow_cli.py did not return a JSON object",
+      exitCode: result.code,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  });
+}
+
+function isWorkflowResultPayload(value: AnyObj): value is WorkflowResultPayload {
+  return typeof value.runId === "string"
+    && typeof value.flow === "string"
+    && typeof value.phase === "string"
+    && typeof value.outcome === "string"
+    && typeof value.ok === "boolean";
+}
+
+function workflowToolResult(parsed: AnyObj): AnyObj {
+  if (isWorkflowResultPayload(parsed)) return translateWorkflowResult(parsed);
+  return parsed;
+}
+
+function registerStart(api: PluginApi, getCfg: GetCfgFn) {
+  api.registerTool({
+    name: "video_pipeline_start",
+    description: "Start a V2 run-based workflow and return a structured WorkflowResult.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["flow"],
+      properties: {
+        flow: { type: "string", enum: ["source_root", "relocate"] },
+        runId: { type: "string" },
+        allowNeedsReview: { type: "boolean", default: false },
+        driveRoutesPath: { type: "string" },
+        maxFilesPerRun: { type: "integer", minimum: 1, maximum: 5000 },
+        roots: { type: "array", items: { type: "string" } },
+        rootsFilePath: { type: "string" },
+        extensions: { type: "array", items: { type: "string" } },
+        limit: { type: "integer", minimum: 0, maximum: 100000 },
+        allowUnreviewedMetadata: { type: "boolean", default: false },
+        queueMissingMetadata: { type: "boolean", default: true },
+        writeMetadataQueueOnDryRun: { type: "boolean", default: true },
+        scanErrorPolicy: { type: "string", enum: ["warn", "fail", "threshold"], default: "warn" },
+        scanErrorThreshold: { type: "integer", minimum: 0, maximum: 100000 },
+        scanRetryCount: { type: "integer", minimum: 0, maximum: 10, default: 1 },
+        onDstExists: { type: "string", enum: ["error", "rename_suffix"], default: "error" },
+        skipSuspiciousTitleCheck: { type: "boolean", default: false },
+      },
+    },
+    async execute(_id: string, params: AnyObj) {
+      const cfg = getCfg(api);
+      const args = [
+        "--flow", String(params.flow),
+        "--windows-ops-root", cfg.windowsOpsRoot,
+        "--source-root", cfg.sourceRoot,
+        "--dest-root", cfg.destRoot,
+        "--db", cfg.db,
+        "--drive-routes-path", String(params.driveRoutesPath || cfg.driveRoutesPath || ""),
+        "--max-files-per-run", String(finiteInteger(params.maxFilesPerRun) ?? cfg.defaultMaxFilesPerRun),
+      ];
+      if (typeof params.runId === "string" && params.runId.trim()) args.push("--run-id", params.runId.trim());
+      addFlag(args, "--allow-needs-review", params.allowNeedsReview);
+      if (Array.isArray(params.roots)) args.push("--roots-json", JSON.stringify(stringArray(params.roots)));
+      if (typeof params.rootsFilePath === "string") args.push("--roots-file-path", params.rootsFilePath);
+      if (Array.isArray(params.extensions)) args.push("--extensions-json", JSON.stringify(stringArray(params.extensions)));
+      const limit = finiteInteger(params.limit);
+      if (limit !== null) args.push("--limit", String(limit));
+      addFlag(args, "--allow-unreviewed-metadata", params.allowUnreviewedMetadata);
+      addFlag(args, "--queue-missing-metadata", params.queueMissingMetadata !== false);
+      addFlag(args, "--write-metadata-queue-on-dry-run", params.writeMetadataQueueOnDryRun !== false);
+      if (typeof params.scanErrorPolicy === "string") args.push("--scan-error-policy", params.scanErrorPolicy);
+      const threshold = finiteInteger(params.scanErrorThreshold);
+      if (threshold !== null) args.push("--scan-error-threshold", String(threshold));
+      const retry = finiteInteger(params.scanRetryCount);
+      if (retry !== null) args.push("--scan-retry-count", String(retry));
+      if (typeof params.onDstExists === "string") args.push("--on-dst-exists", params.onDstExists);
+      addFlag(args, "--skip-suspicious-title-check", params.skipSuspiciousTitleCheck);
+      return runWorkflowCli("start", args, workflowToolResult);
+    },
+  });
+}
+
+function registerResume(api: PluginApi, getCfg: GetCfgFn) {
+  api.registerTool({
+    name: "video_pipeline_resume",
+    description: "Resume an existing V2 workflow run using an action from nextActions.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["runId"],
+      properties: {
+        runId: { type: "string" },
+        action: { type: "string" },
+        resumeAction: { type: "string" },
+        artifactId: { type: "string" },
+        gateId: { type: "string" },
+        artifactIds: { type: "array", items: { type: "string" } },
+        reviewYamlPaths: { type: "array", items: { type: "string" } },
+        onDstExists: { type: "string", enum: ["error", "rename_suffix"] },
+      },
+    },
+    async execute(_id: string, params: AnyObj) {
+      const cfg = getCfg(api);
+      const action = typeof params.action === "string" && params.action.trim()
+        ? params.action.trim()
+        : typeof params.resumeAction === "string" && params.resumeAction.trim()
+          ? params.resumeAction.trim()
+          : "";
+      const args = [
+        "--windows-ops-root", cfg.windowsOpsRoot,
+        "--db", cfg.db,
+        "--run-id", String(params.runId || ""),
+      ];
+      if (action) args.push("--action", action);
+      if (typeof params.artifactId === "string" && params.artifactId.trim()) args.push("--artifact-id", params.artifactId.trim());
+      if (typeof params.onDstExists === "string" && params.onDstExists.trim()) args.push("--on-dst-exists", params.onDstExists.trim());
+      return runWorkflowCli("resume", args, workflowToolResult);
+    },
+  });
+}
+
+function registerStatus(api: PluginApi, getCfg: GetCfgFn) {
+  api.registerTool({
+    name: "video_pipeline_status",
+    description: "Read V2 workflow run status, recent runs, open gates, and latest artifacts.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        runId: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        includeArtifacts: { type: "boolean", default: false },
+      },
+    },
+    async execute(_id: string, params: AnyObj) {
+      const cfg = getCfg(api);
+      const args = ["--windows-ops-root", cfg.windowsOpsRoot];
+      if (typeof params.runId === "string" && params.runId.trim()) args.push("--run-id", params.runId.trim());
+      const limit = finiteInteger(params.limit);
+      if (limit !== null) args.push("--limit", String(limit));
+      addFlag(args, "--include-artifacts", params.includeArtifacts);
+      return runWorkflowCli("status", args, (parsed) => parsed);
+    },
+  });
+}
+
+function registerInspectArtifact(api: PluginApi, getCfg: GetCfgFn) {
+  api.registerTool({
+    name: "video_pipeline_inspect_artifact",
+    description: "Inspect a V2 workflow artifact by runId and artifactId.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["runId", "artifactId"],
+      properties: {
+        runId: { type: "string" },
+        artifactId: { type: "string" },
+        includeContentPreview: { type: "boolean", default: false },
+        previewBytes: { type: "integer", minimum: 1, maximum: 65536 },
+      },
+    },
+    async execute(_id: string, params: AnyObj) {
+      const cfg = getCfg(api);
+      const args = [
+        "--windows-ops-root", cfg.windowsOpsRoot,
+        "--run-id", String(params.runId || ""),
+        "--artifact-id", String(params.artifactId || ""),
+      ];
+      addFlag(args, "--include-content-preview", params.includeContentPreview);
+      const previewBytes = finiteInteger(params.previewBytes);
+      if (previewBytes !== null) args.push("--preview-bytes", String(previewBytes));
+      return runWorkflowCli("inspect-artifact", args, (parsed) => parsed);
+    },
+  });
+}
+
+export function registerWorkflowTools(api: PluginApi, getCfg: GetCfgFn) {
+  registerStart(api, getCfg);
+  registerResume(api, getCfg);
+  registerStatus(api, getCfg);
+  registerInspectArtifact(api, getCfg);
+}


### PR DESCRIPTION
## Summary
- Replace the broad OpenClaw public tool registration with the four V2 workflow commands
- Add workflow_cli.py as the thin Python dispatcher for start/resume/status/inspect-artifact
- Add Vitest and pytest coverage for V2 schemas, command dispatch, status, and artifact inspection

Closes #108

## Tests
- npm test
- pytest -q py/tests
- git diff --check
- python3 -m py_compile workflow_cli.py