### PR TITLE
Implement deterministic V2 resume actions

### DIFF
--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -206,6 +206,13 @@ def test_relocate_dry_run_suspicious_title_creates_review_gate(tmp_path) -> None
 def test_relocate_metadata_resume_action_rechecks_run_and_reaches_plan_ready(tmp_path) -> None:
     harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_resume_gap", scenario="metadata_gap")
     harness.dry_run()
+    store = WorkflowStore(Path(harness.cfg.windows_ops_root))
+    store.create_review_gate(
+        harness.cfg.run_id,
+        gate_type="relocate_metadata_review",
+        artifact_ids=["relocate_metadata_queue"],
+        gate_id="relocate_metadata_review",
+    )
     harness.scenario = "plan_ready"
 
     result = harness.service().resume(
@@ -226,6 +233,10 @@ def test_relocate_metadata_resume_action_rechecks_run_and_reaches_plan_ready(tmp
     manifest = harness.manifest()
     assert manifest["phase"] == "plan_ready"
     assert manifest["artifacts"]["relocate_plan_0002"]["inputArtifactIds"] == ["relocate_diagnostics_0002"]
+    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "approved"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["resolution"] == {
+        "action": "relocate_metadata_recheck_plan_ready"
+    }
 
 
 def test_relocate_review_resume_action_approves_gate_and_reaches_plan_ready(tmp_path) -> None:

--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -128,6 +128,9 @@ class RelocateWorkflowHarness:
         service = RelocateWorkflowService(python_runner=self.python_runner, py_root=self.tmp_path)
         return service.dry_run(self.cfg)
 
+    def service(self) -> RelocateWorkflowService:
+        return RelocateWorkflowService(python_runner=self.python_runner, py_root=self.tmp_path)
+
     def manifest(self) -> dict:
         manifest_path = Path(self.cfg.windows_ops_root) / "runs" / self.cfg.run_id / "run.json"
         return json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -200,45 +203,50 @@ def test_relocate_dry_run_suspicious_title_creates_review_gate(tmp_path) -> None
     assert payload["gates"][0]["artifactIds"] == ["relocate_diagnostics"]
 
 
-def test_relocate_metadata_resume_actions_do_not_block_review_required_run(tmp_path) -> None:
+def test_relocate_metadata_resume_action_rechecks_run_and_reaches_plan_ready(tmp_path) -> None:
     harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_resume_gap", scenario="metadata_gap")
     harness.dry_run()
-    service = RelocateWorkflowService(py_root=tmp_path)
+    harness.scenario = "plan_ready"
 
-    result = service.resume(
+    result = harness.service().resume(
         RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
         action="prepare_relocate_metadata",
     )
 
     payload = result.to_dict()
-    assert payload["ok"] is False
-    assert payload["phase"] == "review_required"
-    assert payload["outcome"] == "relocate_metadata_preparation_pending"
-    assert payload["nextActions"][0]["action"] == "prepare_relocate_metadata"
+    assert payload["ok"] is True
+    assert payload["phase"] == "plan_ready"
+    assert payload["outcome"] == "relocate_plan_ready"
+    assert payload["nextActions"][0]["action"] == "review_plan"
+    assert payload["nextActions"][0]["params"] == {
+        "runId": "run_relocate_resume_gap",
+        "artifactId": "relocate_plan_0002",
+        "resumeAction": "apply_relocate_move_plan",
+    }
     manifest = harness.manifest()
-    assert manifest["phase"] == "review_required"
-    assert payload["diagnostics"][-1]["code"] == "relocate_metadata_preparation_required"
+    assert manifest["phase"] == "plan_ready"
+    assert manifest["artifacts"]["relocate_plan_0002"]["inputArtifactIds"] == ["relocate_diagnostics_0002"]
 
 
-def test_relocate_review_resume_action_keeps_gate_open_without_blocking(tmp_path) -> None:
+def test_relocate_review_resume_action_approves_gate_and_reaches_plan_ready(tmp_path) -> None:
     harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_resume_review", scenario="suspicious")
     harness.dry_run()
-    service = RelocateWorkflowService(py_root=tmp_path)
+    harness.scenario = "plan_ready"
 
-    result = service.resume(
+    result = harness.service().resume(
         RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
         action="review_relocate_metadata",
     )
 
     payload = result.to_dict()
-    assert payload["ok"] is False
-    assert payload["phase"] == "review_required"
-    assert payload["outcome"] == "relocate_metadata_review_pending"
-    assert payload["nextActions"][0]["action"] == "review_relocate_metadata"
-    assert payload["nextActions"][0]["params"]["gateId"] == "relocate_metadata_review"
+    assert payload["ok"] is True
+    assert payload["phase"] == "plan_ready"
+    assert payload["outcome"] == "relocate_plan_ready"
+    assert payload["nextActions"][0]["action"] == "review_plan"
     manifest = harness.manifest()
-    assert manifest["phase"] == "review_required"
-    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "open"
+    assert manifest["phase"] == "plan_ready"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "approved"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["resolution"] == {"action": "review_relocate_metadata"}
 
 
 def test_relocate_dry_run_already_correct_requires_explicit_count(tmp_path) -> None:

--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -239,6 +239,33 @@ def test_relocate_metadata_resume_action_rechecks_run_and_reaches_plan_ready(tmp
     }
 
 
+def test_relocate_metadata_recheck_approves_rejected_gate_before_plan_ready(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_rejected_gate", scenario="suspicious")
+    harness.dry_run()
+    store = WorkflowStore(Path(harness.cfg.windows_ops_root))
+    store.update_review_gate(
+        harness.cfg.run_id,
+        "relocate_metadata_review",
+        status=ReviewGateStatus.REJECTED,
+        resolution={"action": "operator_rejected"},
+    )
+    harness.scenario = "plan_ready"
+
+    result = harness.service().resume(
+        RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
+        action="prepare_relocate_metadata",
+    )
+
+    payload = result.to_dict()
+    assert payload["ok"] is True
+    assert payload["phase"] == "plan_ready"
+    manifest = harness.manifest()
+    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "approved"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["resolution"] == {
+        "action": "relocate_metadata_recheck_plan_ready"
+    }
+
+
 def test_relocate_review_resume_action_approves_gate_and_reaches_plan_ready(tmp_path) -> None:
     harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_resume_review", scenario="suspicious")
     harness.dry_run()
@@ -281,6 +308,27 @@ def test_relocate_metadata_recheck_refreshes_open_gate_artifacts(tmp_path) -> No
     manifest = harness.manifest()
     assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "open"
     assert manifest["reviewGates"]["relocate_metadata_review"]["artifactIds"] == ["relocate_diagnostics_0002"]
+
+
+def test_relocate_metadata_recheck_approves_gate_before_complete(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_recheck_complete", scenario="suspicious")
+    harness.dry_run()
+    harness.scenario = "already_correct"
+
+    result = harness.service().resume(
+        RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
+        action="prepare_relocate_metadata",
+    )
+
+    payload = result.to_dict()
+    assert payload["ok"] is True
+    assert payload["phase"] == "complete"
+    assert payload["outcome"] == "relocate_already_correct"
+    manifest = harness.manifest()
+    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "approved"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["resolution"] == {
+        "action": "relocate_metadata_recheck_complete"
+    }
 
 
 def test_relocate_dry_run_already_correct_requires_explicit_count(tmp_path) -> None:

--- a/py/tests/test_relocate_workflow.py
+++ b/py/tests/test_relocate_workflow.py
@@ -260,6 +260,29 @@ def test_relocate_review_resume_action_approves_gate_and_reaches_plan_ready(tmp_
     assert manifest["reviewGates"]["relocate_metadata_review"]["resolution"] == {"action": "review_relocate_metadata"}
 
 
+def test_relocate_metadata_recheck_refreshes_open_gate_artifacts(tmp_path) -> None:
+    harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_recheck_still_blocked", scenario="suspicious")
+    harness.dry_run()
+
+    result = harness.service().resume(
+        RelocateApplyConfig(windows_ops_root=harness.cfg.windows_ops_root, run_id=harness.cfg.run_id),
+        action="prepare_relocate_metadata",
+    )
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["phase"] == "review_required"
+    assert payload["outcome"] == "relocate_metadata_review_still_required"
+    assert payload["nextActions"][0]["params"] == {
+        "runId": "run_relocate_recheck_still_blocked",
+        "gateId": "relocate_metadata_review",
+        "artifactIds": ["relocate_diagnostics_0002"],
+    }
+    manifest = harness.manifest()
+    assert manifest["reviewGates"]["relocate_metadata_review"]["status"] == "open"
+    assert manifest["reviewGates"]["relocate_metadata_review"]["artifactIds"] == ["relocate_diagnostics_0002"]
+
+
 def test_relocate_dry_run_already_correct_requires_explicit_count(tmp_path) -> None:
     harness = RelocateWorkflowHarness(tmp_path, run_id="run_relocate_already", scenario="already_correct")
 

--- a/py/tests/test_workflow_cli.py
+++ b/py/tests/test_workflow_cli.py
@@ -28,9 +28,101 @@ def test_workflow_cli_status_lists_recent_runs(tmp_path):
     assert payload["ok"] is True
     assert payload["runs"][0]["runId"] == "run_source"
     assert payload["runs"][0]["phase"] == "inventory_ready"
+    assert payload["runs"][0]["nextActions"] == []
     assert "artifacts" not in payload["runs"][0]
     assert payload["openGates"][0]["runId"] == "run_source"
     assert payload["openGates"][0]["id"] == "metadata_review"
+
+
+def test_workflow_cli_status_reconstructs_source_root_review_action(tmp_path):
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_source_review")
+    review_path = ops_root / "runs" / "run_source_review" / "review" / "metadata_review_0001.yaml"
+    review_path.write_text("hints: []\n", encoding="utf-8")
+    store.register_artifact(
+        "run_source_review",
+        artifact_type="metadata_review_yaml",
+        path=review_path,
+        producer="test",
+        artifact_id="metadata_review_yaml_0001",
+    )
+    store.create_review_gate(
+        "run_source_review",
+        gate_type="metadata_review",
+        artifact_ids=["metadata_review_yaml_0001"],
+        gate_id="metadata_review",
+    )
+    store.transition_run("run_source_review", WorkflowPhase.INVENTORY_READY)
+    store.transition_run("run_source_review", WorkflowPhase.METADATA_EXTRACTED)
+    store.transition_run("run_source_review", WorkflowPhase.REVIEW_REQUIRED)
+
+    payload = _cmd_status(
+        argparse.Namespace(
+            windows_ops_root=str(ops_root),
+            run_id="run_source_review",
+            limit=10,
+            include_artifacts=True,
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["run"]["nextActions"] == [
+        {
+            "action": "review_metadata",
+            "label": "Review extracted metadata YAML",
+            "tool": "video_pipeline_resume",
+            "params": {
+                "runId": "run_source_review",
+                "gateId": "metadata_review",
+                "artifactIds": ["metadata_review_yaml_0001"],
+                "reviewYamlPaths": [str(review_path)],
+                "resumeAction": "apply_reviewed_metadata",
+            },
+            "requiresHumanInput": True,
+        }
+    ]
+
+
+def test_workflow_cli_status_reconstructs_latest_relocate_plan_action(tmp_path):
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_relocate_plan")
+    old_plan_path = ops_root / "runs" / "run_relocate_plan" / "plan" / "relocate_plan.jsonl"
+    old_plan_path.write_text("{}\n", encoding="utf-8")
+    store.register_artifact(
+        "run_relocate_plan",
+        artifact_type="relocate_plan",
+        path=old_plan_path,
+        producer="test",
+        artifact_id="relocate_plan",
+    )
+    latest_plan_path = ops_root / "runs" / "run_relocate_plan" / "plan" / "relocate_plan_0002.jsonl"
+    latest_plan_path.write_text('{"ok": true}\n', encoding="utf-8")
+    store.register_artifact(
+        "run_relocate_plan",
+        artifact_type="relocate_plan",
+        path=latest_plan_path,
+        producer="test",
+        artifact_id="relocate_plan_0002",
+    )
+    store.transition_run("run_relocate_plan", WorkflowPhase.PLAN_READY)
+
+    payload = _cmd_status(
+        argparse.Namespace(
+            windows_ops_root=str(ops_root),
+            run_id="run_relocate_plan",
+            limit=10,
+            include_artifacts=False,
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["run"]["nextActions"][0]["params"] == {
+        "runId": "run_relocate_plan",
+        "artifactId": "relocate_plan_0002",
+        "resumeAction": "apply_relocate_move_plan",
+    }
 
 
 def test_workflow_cli_inspect_artifact_returns_related_gates_and_preview(tmp_path):

--- a/py/tests/test_workflow_cli.py
+++ b/py/tests/test_workflow_cli.py
@@ -125,6 +125,60 @@ def test_workflow_cli_status_reconstructs_latest_relocate_plan_action(tmp_path):
     }
 
 
+def test_workflow_cli_status_prefers_open_relocate_review_gate_over_stale_queue(tmp_path):
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.RELOCATE, run_id="run_relocate_review")
+    queue_path = ops_root / "runs" / "run_relocate_review" / "metadata" / "relocate_metadata_queue.jsonl"
+    queue_path.write_text("{}\n", encoding="utf-8")
+    store.register_artifact(
+        "run_relocate_review",
+        artifact_type="relocate_metadata_queue",
+        path=queue_path,
+        producer="test",
+        artifact_id="relocate_metadata_queue",
+    )
+    diagnostics_path = ops_root / "runs" / "run_relocate_review" / "logs" / "relocate_summary.json"
+    diagnostics_path.write_text("{}\n", encoding="utf-8")
+    store.register_artifact(
+        "run_relocate_review",
+        artifact_type="relocate_diagnostics",
+        path=diagnostics_path,
+        producer="test",
+        artifact_id="relocate_diagnostics",
+    )
+    store.create_review_gate(
+        "run_relocate_review",
+        gate_type="relocate_metadata_review",
+        artifact_ids=["relocate_diagnostics"],
+        gate_id="relocate_metadata_review",
+    )
+    store.transition_run("run_relocate_review", WorkflowPhase.METADATA_EXTRACTED)
+    store.transition_run("run_relocate_review", WorkflowPhase.REVIEW_REQUIRED)
+
+    payload = _cmd_status(
+        argparse.Namespace(
+            windows_ops_root=str(ops_root),
+            run_id="run_relocate_review",
+            limit=10,
+            include_artifacts=False,
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["run"]["nextActions"][0] == {
+        "action": "review_relocate_metadata",
+        "label": "Review blocked relocate metadata",
+        "tool": "video_pipeline_resume",
+        "params": {
+            "runId": "run_relocate_review",
+            "gateId": "relocate_metadata_review",
+            "artifactIds": ["relocate_diagnostics"],
+        },
+        "requiresHumanInput": True,
+    }
+
+
 def test_workflow_cli_inspect_artifact_returns_related_gates_and_preview(tmp_path):
     ops_root = tmp_path / "ops"
     store = WorkflowStore(ops_root)

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -861,7 +861,7 @@ class RelocateWorkflowService:
     ) -> Any:
         run = store.read_run(run_id)
         if gate_id in run.review_gates and run.review_gates[gate_id].status == ReviewGateStatus.OPEN.value:
-            return run.review_gates[gate_id]
+            return store.update_review_gate_artifacts(run_id, gate_id, artifact_ids=artifact_ids)
         if gate_id in run.review_gates:
             gate_id = next_gate_id(run, gate_id)
         return store.create_review_gate(

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -517,7 +517,7 @@ class RelocateWorkflowService:
         has_review_blocker = suspicious > 0 or needs_review > 0 or unreviewed > 0
 
         if planned_moves > 0 and plan_artifact is not None:
-            self._approve_open_metadata_gates(store, run_id, "relocate_metadata_recheck_plan_ready")
+            self._approve_blocking_metadata_gates(store, run_id, "relocate_metadata_recheck_plan_ready")
             self._advance_to_phase(store, run_id, WorkflowPhase.PLAN_READY)
             return self._result(
                 ok=True,
@@ -599,6 +599,7 @@ class RelocateWorkflowService:
             )
 
         if already_correct > 0 and planned_moves == 0:
+            self._approve_blocking_metadata_gates(store, run_id, "relocate_metadata_recheck_complete")
             self._advance_to_phase(store, run_id, WorkflowPhase.COMPLETE)
             return self._result(
                 ok=True,
@@ -608,6 +609,7 @@ class RelocateWorkflowService:
                 outcome="relocate_already_correct",
             )
 
+        self._approve_blocking_metadata_gates(store, run_id, "relocate_metadata_recheck_complete")
         self._advance_to_phase(store, run_id, WorkflowPhase.COMPLETE)
         return self._result(
             ok=True,
@@ -871,14 +873,14 @@ class RelocateWorkflowService:
             gate_id=gate_id,
         )
 
-    def _approve_open_metadata_gates(self, store: WorkflowStore, run_id: str, action: str) -> None:
+    def _approve_blocking_metadata_gates(self, store: WorkflowStore, run_id: str, action: str) -> None:
         run = store.read_run(run_id)
         for gate_id in run.review_gate_ids:
             gate = run.review_gates.get(gate_id)
             if (
                 gate is not None
                 and gate.type == "relocate_metadata_review"
-                and gate.status == ReviewGateStatus.OPEN.value
+                and gate.status in {ReviewGateStatus.OPEN.value, ReviewGateStatus.REJECTED.value}
             ):
                 store.update_review_gate(
                     run_id,

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -517,6 +517,7 @@ class RelocateWorkflowService:
         has_review_blocker = suspicious > 0 or needs_review > 0 or unreviewed > 0
 
         if planned_moves > 0 and plan_artifact is not None:
+            self._approve_open_metadata_gates(store, run_id, "relocate_metadata_recheck_plan_ready")
             self._advance_to_phase(store, run_id, WorkflowPhase.PLAN_READY)
             return self._result(
                 ok=True,
@@ -869,6 +870,22 @@ class RelocateWorkflowService:
             artifact_ids=artifact_ids,
             gate_id=gate_id,
         )
+
+    def _approve_open_metadata_gates(self, store: WorkflowStore, run_id: str, action: str) -> None:
+        run = store.read_run(run_id)
+        for gate_id in run.review_gate_ids:
+            gate = run.review_gates.get(gate_id)
+            if (
+                gate is not None
+                and gate.type == "relocate_metadata_review"
+                and gate.status == ReviewGateStatus.OPEN.value
+            ):
+                store.update_review_gate(
+                    run_id,
+                    gate_id,
+                    status=ReviewGateStatus.APPROVED,
+                    resolution={"action": action},
+                )
 
     def _advance_to_phase(self, store: WorkflowStore, run_id: str, target: WorkflowPhase) -> None:
         run = store.read_run(run_id)

--- a/py/video_pipeline/workflows/relocate.py
+++ b/py/video_pipeline/workflows/relocate.py
@@ -83,6 +83,24 @@ def read_jsonl_rows(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def next_artifact_id(run: Any, base_id: str) -> str:
+    if base_id not in run.artifacts:
+        return base_id
+    idx = 2
+    while f"{base_id}_{idx:04d}" in run.artifacts:
+        idx += 1
+    return f"{base_id}_{idx:04d}"
+
+
+def next_gate_id(run: Any, base_id: str) -> str:
+    if base_id not in run.review_gates:
+        return base_id
+    idx = 2
+    while f"{base_id}_{idx:04d}" in run.review_gates:
+        idx += 1
+    return f"{base_id}_{idx:04d}"
+
+
 class RelocateWorkflowService:
     def __init__(
         self,
@@ -392,7 +410,10 @@ class RelocateWorkflowService:
         plan_dir = run_dir / "plan"
         metadata_dir = run_dir / "metadata"
         logs_dir = run_dir / "logs"
-        summary_path = logs_dir / "relocate_summary.json"
+        run = store.read_run(run_id)
+        diagnostics_id = next_artifact_id(run, "relocate_diagnostics")
+        diagnostics_suffix = "" if diagnostics_id == "relocate_diagnostics" else diagnostics_id.removeprefix("relocate_diagnostics")
+        summary_path = logs_dir / f"relocate_summary{diagnostics_suffix}.json"
 
         args = [
             "--db",
@@ -441,7 +462,7 @@ class RelocateWorkflowService:
             artifact_type="relocate_diagnostics",
             path=summary_path,
             producer="relocate_existing_files.py",
-            artifact_id="relocate_diagnostics",
+            artifact_id=diagnostics_id,
             metadata={"summary": summary},
         )
 
@@ -449,7 +470,9 @@ class RelocateWorkflowService:
         plan_path_raw = summary.get("planPath")
         if isinstance(plan_path_raw, str) and plan_path_raw:
             plan_source = local_path_from_any(plan_path_raw)
-            plan_target = plan_dir / "relocate_plan.jsonl"
+            run = store.read_run(run_id)
+            plan_id = next_artifact_id(run, "relocate_plan")
+            plan_target = plan_dir / f"{plan_id}.jsonl"
             if plan_source.resolve() != plan_target.resolve():
                 shutil.copyfile(plan_source, plan_target)
             plan_artifact = store.register_artifact(
@@ -457,7 +480,7 @@ class RelocateWorkflowService:
                 artifact_type="relocate_plan",
                 path=plan_target,
                 producer="relocate_existing_files.py",
-                artifact_id="relocate_plan",
+                artifact_id=plan_id,
                 input_artifact_ids=[diagnostics_artifact.id],
                 metadata={"summary": summary},
             )
@@ -466,7 +489,9 @@ class RelocateWorkflowService:
         queue_path_raw = summary.get("metadataQueuePath")
         if isinstance(queue_path_raw, str) and queue_path_raw:
             queue_source = local_path_from_any(queue_path_raw)
-            queue_target = metadata_dir / "relocate_metadata_queue.jsonl"
+            run = store.read_run(run_id)
+            queue_id = next_artifact_id(run, "relocate_metadata_queue")
+            queue_target = metadata_dir / f"{queue_id}.jsonl"
             if queue_source.resolve() != queue_target.resolve():
                 shutil.copyfile(queue_source, queue_target)
             queue_artifact = store.register_artifact(
@@ -474,7 +499,7 @@ class RelocateWorkflowService:
                 artifact_type="relocate_metadata_queue",
                 path=queue_target,
                 producer="relocate_existing_files.py",
-                artifact_id="relocate_metadata_queue",
+                artifact_id=queue_id,
                 input_artifact_ids=[diagnostics_artifact.id],
                 metadata={"summary": summary},
             )
@@ -492,7 +517,7 @@ class RelocateWorkflowService:
         has_review_blocker = suspicious > 0 or needs_review > 0 or unreviewed > 0
 
         if planned_moves > 0 and plan_artifact is not None:
-            store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            self._advance_to_phase(store, run_id, WorkflowPhase.PLAN_READY)
             return self._result(
                 ok=True,
                 store=store,
@@ -517,14 +542,14 @@ class RelocateWorkflowService:
         if has_metadata_gap or metadata_queue_count > 0:
             artifact_ids = [queue_artifact.id] if queue_artifact is not None else [diagnostics_artifact.id]
             if has_review_blocker:
-                store.create_review_gate(
+                self._ensure_review_gate(
+                    store,
                     run_id,
                     gate_type="relocate_metadata_review",
                     artifact_ids=artifact_ids,
                     gate_id="relocate_metadata_review",
                 )
-            store.transition_run(run_id, WorkflowPhase.METADATA_EXTRACTED)
-            store.transition_run(run_id, WorkflowPhase.REVIEW_REQUIRED)
+            self._advance_to_phase(store, run_id, WorkflowPhase.REVIEW_REQUIRED)
             return self._result(
                 ok=False,
                 store=store,
@@ -543,14 +568,14 @@ class RelocateWorkflowService:
             )
 
         if has_review_blocker:
-            store.create_review_gate(
+            gate = self._ensure_review_gate(
+                store,
                 run_id,
                 gate_type="relocate_metadata_review",
                 artifact_ids=[diagnostics_artifact.id],
                 gate_id="relocate_metadata_review",
             )
-            store.transition_run(run_id, WorkflowPhase.METADATA_EXTRACTED)
-            store.transition_run(run_id, WorkflowPhase.REVIEW_REQUIRED)
+            self._advance_to_phase(store, run_id, WorkflowPhase.REVIEW_REQUIRED)
             return self._result(
                 ok=False,
                 store=store,
@@ -564,7 +589,7 @@ class RelocateWorkflowService:
                         tool="video_pipeline_resume",
                         params={
                             "runId": run_id,
-                            "gateId": "relocate_metadata_review",
+                            "gateId": gate.id,
                             "artifactIds": [diagnostics_artifact.id],
                         },
                         requires_human_input=True,
@@ -573,8 +598,7 @@ class RelocateWorkflowService:
             )
 
         if already_correct > 0 and planned_moves == 0:
-            store.transition_run(run_id, WorkflowPhase.PLAN_READY)
-            store.transition_run(run_id, WorkflowPhase.COMPLETE)
+            self._advance_to_phase(store, run_id, WorkflowPhase.COMPLETE)
             return self._result(
                 ok=True,
                 store=store,
@@ -583,8 +607,7 @@ class RelocateWorkflowService:
                 outcome="relocate_already_correct",
             )
 
-        store.transition_run(run_id, WorkflowPhase.PLAN_READY)
-        store.transition_run(run_id, WorkflowPhase.COMPLETE)
+        self._advance_to_phase(store, run_id, WorkflowPhase.COMPLETE)
         return self._result(
             ok=True,
             store=store,
@@ -775,47 +798,106 @@ class RelocateWorkflowService:
                 outcome="relocate_resume_action_rejected",
             )
 
-        params: dict[str, Any] = {"runId": run_id}
-        queue_artifacts = [aid for aid in run.artifact_ids if run.artifacts.get(aid) and run.artifacts[aid].type == "relocate_metadata_queue"]
-        diagnostics_artifacts = [aid for aid in run.artifact_ids if run.artifacts.get(aid) and run.artifacts[aid].type == "relocate_diagnostics"]
-        if action == "prepare_relocate_metadata":
-            params["artifactIds"] = queue_artifacts or diagnostics_artifacts
-            next_action = NextAction(
-                action="prepare_relocate_metadata",
-                label="Prepare missing or blocked relocate metadata",
-                tool="video_pipeline_resume",
-                params=params,
-                requires_human_input=False,
-            )
-            outcome = "relocate_metadata_preparation_pending"
-        else:
-            gate_ids = [
-                gid
-                for gid in run.review_gate_ids
-                if gid in run.review_gates and run.review_gates[gid].status == ReviewGateStatus.OPEN.value
-            ]
-            if gate_ids:
-                params["gateId"] = gate_ids[0]
-                params["artifactIds"] = run.review_gates[gate_ids[0]].artifact_ids
-            else:
-                params["artifactIds"] = diagnostics_artifacts
-            next_action = NextAction(
-                action="review_relocate_metadata",
-                label="Review blocked relocate metadata",
-                tool="video_pipeline_resume",
-                params=params,
-                requires_human_input=True,
-            )
-            outcome = "relocate_metadata_review_pending"
+        gate_ids = [
+            gid
+            for gid in run.review_gate_ids
+            if gid in run.review_gates and run.review_gates[gid].status == ReviewGateStatus.OPEN.value
+        ]
+        if action == "review_relocate_metadata":
+            for gate_id in gate_ids:
+                store.update_review_gate(
+                    run_id,
+                    gate_id,
+                    status=ReviewGateStatus.APPROVED,
+                    resolution={"action": action},
+                )
 
-        return self._result(
-            ok=False,
-            store=store,
-            run_id=run_id,
-            phase=run.phase,
-            outcome=outcome,
-            next_actions=[next_action],
+        rerun = store.read_run(run_id)
+        cfg = self._config_from_run(rerun)
+        result = self._dry_run_existing(
+            run_id,
+            cfg,
+            store,
+            str(local_path_from_any(str(rerun.config_snapshot.get("db") or ""))),
         )
+        if result.outcome == "relocate_metadata_preparation_required":
+            result.outcome = "relocate_metadata_preparation_still_required"
+        elif result.outcome == "relocate_review_required":
+            result.outcome = "relocate_metadata_review_still_required"
+        return result
+
+    def _config_from_run(self, run: Any) -> RelocateDryRunConfig:
+        snapshot = run.config_snapshot
+        return RelocateDryRunConfig(
+            windows_ops_root=str(snapshot.get("windowsOpsRoot") or ""),
+            dest_root=str(snapshot.get("destRoot") or ""),
+            db=str(snapshot.get("db") or ""),
+            roots=[str(v) for v in snapshot.get("roots") or [] if isinstance(v, str) and v],
+            roots_file_path=str(snapshot.get("rootsFilePath") or ""),
+            extensions=[str(v) for v in snapshot.get("extensions") or [] if isinstance(v, str) and v],
+            drive_routes=str(snapshot.get("driveRoutes") or ""),
+            limit=int(snapshot.get("limit") or 0),
+            allow_needs_review=bool(snapshot.get("allowNeedsReview")),
+            allow_unreviewed_metadata=bool(snapshot.get("allowUnreviewedMetadata")),
+            queue_missing_metadata=bool(snapshot.get("queueMissingMetadata")),
+            write_metadata_queue_on_dry_run=bool(snapshot.get("writeMetadataQueueOnDryRun")),
+            scan_error_policy=str(snapshot.get("scanErrorPolicy") or "warn"),
+            scan_error_threshold=int(snapshot.get("scanErrorThreshold") or 0),
+            scan_retry_count=int(snapshot.get("scanRetryCount") or 1),
+            on_dst_exists=str(snapshot.get("onDstExists") or "error"),
+            skip_suspicious_title_check=bool(snapshot.get("skipSuspiciousTitleCheck")),
+            run_id=run.run_id,
+        )
+
+    def _ensure_review_gate(
+        self,
+        store: WorkflowStore,
+        run_id: str,
+        *,
+        gate_type: str,
+        artifact_ids: list[str],
+        gate_id: str,
+    ) -> Any:
+        run = store.read_run(run_id)
+        if gate_id in run.review_gates and run.review_gates[gate_id].status == ReviewGateStatus.OPEN.value:
+            return run.review_gates[gate_id]
+        if gate_id in run.review_gates:
+            gate_id = next_gate_id(run, gate_id)
+        return store.create_review_gate(
+            run_id,
+            gate_type=gate_type,
+            artifact_ids=artifact_ids,
+            gate_id=gate_id,
+        )
+
+    def _advance_to_phase(self, store: WorkflowStore, run_id: str, target: WorkflowPhase) -> None:
+        run = store.read_run(run_id)
+        if run.phase == target.value:
+            return
+        if target == WorkflowPhase.REVIEW_REQUIRED:
+            if run.phase == WorkflowPhase.CREATED.value:
+                store.transition_run(run_id, WorkflowPhase.METADATA_EXTRACTED)
+                store.transition_run(run_id, WorkflowPhase.REVIEW_REQUIRED)
+            elif run.phase == WorkflowPhase.METADATA_EXTRACTED.value:
+                store.transition_run(run_id, WorkflowPhase.REVIEW_REQUIRED)
+            return
+        if target == WorkflowPhase.PLAN_READY:
+            if run.phase == WorkflowPhase.REVIEW_REQUIRED.value:
+                store.transition_run(run_id, WorkflowPhase.METADATA_ACCEPTED)
+                store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            elif run.phase == WorkflowPhase.METADATA_EXTRACTED.value:
+                store.transition_run(run_id, WorkflowPhase.METADATA_ACCEPTED)
+                store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            elif run.phase == WorkflowPhase.CREATED.value:
+                store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            elif run.phase == WorkflowPhase.METADATA_ACCEPTED.value:
+                store.transition_run(run_id, WorkflowPhase.PLAN_READY)
+            return
+        if target == WorkflowPhase.COMPLETE:
+            self._advance_to_phase(store, run_id, WorkflowPhase.PLAN_READY)
+            current = store.read_run(run_id)
+            if current.phase == WorkflowPhase.PLAN_READY.value:
+                store.transition_run(run_id, WorkflowPhase.COMPLETE)
 
     def _block_apply(
         self,

--- a/py/video_pipeline/workflows/store.py
+++ b/py/video_pipeline/workflows/store.py
@@ -208,3 +208,18 @@ class WorkflowStore:
         run.updated_at = now_iso()
         self.write_run(run)
         return gate
+
+    def update_review_gate_artifacts(
+        self,
+        run_id: str,
+        gate_id: str,
+        *,
+        artifact_ids: list[str],
+    ) -> ReviewGate:
+        run = self.read_run(run_id)
+        gate = run.review_gates[gate_id]
+        gate.artifact_ids = list(artifact_ids)
+        run.review_gates[gate_id] = gate
+        run.updated_at = now_iso()
+        self.write_run(run)
+        return gate

--- a/py/workflow_cli.py
+++ b/py/workflow_cli.py
@@ -9,9 +9,11 @@ from typing import Any
 
 from video_pipeline.platform.pathscan_common import windows_to_wsl_path
 from video_pipeline.workflows import (
+    NextAction,
     RelocateApplyConfig,
     RelocateDryRunConfig,
     RelocateWorkflowService,
+    ReviewGateStatus,
     SourceRootApplyConfig,
     SourceRootDryRunConfig,
     SourceRootWorkflowService,
@@ -42,10 +44,126 @@ def _store(windows_ops_root: str) -> WorkflowStore:
 
 def _run_to_status(run: Any, *, include_artifacts: bool) -> dict[str, Any]:
     payload = run.to_dict()
+    payload["nextActions"] = [action.to_dict() for action in _next_actions_for_run(run)]
     if not include_artifacts:
         payload.pop("artifacts", None)
         payload.pop("reviewGates", None)
     return payload
+
+
+def _latest_artifact_id(run: Any, artifact_type: str) -> str | None:
+    for artifact_id in reversed(run.artifact_ids):
+        artifact = run.artifacts.get(artifact_id)
+        if artifact is not None and artifact.type == artifact_type:
+            return artifact.id
+    return None
+
+
+def _next_actions_for_run(run: Any) -> list[NextAction]:
+    if run.phase == "plan_ready":
+        if run.flow == "source_root":
+            plan_id = _latest_artifact_id(run, "source_root_move_plan")
+            if plan_id:
+                return [
+                    NextAction(
+                        action="review_plan",
+                        label="Review sourceRoot move plan",
+                        tool="video_pipeline_resume",
+                        params={
+                            "runId": run.run_id,
+                            "artifactId": plan_id,
+                            "resumeAction": "apply_source_root_move_plan",
+                        },
+                        requires_human_input=True,
+                    )
+                ]
+        if run.flow == "relocate":
+            plan_id = _latest_artifact_id(run, "relocate_plan")
+            if plan_id:
+                return [
+                    NextAction(
+                        action="review_plan",
+                        label="Review relocate move plan",
+                        tool="video_pipeline_resume",
+                        params={
+                            "runId": run.run_id,
+                            "artifactId": plan_id,
+                            "resumeAction": "apply_relocate_move_plan",
+                        },
+                        requires_human_input=True,
+                    )
+                ]
+    if run.phase != "review_required":
+        return []
+
+    open_gates = [
+        gate
+        for gate_id in run.review_gate_ids
+        if (gate := run.review_gates.get(gate_id)) is not None and gate.status == ReviewGateStatus.OPEN.value
+    ]
+    if run.flow == "source_root":
+        metadata_gate = next((gate for gate in open_gates if gate.type == "metadata_review"), None)
+        if metadata_gate is None:
+            return []
+        review_yaml_paths = [
+            run.artifacts[artifact_id].path
+            for artifact_id in metadata_gate.artifact_ids
+            if artifact_id in run.artifacts and run.artifacts[artifact_id].type == "metadata_review_yaml"
+        ]
+        return [
+            NextAction(
+                action="review_metadata",
+                label="Review extracted metadata YAML",
+                tool="video_pipeline_resume",
+                params={
+                    "runId": run.run_id,
+                    "gateId": metadata_gate.id,
+                    "artifactIds": list(metadata_gate.artifact_ids),
+                    "reviewYamlPaths": review_yaml_paths,
+                    "resumeAction": "apply_reviewed_metadata",
+                },
+                requires_human_input=True,
+            )
+        ]
+    if run.flow == "relocate":
+        queue_id = _latest_artifact_id(run, "relocate_metadata_queue")
+        diagnostics_id = _latest_artifact_id(run, "relocate_diagnostics")
+        review_gate = next((gate for gate in open_gates if gate.type == "relocate_metadata_review"), None)
+        if queue_id:
+            return [
+                NextAction(
+                    action="prepare_relocate_metadata",
+                    label="Prepare missing or blocked relocate metadata",
+                    tool="video_pipeline_resume",
+                    params={"runId": run.run_id, "artifactIds": [queue_id]},
+                    requires_human_input=review_gate is not None,
+                )
+            ]
+        if review_gate is not None:
+            return [
+                NextAction(
+                    action="review_relocate_metadata",
+                    label="Review blocked relocate metadata",
+                    tool="video_pipeline_resume",
+                    params={
+                        "runId": run.run_id,
+                        "gateId": review_gate.id,
+                        "artifactIds": list(review_gate.artifact_ids),
+                    },
+                    requires_human_input=True,
+                )
+            ]
+        if diagnostics_id:
+            return [
+                NextAction(
+                    action="prepare_relocate_metadata",
+                    label="Prepare missing or blocked relocate metadata",
+                    tool="video_pipeline_resume",
+                    params={"runId": run.run_id, "artifactIds": [diagnostics_id]},
+                    requires_human_input=False,
+                )
+            ]
+    return []
 
 
 def _cmd_start(args: argparse.Namespace) -> dict[str, Any]:

--- a/py/workflow_cli.py
+++ b/py/workflow_cli.py
@@ -129,16 +129,6 @@ def _next_actions_for_run(run: Any) -> list[NextAction]:
         queue_id = _latest_artifact_id(run, "relocate_metadata_queue")
         diagnostics_id = _latest_artifact_id(run, "relocate_diagnostics")
         review_gate = next((gate for gate in open_gates if gate.type == "relocate_metadata_review"), None)
-        if queue_id:
-            return [
-                NextAction(
-                    action="prepare_relocate_metadata",
-                    label="Prepare missing or blocked relocate metadata",
-                    tool="video_pipeline_resume",
-                    params={"runId": run.run_id, "artifactIds": [queue_id]},
-                    requires_human_input=review_gate is not None,
-                )
-            ]
         if review_gate is not None:
             return [
                 NextAction(
@@ -151,6 +141,16 @@ def _next_actions_for_run(run: Any) -> list[NextAction]:
                         "artifactIds": list(review_gate.artifact_ids),
                     },
                     requires_human_input=True,
+                )
+            ]
+        if queue_id:
+            return [
+                NextAction(
+                    action="prepare_relocate_metadata",
+                    label="Prepare missing or blocked relocate metadata",
+                    tool="video_pipeline_resume",
+                    params={"runId": run.run_id, "artifactIds": [queue_id]},
+                    requires_human_input=review_gate is not None,
                 )
             ]
         if diagnostics_id:

--- a/skills/extract-review/SKILL.md
+++ b/skills/extract-review/SKILL.md
@@ -12,7 +12,7 @@ metadata: {"openclaw":{"emoji":"🧠","requires":{"plugins":["video-library-pipe
 - Do not search for latest extraction JSONL/YAML files.
 - The run manifest and `ReviewGate.artifactIds` define the review scope.
 - Do not ask the user to decide destination folders in this stage.
-- SourceRoot metadata review resume is not supported in the current V2 public surface when the returned action is `apply_reviewed_metadata`. Do not call that unsupported action. Future implementation is tracked in #125.
+- SourceRoot metadata review resumes through the returned `apply_reviewed_metadata` action after the user confirms YAML review is complete.
 
 ## Review Scope
 
@@ -47,23 +47,20 @@ Out of scope:
    }
    ```
 4. Present the artifact path and concrete review scope to the user.
-5. After the user confirms review is complete, check the returned follow-up action:
-   - If `resumeAction == "apply_reviewed_metadata"` for a sourceRoot run, stop and report that this metadata review resume path is not yet supported by the V2 public surface.
-   - Otherwise execute only supported returned follow-up params:
+5. After the user confirms review is complete, execute the returned follow-up params:
    ```json
    video_pipeline_resume {
      "runId": "<runId>",
-     "resumeAction": "<supported resumeAction from nextActions>",
-     "...": "other params from the retained WorkflowResult followUpToolCalls[].params"
+     "resumeAction": "<resumeAction from nextActions>",
+     "...": "other params from nextActions.params"
    }
    ```
 
 ## Required Behavior
 
-- Use params exactly as returned by a retained `WorkflowResult.followUpToolCalls` or `nextActions.params`.
+- Use params exactly as returned by `followUpToolCalls` or `nextActions.params`.
 - If a follow-up has `requiresHumanReview: true`, never call it before user confirmation.
-- Do not synthesize resume params from `video_pipeline_status`; status is inspect-only and does not return actionable next steps.
-- Do not call unsupported sourceRoot metadata review action `apply_reviewed_metadata`; report the workflow gap tracked in #125.
+- Do not synthesize resume params by scanning latest files; use status/result `nextActions`.
 - After resume, read the returned `phase`:
   - `plan_ready`: hand off to `skills/move-review/SKILL.md`.
   - `review_required`: repeat this skill for the new/open gate.
@@ -71,4 +68,4 @@ Out of scope:
 
 ## Legacy Guardrail
 
-The old standalone extraction/apply tools are hidden in the V2 public surface. Do not instruct the operator to call hidden legacy tools directly. If metadata repair cannot be completed through the returned `video_pipeline_resume` action, report the #125 workflow gap rather than guessing a latest JSONL/YAML path.
+The old standalone extraction/apply tools are hidden in the V2 public surface. Do not instruct the operator to call hidden legacy tools directly. If metadata repair cannot be completed through the returned `video_pipeline_resume` action, report diagnostics rather than guessing a latest JSONL/YAML path.

--- a/skills/relocate-review/SKILL.md
+++ b/skills/relocate-review/SKILL.md
@@ -12,7 +12,7 @@ metadata: {"openclaw":{"emoji":"📁","requires":{"plugins":["video-library-pipe
 - Start with `video_pipeline_start {"flow":"relocate"}`.
 - Do not call hidden legacy relocation tools directly.
 - Destination layout is determined by workflow logic and drive routes. Do not ask the user to choose drives or folder taxonomy.
-- Relocate metadata follow-up actions `prepare_relocate_metadata` and `review_relocate_metadata` do not currently advance the V2 workflow. Do not replay them as progress actions; report the #125 workflow gap.
+- Relocate metadata follow-up actions `prepare_relocate_metadata` and `review_relocate_metadata` are supported V2 resume actions. They re-evaluate the same run and may advance it to `plan_ready`.
 
 ## Roots Rule
 
@@ -47,9 +47,7 @@ metadata: {"openclaw":{"emoji":"📁","requires":{"plugins":["video-library-pipe
    - `phase == "review_required"`: inspect gate artifacts and hand off to `skills/extract-review/SKILL.md` or report required review.
    - `phase == "complete"`: report the outcome, such as already-correct.
    - `phase == "blocked"` or `phase == "failed"`: report diagnostics and stop.
-4. Resume only through supported returned follow-up params:
-   - If the returned action is `prepare_relocate_metadata` or `review_relocate_metadata`, stop and report that relocate metadata continuation is not yet supported by the V2 public surface. This gap is tracked in #125.
-   - Otherwise execute only supported returned follow-up params:
+4. Resume only through returned follow-up params:
    ```json
    video_pipeline_resume {
      "runId": "<runId>",
@@ -63,8 +61,8 @@ metadata: {"openclaw":{"emoji":"📁","requires":{"plugins":["video-library-pipe
 - The `artifactId` belongs to the same `runId`.
 - Open review gates are resolved before apply.
 - No latest-plan or path guessing is used.
-- Relocate metadata actions are not treated as apply/progress actions until #125 is implemented.
+- Relocate metadata actions are progress actions, but still require user confirmation first when `requiresHumanReview` is true.
 
 ## Unsupported Legacy Cleanup
 
-Some older folder-contamination and direct-title-repair flows depended on hidden legacy public tools. In V2 public operation, report that those flows require a future V2 workflow unless the current run returns an explicit supported `video_pipeline_resume` action for them. Relocate metadata actions that only return another pending metadata action are workflow gaps tracked in #125, not supported continuation paths.
+Some older folder-contamination and direct-title-repair flows depended on hidden legacy public tools. In V2 public operation, report that those flows require a future V2 workflow unless the current run returns an explicit supported `video_pipeline_resume` action for them.

--- a/skills/video-library-pipeline/SKILL.md
+++ b/skills/video-library-pipeline/SKILL.md
@@ -27,7 +27,7 @@ This skill is the V2 orchestrator for `video-library-pipeline`.
 |---|---|
 | Process new recordings from `sourceRoot` | Read `skills/inventory-review/SKILL.md`; start `flow: "source_root"` |
 | Reorganize/relocate existing library files | Read `skills/relocate-review/SKILL.md`; start `flow: "relocate"` |
-| Continue an existing run | Call `video_pipeline_status` with `runId` to inspect state. Resume only if you already have `followUpToolCalls` / `nextActions` from the latest `WorkflowResult`; status itself does not return resume actions. |
+| Continue an existing run | Call `video_pipeline_status` with `runId` and `includeArtifacts:true`; use returned `nextActions` to resume. |
 | Inspect review YAML, plan, diagnostics, or apply log | Call `video_pipeline_inspect_artifact` with `runId` and `artifactId` |
 | Metadata review handoff | Read `skills/extract-review/SKILL.md`; use the run's `ReviewGate` and artifacts |
 | Apply/move after plan review | Read `skills/move-review/SKILL.md`; resume the run with the plan action returned by `nextActions` |
@@ -48,13 +48,13 @@ If the request targets an already-existing directory tree under the library, tre
    - `outcome`
    - `artifacts`
    - `gates`
-   - `nextActions` / `followUpToolCalls` only when the result is a `WorkflowResult` from `start` or `resume`
+   - `nextActions` / `followUpToolCalls`
    - `diagnostics`
 3. If a human review gate is present, inspect the referenced artifact and ask the user to review it.
-4. After review or approval, call `video_pipeline_resume` only with exact params from a retained `WorkflowResult.followUpToolCalls[].params` or `nextActions[].params`.
+4. After review or approval, call `video_pipeline_resume` only with exact params from `followUpToolCalls[].params` or `nextActions[].params`.
 5. Repeat until `phase` is `complete`, `blocked`, or `failed`.
 
-`video_pipeline_status` returns the run manifest for inspection. It does not reconstruct actionable resume parameters. If no prior `WorkflowResult` with next actions is available, report that deterministic continuation is not available from status alone rather than guessing. Future implementation is tracked in #125.
+`video_pipeline_status` reconstructs actionable `nextActions` from the run manifest for non-terminal review and plan phases. If no action is returned, do not guess a latest JSONL/YAML/plan path.
 
 ## Reporting
 


### PR DESCRIPTION
## Summary
- reconstruct actionable V2 nextActions from video_pipeline_status for review and plan phases
- make relocate metadata resume actions re-evaluate the same run and advance to plan_ready when metadata blockers are cleared
- preserve run-scoped artifact identity with numbered relocate artifacts on repeated evaluations
- update V2 skills to reflect supported sourceRoot and relocate continuation paths

Closes #125

## Validation
- pytest -q py/tests
- npm test