### PR TITLE
Make program alias hints readiness truthful

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -36,7 +36,7 @@
 
 補足:
 
-- ヒントファイル `rules/program_aliases.yaml` は任意。欠損時は AI のみのモードで抽出を継続する
+- ヒントファイル `rules/program_aliases.yaml` は任意。欠損時は AI のみのモードで抽出を継続する。ファイルが存在する場合は `pyyaml` で読み込める必要があり、読み込み不能なら抽出を停止する
 - バックフィルルートファイル `rules/backfill_roots.yaml` は backfill ツールへのオプション入力。未設定時は `destRoot` を使用
 - 再配置ルートファイル `rules/relocate_roots.yaml` は relocate ツールへのオプション入力。安全のため、relocate には依然として明示的な `roots` または `rootsFilePath` が必要
 - 放送バケットルール `rules/broadcast_buckets.yaml` は dedup ツールが使用（terrestrial / bs_cs / unknown 分類）
@@ -55,7 +55,7 @@
 
 ## Python ランタイム依存関係
 
-- `pyyaml` — `drive_routes.yaml` ロードに必要（`py/video_pipeline/domain/path_placement_rules.py`）。標準ライブラリ外では唯一の必須依存
+- `pyyaml` — `drive_routes.yaml` と `program_aliases.yaml` のロードに必要。標準ライブラリ外では唯一の必須依存
 - Python 標準ライブラリ（`sqlite3`, `argparse`, `json`, `unicodedata` 等）
 - DB アクセスは標準 `sqlite3` のみ（外部 ORM 依存なし）
 

--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -232,36 +232,66 @@ def _iter_regex_rules(obj: Any) -> list[tuple[re.Pattern, str, str]]:
     return result
 
 
-def _load_hint_items_from_file(path: Path) -> tuple[list[dict[str, Any]], list[tuple[re.Pattern, str]]]:
+class HintLoadFailure(RuntimeError):
+    def __init__(self, status: dict[str, Any]) -> None:
+        super().__init__(str(status.get("hintsLoadError") or "failed to load hints"))
+        self.status = status
+
+
+def _default_hints_status(path: str | None) -> dict[str, Any]:
+    return {
+        "hintsPath": str(path or ""),
+        "hintsFilePresent": False,
+        "hintsParserAvailable": yaml is not None,
+        "hintsLoadable": False,
+        "hintsLoaded": False,
+        "hintsLoadError": None,
+        "hintsAliasCount": 0,
+        "hintsRegexRulesCount": 0,
+    }
+
+
+def _hint_load_error(status: dict[str, Any], message: str) -> HintLoadFailure:
+    status["hintsLoadable"] = False
+    status["hintsLoaded"] = False
+    status["hintsLoadError"] = message
+    return HintLoadFailure(status)
+
+
+def _load_hint_items_from_file(path: Path) -> tuple[list[dict[str, Any]], list[tuple[re.Pattern, str, str]]]:
     """ファイルから (alias_items, regex_rules) を読み込む。"""
     if not path.exists():
         return [], []
-    try:
-        obj: Any = None
-        if path.suffix.lower() == ".json":
+    obj: Any = None
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
             with path.open("r", encoding="utf-8-sig") as f:
                 obj = json.load(f)
-        elif path.suffix.lower() in {".yaml", ".yml"}:
-            if yaml is None:
-                print(f"W hints yaml parser unavailable, skip={path}")
-                return [], []
+        except Exception as e:
+            raise ValueError(f"failed to load JSON hints: path={path} error={e}") from e
+    elif suffix in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError(f"PyYAML is required to load hints YAML: path={path}")
+        try:
             with path.open("r", encoding="utf-8-sig") as f:
                 obj = yaml.safe_load(f)
-        if obj is None:
-            return [], []
-        return _iter_hint_items(obj), _iter_regex_rules(obj)
-    except Exception as e:
-        print(f"W failed to load hints: path={path} error={e}")
-    return [], []
+        except Exception as e:
+            raise ValueError(f"failed to load YAML hints: path={path} error={e}") from e
+    if obj is None:
+        return [], []
+    return _iter_hint_items(obj), _iter_regex_rules(obj)
 
 
-def _load_hints(path: str | None) -> tuple[HintSet, bool]:
+def _load_hints_with_status(path: str | None) -> tuple[HintSet, dict[str, Any]]:
+    status = _default_hints_status(path)
     if not path:
-        return HintSet(), False
+        return HintSet(), status
     p = Path(path)
     if not p.exists():
         print(f"W hints file missing: {p}")
-        return HintSet(), False
+        return HintSet(), status
+    status["hintsFilePresent"] = True
 
     files: list[Path]
     if p.is_dir():
@@ -272,9 +302,12 @@ def _load_hints(path: str | None) -> tuple[HintSet, bool]:
         files = [p]
 
     alias_map: dict[str, str] = {}
-    regex_rules: list[tuple[re.Pattern, str]] = []
+    regex_rules: list[tuple[re.Pattern, str, str]] = []
     for fp in files:
-        alias_items, rules = _load_hint_items_from_file(fp)
+        try:
+            alias_items, rules = _load_hint_items_from_file(fp)
+        except Exception as e:
+            raise _hint_load_error(status, str(e)) from e
         for item in alias_items:
             canonical = item.get("canonical_title")
             if not isinstance(canonical, str):
@@ -294,7 +327,16 @@ def _load_hints(path: str | None) -> tuple[HintSet, bool]:
         regex_rules.extend(rules)
 
     hints = HintSet(alias_map=alias_map, regex_rules=regex_rules)
-    return hints, bool(hints)
+    status["hintsLoadable"] = True
+    status["hintsLoaded"] = bool(hints)
+    status["hintsAliasCount"] = len(hints.alias_map)
+    status["hintsRegexRulesCount"] = len(hints.regex_rules)
+    return hints, status
+
+
+def _load_hints(path: str | None) -> tuple[HintSet, bool]:
+    hints, status = _load_hints_with_status(path)
+    return hints, bool(status["hintsLoaded"])
 
 
 def _canonicalize_title_from_hints(base: str, parsed_program_title: str, alias_map: HintSet) -> str:
@@ -754,13 +796,26 @@ def main() -> int:
                     help="Write input JSONL batches and exit without running extraction or upserting to DB.")
     args = ap.parse_args()
 
-    alias_hints, hints_loaded = _load_hints(args.hints)
+    try:
+        alias_hints, hints_status = _load_hints_with_status(args.hints)
+    except HintLoadFailure as e:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "tool": "run_metadata_batches_promptv1",
+                    **e.status,
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 2
     print(
         f"INFO title_architecture={ACTIVE_TITLE_ARCHITECTURE} "
         f"deferred={','.join(DEFERRED_TITLE_ARCHITECTURES)} "
-        f"hints_loaded={str(hints_loaded).lower()} "
-        f"alias_count={len(alias_hints.alias_map)} "
-        f"regex_rules_count={len(alias_hints.regex_rules)}"
+        f"hints_loaded={str(hints_status['hintsLoaded']).lower()} "
+        f"alias_count={hints_status['hintsAliasCount']} "
+        f"regex_rules_count={hints_status['hintsRegexRulesCount']}"
     )
     outdir = Path(args.outdir)
     outdir.mkdir(parents=True, exist_ok=True)
@@ -985,6 +1040,7 @@ def main() -> int:
                     "batches": int(batch_idx),
                     "inputJsonlPaths": generated_input_jsonl_paths,
                     "latestInputJsonlPath": generated_input_jsonl_paths[-1] if generated_input_jsonl_paths else None,
+                    **hints_status,
                 },
                 ensure_ascii=False,
             )
@@ -1025,6 +1081,7 @@ def main() -> int:
                 "outputJsonlPaths": generated_output_jsonl_paths,
                 "latestInputJsonlPath": generated_input_jsonl_paths[-1] if generated_input_jsonl_paths else None,
                 "latestOutputJsonlPath": generated_output_jsonl_paths[-1] if generated_output_jsonl_paths else None,
+                **hints_status,
             },
             ensure_ascii=False,
         )

--- a/py/tests/test_run_metadata_batches_hints.py
+++ b/py/tests/test_run_metadata_batches_hints.py
@@ -1,0 +1,92 @@
+import run_metadata_batches_promptv1 as mod
+
+
+def test_load_hints_missing_file_is_ai_only(tmp_path):
+    hints, status = mod._load_hints_with_status(str(tmp_path / "missing.yaml"))
+
+    assert not hints
+    assert status == {
+        "hintsPath": str(tmp_path / "missing.yaml"),
+        "hintsFilePresent": False,
+        "hintsParserAvailable": mod.yaml is not None,
+        "hintsLoadable": False,
+        "hintsLoaded": False,
+        "hintsLoadError": None,
+        "hintsAliasCount": 0,
+        "hintsRegexRulesCount": 0,
+    }
+
+
+def test_load_hints_valid_json_reports_counts(tmp_path):
+    hints_path = tmp_path / "program_aliases.json"
+    hints_path.write_text(
+        """{
+  "hints": [
+    {
+      "canonical_title": "Test Program",
+      "aliases": ["Test Alias"]
+    }
+  ],
+  "rules": [
+    {
+      "match": { "regex": "^Test", "field": "base" },
+      "set": { "program_title": "Test Program" }
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    hints, status = mod._load_hints_with_status(str(hints_path))
+
+    assert hints.alias_map[mod._normalize_alias_key("Test Alias")] == "Test Program"
+    assert status["hintsFilePresent"] is True
+    assert status["hintsLoadable"] is True
+    assert status["hintsLoaded"] is True
+    assert status["hintsLoadError"] is None
+    assert status["hintsAliasCount"] == 2
+    assert status["hintsRegexRulesCount"] == 1
+
+
+def test_load_hints_existing_yaml_requires_parser(tmp_path, monkeypatch):
+    hints_path = tmp_path / "program_aliases.yaml"
+    hints_path.write_text("hints: []\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "yaml", None)
+
+    try:
+        mod._load_hints_with_status(str(hints_path))
+    except mod.HintLoadFailure as exc:
+        status = exc.status
+    else:
+        raise AssertionError("expected HintLoadFailure")
+
+    assert status["hintsFilePresent"] is True
+    assert status["hintsParserAvailable"] is False
+    assert status["hintsLoadable"] is False
+    assert status["hintsLoaded"] is False
+    assert "PyYAML is required" in status["hintsLoadError"]
+
+
+def test_load_hints_invalid_yaml_is_hard_failure(tmp_path, monkeypatch):
+    class BrokenYaml:
+        @staticmethod
+        def safe_load(_file):
+            raise ValueError("bad yaml")
+
+    hints_path = tmp_path / "program_aliases.yaml"
+    hints_path.write_text("hints: []\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "yaml", BrokenYaml)
+
+    try:
+        mod._load_hints_with_status(str(hints_path))
+    except mod.HintLoadFailure as exc:
+        status = exc.status
+    else:
+        raise AssertionError("expected HintLoadFailure")
+
+    assert status["hintsFilePresent"] is True
+    assert status["hintsParserAvailable"] is True
+    assert status["hintsLoadable"] is False
+    assert status["hintsLoaded"] is False
+    assert "bad yaml" in status["hintsLoadError"]

--- a/py/tests/test_workflow_cli.py
+++ b/py/tests/test_workflow_cli.py
@@ -6,6 +6,8 @@ from workflow_cli import _cmd_inspect_artifact, _cmd_status
 
 def test_workflow_cli_status_lists_recent_runs(tmp_path):
     ops_root = tmp_path / "ops"
+    hints_path = tmp_path / "program_aliases.json"
+    hints_path.write_text('{"hints": []}\n', encoding="utf-8")
     store = WorkflowStore(ops_root)
     store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_source")
     store.transition_run("run_source", WorkflowPhase.INVENTORY_READY)
@@ -22,10 +24,14 @@ def test_workflow_cli_status_lists_recent_runs(tmp_path):
             run_id="",
             limit=10,
             include_artifacts=False,
+            hints_path=str(hints_path),
         )
     )
 
     assert payload["ok"] is True
+    assert payload["hints"]["ok"] is True
+    assert payload["hints"]["hintsFilePresent"] is True
+    assert payload["hints"]["hintsLoadable"] is True
     assert payload["runs"][0]["runId"] == "run_source"
     assert payload["runs"][0]["phase"] == "inventory_ready"
     assert payload["runs"][0]["nextActions"] == []
@@ -63,6 +69,7 @@ def test_workflow_cli_status_reconstructs_source_root_review_action(tmp_path):
             run_id="run_source_review",
             limit=10,
             include_artifacts=True,
+            hints_path=str(tmp_path / "missing_program_aliases.yaml"),
         )
     )
 
@@ -114,6 +121,7 @@ def test_workflow_cli_status_reconstructs_latest_relocate_plan_action(tmp_path):
             run_id="run_relocate_plan",
             limit=10,
             include_artifacts=False,
+            hints_path=str(tmp_path / "missing_program_aliases.yaml"),
         )
     )
 
@@ -162,6 +170,7 @@ def test_workflow_cli_status_prefers_open_relocate_review_gate_over_stale_queue(
             run_id="run_relocate_review",
             limit=10,
             include_artifacts=False,
+            hints_path=str(tmp_path / "missing_program_aliases.yaml"),
         )
     )
 

--- a/py/workflow_cli.py
+++ b/py/workflow_cli.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from run_metadata_batches_promptv1 import HintLoadFailure, _load_hints_with_status
 from video_pipeline.platform.pathscan_common import windows_to_wsl_path
 from video_pipeline.workflows import (
     NextAction,
@@ -40,6 +41,19 @@ def _parse_json_array(value: str) -> list[str]:
 
 def _store(windows_ops_root: str) -> WorkflowStore:
     return WorkflowStore(_local_path(windows_ops_root))
+
+
+def _default_hints_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "rules" / "program_aliases.yaml"
+
+
+def _hints_status(path: str | None = None) -> dict[str, Any]:
+    hints_path = str(path or _default_hints_path())
+    try:
+        _hints, status = _load_hints_with_status(hints_path)
+        return {"ok": True, **status}
+    except HintLoadFailure as exc:
+        return {"ok": False, **exc.status}
 
 
 def _run_to_status(run: Any, *, include_artifacts: bool) -> dict[str, Any]:
@@ -241,9 +255,11 @@ def _cmd_resume(args: argparse.Namespace) -> dict[str, Any]:
 
 def _cmd_status(args: argparse.Namespace) -> dict[str, Any]:
     store = _store(args.windows_ops_root)
+    hints = _hints_status(getattr(args, "hints_path", "") or None)
     if args.run_id:
         return {
             "ok": True,
+            "hints": hints,
             "run": _run_to_status(store.read_run(args.run_id), include_artifacts=args.include_artifacts),
         }
 
@@ -267,7 +283,13 @@ def _cmd_status(args: argparse.Namespace) -> dict[str, Any]:
         for artifact in artifacts.values():
             if isinstance(artifact, dict):
                 latest_artifacts.append({"runId": run.get("runId"), **artifact})
-    return {"ok": True, "runs": runs, "openGates": open_gates, "latestArtifacts": latest_artifacts[: args.limit]}
+    return {
+        "ok": True,
+        "hints": hints,
+        "runs": runs,
+        "openGates": open_gates,
+        "latestArtifacts": latest_artifacts[: args.limit],
+    }
 
 
 def _cmd_inspect_artifact(args: argparse.Namespace) -> dict[str, Any]:
@@ -336,6 +358,7 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--run-id", default="")
     status.add_argument("--limit", type=int, default=10)
     status.add_argument("--include-artifacts", action="store_true")
+    status.add_argument("--hints-path", default="")
 
     inspect = sub.add_parser("inspect-artifact")
     inspect.add_argument("--windows-ops-root", required=True)

--- a/src/tools/tool-status.ts
+++ b/src/tools/tool-status.ts
@@ -47,14 +47,16 @@ export function registerToolStatus(api: PluginApi, getCfg: GetCfgFn) {
         const latestRelocateApply = latestJsonlFile(moveDir, "relocate_apply_");
         const latestRelocateQueue = latestJsonlFile(llmDir, "relocate_metadata_queue_");
         const hintsYaml = path.join(getExtensionRootDir(), "rules", "program_aliases.yaml");
-        const hintsPresent = fs.existsSync(hintsYaml);
+        const hintsFilePresent = fs.existsSync(hintsYaml);
         const out: AnyObj = {
           ok: true,
           tool: "video_pipeline_status",
           missingConfigKeys,
-          rulesState: hintsPresent ? "configured_optional" : "missing_ai_only_mode",
+          rulesState: hintsFilePresent ? "hints_file_present_runtime_unchecked" : "missing_ai_only_mode",
           hintsPath: hintsYaml,
-          hintsPresent,
+          hintsFilePresent,
+          hintsRuntimeLoadable: null,
+          hintsLoadError: hintsFilePresent ? "legacy status does not execute the Python hints loader" : null,
         };
         if (params.includeRawPaths) {
           out.moveDir = moveDir;

--- a/src/tools/tool-validate.test.ts
+++ b/src/tools/tool-validate.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  extensionRoot: "",
+  runCmd: vi.fn(),
+}));
+
+vi.mock("./runtime", async () => {
+  const actual = await vi.importActual<typeof import("./runtime")>("./runtime");
+  return {
+    ...actual,
+    getExtensionRootDir: vi.fn(() => mocks.extensionRoot),
+    runCmd: mocks.runCmd,
+    toToolResult: vi.fn((obj: Record<string, unknown>) => obj),
+  };
+});
+
+vi.mock("./windows-scripts-bootstrap", () => ({
+  REQUIRED_WINDOWS_SCRIPTS: ["unwatched_inventory.ps1", "apply_move_plan.ps1"],
+  ensureWindowsScripts: vi.fn(() => ({
+    created: [],
+    updated: [],
+    existing: [],
+    failed: [],
+    missingTemplates: [],
+  })),
+}));
+
+import { registerToolValidate } from "./tool-validate";
+
+function createMockApi() {
+  return { registerTool: vi.fn() };
+}
+
+function getRegisteredTool(api: ReturnType<typeof createMockApi>, name: string) {
+  const toolDefs = api.registerTool.mock.calls.map(([def]) => def);
+  const tool = toolDefs.find((def: { name: string }) => def.name === name);
+  expect(tool).toBeTruthy();
+  return tool;
+}
+
+function cfg(root: string) {
+  return {
+    db: path.join(root, "db", "mediaops.sqlite"),
+    sourceRoot: path.join(root, "source"),
+    destRoot: path.join(root, "dest"),
+    windowsOpsRoot: root,
+    defaultMaxFilesPerRun: 200,
+    tsRoot: "",
+    driveRoutesPath: path.join(root, "rules", "drive_routes.yaml"),
+  };
+}
+
+function cmd(ok = true, stderr = "") {
+  return {
+    ok,
+    code: ok ? 0 : 1,
+    stdout: "",
+    stderr,
+    command: "uv",
+    args: [],
+  };
+}
+
+describe("video_pipeline_validate hints readiness", () => {
+  let tempRoot = "";
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join("/tmp", "vlp-validate-"));
+    mocks.extensionRoot = tempRoot;
+    for (const rel of ["db", "move", "llm", "scripts", "rules", "source", "dest"]) {
+      fs.mkdirSync(path.join(tempRoot, rel), { recursive: true });
+    }
+    fs.writeFileSync(path.join(tempRoot, "db", "mediaops.sqlite"), "");
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("marks existing broken program_aliases.yaml as not loadable", async () => {
+    fs.writeFileSync(path.join(tempRoot, "rules", "program_aliases.yaml"), "hints: [\n", "utf-8");
+    mocks.runCmd
+      .mockReturnValueOnce(cmd(true))
+      .mockReturnValueOnce(cmd(true))
+      .mockReturnValueOnce(cmd(true))
+      .mockReturnValueOnce(cmd(true))
+      .mockReturnValueOnce(cmd(false, "yaml.parser.ParserError: expected ',' or ']'"));
+    const api = createMockApi();
+    registerToolValidate(api as never, () => cfg(tempRoot));
+
+    const result = await getRegisteredTool(api, "video_pipeline_validate").execute("call-validate", {
+      checkWindowsInterop: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      checks: {
+        hintsFilePresent: true,
+        hintsParserAvailable: true,
+        hintsLoadable: false,
+        hintsLoadError: "yaml.parser.ParserError: expected ',' or ']'",
+      },
+    });
+    expect(mocks.runCmd).toHaveBeenCalledWith("uv", expect.arrayContaining([path.join(tempRoot, "rules", "program_aliases.yaml")]));
+  });
+});

--- a/src/tools/tool-validate.ts
+++ b/src/tools/tool-validate.ts
@@ -80,10 +80,19 @@ export function registerToolValidate(api: PluginApi, getCfg: GetCfgFn) {
         const hintsParser = hintsFilePresent
           ? runCmd("uv", ["run", "python", "-c", "import yaml"])
           : { ok: true, stderr: "", stdout: "" };
+        const hintsLoad = hintsFilePresent && hintsParser.ok
+          ? runCmd("uv", [
+            "run",
+            "python",
+            "-c",
+            "import sys,yaml; yaml.safe_load(open(sys.argv[1], encoding='utf-8-sig'))",
+            hintsPath,
+          ])
+          : hintsParser;
         checks.hintsParserAvailable = hintsParser.ok;
-        checks.hintsLoadable = !hintsFilePresent || hintsParser.ok;
-        checks.hintsLoadError = hintsFilePresent && !hintsParser.ok
-          ? String(hintsParser.stderr || hintsParser.stdout || "PyYAML is required to load program_aliases.yaml").trim()
+        checks.hintsLoadable = !hintsFilePresent || (hintsParser.ok && hintsLoad.ok);
+        checks.hintsLoadError = hintsFilePresent && !checks.hintsLoadable
+          ? String((!hintsParser.ok ? hintsParser.stderr || hintsParser.stdout : hintsLoad.stderr || hintsLoad.stdout) || "failed to load program_aliases.yaml").trim()
           : "";
 
         if (params.checkWindowsInterop) {

--- a/src/tools/tool-validate.ts
+++ b/src/tools/tool-validate.ts
@@ -41,6 +41,7 @@ export function registerToolValidate(api: PluginApi, getCfg: GetCfgFn) {
         const rulesDir = path.join(getExtensionRootDir(), "rules");
         const scriptsDir = !!cfg.windowsOpsRoot ? path.join(cfg.windowsOpsRoot, "scripts") : "";
         const hintsPath = rulesDir ? path.join(rulesDir, "program_aliases.yaml") : "";
+        const hintsFilePresent = !!hintsPath && fs.existsSync(hintsPath);
         const checks: AnyObj = {
           dbPathConfigured: !!cfg.db,
           dbParentDirExists: !!dbDir && fs.existsSync(dbDir),
@@ -49,7 +50,8 @@ export function registerToolValidate(api: PluginApi, getCfg: GetCfgFn) {
           llmDirExists: !!llmDir && fs.existsSync(llmDir),
           rulesDirExists: !!rulesDir && fs.existsSync(rulesDir),
           scriptsDirExists: !!scriptsDir && fs.existsSync(scriptsDir),
-          hintsYamlPresent: !!hintsPath && fs.existsSync(hintsPath),
+          hintsPath,
+          hintsFilePresent,
           scriptsProvision: {
             created: scriptsProvision.created,
             updated: scriptsProvision.updated,
@@ -75,6 +77,14 @@ export function registerToolValidate(api: PluginApi, getCfg: GetCfgFn) {
         checks.uv = uv.ok;
         checks.pythonViaUv = py.ok;
         checks.sqliteDbOpen = sqliteOpen.ok;
+        const hintsParser = hintsFilePresent
+          ? runCmd("uv", ["run", "python", "-c", "import yaml"])
+          : { ok: true, stderr: "", stdout: "" };
+        checks.hintsParserAvailable = hintsParser.ok;
+        checks.hintsLoadable = !hintsFilePresent || hintsParser.ok;
+        checks.hintsLoadError = hintsFilePresent && !hintsParser.ok
+          ? String(hintsParser.stderr || hintsParser.stdout || "PyYAML is required to load program_aliases.yaml").trim()
+          : "";
 
         if (params.checkWindowsInterop) {
           const pwshCandidates = ["/mnt/c/Program Files/PowerShell/7/pwsh.exe", "pwsh.exe"];
@@ -129,7 +139,9 @@ export function registerToolValidate(api: PluginApi, getCfg: GetCfgFn) {
           if (
             k === "requiredWindowsScripts" ||
             k === "scriptsProvision" ||
-            k === "hintsYamlPresent" ||
+            k === "hintsPath" ||
+            k === "hintsFilePresent" ||
+            k === "hintsLoadError" ||
             k === "moveDirExists" ||
             k === "llmDirExists"
           ) {

--- a/src/tools/tool-workflows.test.ts
+++ b/src/tools/tool-workflows.test.ts
@@ -307,12 +307,20 @@ describe("V2 workflow tools", () => {
   it("returns status and inspect JSON without WorkflowResult translation", async () => {
     const api = createMockApi();
     registerWorkflowTools(api as never, () => cfg());
-    vi.mocked(runCmd).mockReturnValueOnce(cmdResult({ ok: true, runs: [{ runId: "run_a" }] }));
+    vi.mocked(runCmd).mockReturnValueOnce(cmdResult({
+      ok: true,
+      hints: { ok: true, hintsFilePresent: true, hintsLoadable: true },
+      runs: [{ runId: "run_a" }],
+    }));
     const status = await getRegisteredTool(api, "video_pipeline_status").execute("call-4", {
       limit: 5,
       includeArtifacts: true,
     });
-    expect(status).toEqual({ ok: true, runs: [{ runId: "run_a" }] });
+    expect(status).toEqual({
+      ok: true,
+      hints: { ok: true, hintsFilePresent: true, hintsLoadable: true },
+      runs: [{ runId: "run_a" }],
+    });
     expect(runCmd).toHaveBeenLastCalledWith("uv", expect.arrayContaining([
       "status",
       "--limit",


### PR DESCRIPTION
## Summary
- Fail metadata extraction when an existing program_aliases YAML cannot be loaded
- Expose structured hints readiness in extraction summaries and V2 status
- Update legacy status/validate signals, docs, and tests

## Validation
- pytest -q py/tests
- npm test

Closes #100