### PR TITLE
Add V2 workflow contract fixture tests

### DIFF
--- a/py/tests/test_workflow_contract_fixtures.py
+++ b/py/tests/test_workflow_contract_fixtures.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+
+FIXTURES_ROOT = Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_source_root_review_required_fixture_preserves_run_scoped_refs() -> None:
+    payload = load_fixture("v2_workflow_result_source_root_review_required.json")
+
+    assert payload["runId"] == "run_contract_source_review"
+    assert payload["flow"] == "source_root"
+    assert payload["phase"] == "review_required"
+    assert payload["ok"] is False
+
+    artifact_ids = {artifact["id"] for artifact in payload["artifacts"]}
+    assert {"metadata_extract_output_0001", "metadata_review_yaml_0001"} <= artifact_ids
+
+    review_gate = payload["gates"][0]
+    assert review_gate["id"] == "metadata_review"
+    assert review_gate["status"] == "open"
+    assert review_gate["artifactIds"] == ["metadata_review_yaml_0001"]
+    assert set(review_gate["artifactIds"]) <= artifact_ids
+
+    review_action = payload["nextActions"][0]
+    assert review_action["action"] == "review_metadata"
+    assert review_action["tool"] == "video_pipeline_resume"
+    assert review_action["requiresHumanInput"] is True
+    assert review_action["params"] == {
+        "runId": "run_contract_source_review",
+        "gateId": "metadata_review",
+        "artifactIds": ["metadata_review_yaml_0001"],
+        "reviewYamlPaths": ["/ops/runs/run_contract_source_review/review/metadata_review_0001.yaml"],
+        "resumeAction": "apply_reviewed_metadata",
+    }
+
+    review_artifact = next(
+        artifact for artifact in payload["artifacts"] if artifact["id"] == "metadata_review_yaml_0001"
+    )
+    assert review_artifact["inputArtifactIds"] == ["metadata_extract_output_0001"]
+    assert review_artifact["metadata"]["sourceJsonlPath"].endswith("llm_filename_extract_output_0001_0001.jsonl")

--- a/src/workflows/workflow-result-translator.test.ts
+++ b/src/workflows/workflow-result-translator.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { translateWorkflowResult, type WorkflowResultPayload } from "./workflow-result-translator";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_ROOT = resolve(HERE, "../../tests/fixtures");
 
 function basePayload(overrides: Partial<WorkflowResultPayload> = {}): WorkflowResultPayload {
   return {
@@ -17,6 +23,33 @@ function basePayload(overrides: Partial<WorkflowResultPayload> = {}): WorkflowRe
 }
 
 describe("translateWorkflowResult", () => {
+  it("consumes the shared sourceRoot review-required Python contract fixture", () => {
+    const fixture = JSON.parse(
+      readFileSync(resolve(FIXTURES_ROOT, "v2_workflow_result_source_root_review_required.json"), "utf-8"),
+    ) as WorkflowResultPayload;
+
+    const result = translateWorkflowResult(fixture);
+
+    expect(result.runId).toBe("run_contract_source_review");
+    expect(result.phase).toBe("review_required");
+    expect(result.nextActions).toHaveLength(1);
+    expect(result.followUpToolCalls).toEqual([
+      {
+        tool: "video_pipeline_resume",
+        reason: "review_metadata",
+        params: {
+          runId: "run_contract_source_review",
+          gateId: "metadata_review",
+          artifactIds: ["metadata_review_yaml_0001"],
+          reviewYamlPaths: ["/ops/runs/run_contract_source_review/review/metadata_review_0001.yaml"],
+          resumeAction: "apply_reviewed_metadata",
+        },
+        requiresHumanReview: true,
+      },
+    ]);
+    expect(result.nextStep).toContain("Review");
+  });
+
   it("maps sourceRoot plan-ready nextActions to followUpToolCalls", () => {
     const result = translateWorkflowResult(basePayload({
       phase: "plan_ready",

--- a/tests/fixtures/v2_workflow_result_source_root_review_required.json
+++ b/tests/fixtures/v2_workflow_result_source_root_review_required.json
@@ -1,0 +1,77 @@
+{
+  "ok": false,
+  "runId": "run_contract_source_review",
+  "flow": "source_root",
+  "phase": "review_required",
+  "outcome": "source_root_metadata_review_required",
+  "artifacts": [
+    {
+      "id": "metadata_extract_output_0001",
+      "type": "metadata_extract_output",
+      "path": "/ops/runs/run_contract_source_review/metadata/llm_filename_extract_output_0001_0001.jsonl",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "createdAt": "2026-04-26T00:00:00+00:00",
+      "producer": "run_metadata_batches_promptv1.py",
+      "status": "available",
+      "inputArtifactIds": ["metadata_queue"],
+      "metadata": {
+        "summary": {
+          "processed": 1
+        }
+      }
+    },
+    {
+      "id": "metadata_review_yaml_0001",
+      "type": "metadata_review_yaml",
+      "path": "/ops/runs/run_contract_source_review/review/metadata_review_0001.yaml",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "createdAt": "2026-04-26T00:01:00+00:00",
+      "producer": "export_program_yaml.py",
+      "status": "available",
+      "inputArtifactIds": ["metadata_extract_output_0001"],
+      "metadata": {
+        "sourceJsonlPath": "/ops/runs/run_contract_source_review/metadata/llm_filename_extract_output_0001_0001.jsonl",
+        "reviewSummary": {
+          "rowsNeedingReview": 1
+        }
+      }
+    }
+  ],
+  "gates": [
+    {
+      "id": "metadata_review",
+      "type": "metadata_review",
+      "status": "open",
+      "artifactIds": ["metadata_review_yaml_0001"],
+      "requiresHumanReview": true,
+      "openedAt": "2026-04-26T00:01:00+00:00",
+      "resolvedAt": null,
+      "resolution": {}
+    }
+  ],
+  "nextActions": [
+    {
+      "action": "review_metadata",
+      "label": "Review extracted metadata YAML",
+      "tool": "video_pipeline_resume",
+      "params": {
+        "runId": "run_contract_source_review",
+        "gateId": "metadata_review",
+        "artifactIds": ["metadata_review_yaml_0001"],
+        "reviewYamlPaths": ["/ops/runs/run_contract_source_review/review/metadata_review_0001.yaml"],
+        "resumeAction": "apply_reviewed_metadata"
+      },
+      "requiresHumanInput": true
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "metadata_review_required",
+      "severity": "info",
+      "message": "metadata review is required",
+      "details": {
+        "reviewCandidates": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a shared V2 WorkflowResult fixture for sourceRoot metadata review-required state
- validate the fixture from Python for run-scoped artifact, ReviewGate, and nextAction references
- validate the same fixture from TypeScript through translateWorkflowResult so follow-up params are preserved across layers

Closes #110

## Validation
- pytest -q py/tests
- npm test