### PR TITLE
Keep workflow status output pure JSON

### DIFF
--- a/py/run_metadata_batches_promptv1.py
+++ b/py/run_metadata_batches_promptv1.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sqlite3
+import sys
 import unicodedata
 from pathlib import Path, PurePath
 from typing import Any
@@ -289,7 +290,7 @@ def _load_hints_with_status(path: str | None) -> tuple[HintSet, dict[str, Any]]:
         return HintSet(), status
     p = Path(path)
     if not p.exists():
-        print(f"W hints file missing: {p}")
+        print(f"W hints file missing: {p}", file=sys.stderr)
         return HintSet(), status
     status["hintsFilePresent"] = True
 

--- a/py/tests/test_run_metadata_batches_hints.py
+++ b/py/tests/test_run_metadata_batches_hints.py
@@ -1,9 +1,12 @@
 import run_metadata_batches_promptv1 as mod
 
 
-def test_load_hints_missing_file_is_ai_only(tmp_path):
+def test_load_hints_missing_file_is_ai_only_and_stdout_clean(tmp_path, capsys):
     hints, status = mod._load_hints_with_status(str(tmp_path / "missing.yaml"))
 
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "W hints file missing" in captured.err
     assert not hints
     assert status == {
         "hintsPath": str(tmp_path / "missing.yaml"),

--- a/py/tests/test_workflow_cli.py
+++ b/py/tests/test_workflow_cli.py
@@ -40,6 +40,30 @@ def test_workflow_cli_status_lists_recent_runs(tmp_path):
     assert payload["openGates"][0]["id"] == "metadata_review"
 
 
+def test_workflow_cli_status_missing_hints_keeps_stdout_clean(tmp_path, capsys):
+    ops_root = tmp_path / "ops"
+    store = WorkflowStore(ops_root)
+    store.init_run(WorkflowFlow.SOURCE_ROOT, run_id="run_source")
+
+    payload = _cmd_status(
+        argparse.Namespace(
+            windows_ops_root=str(ops_root),
+            run_id="",
+            limit=10,
+            include_artifacts=False,
+            hints_path=str(tmp_path / "missing_program_aliases.yaml"),
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "W hints file missing" in captured.err
+    assert payload["ok"] is True
+    assert payload["hints"]["ok"] is True
+    assert payload["hints"]["hintsFilePresent"] is False
+    assert payload["hints"]["hintsLoadable"] is False
+
+
 def test_workflow_cli_status_reconstructs_source_root_review_action(tmp_path):
     ops_root = tmp_path / "ops"
     store = WorkflowStore(ops_root)


### PR DESCRIPTION
## Summary
- Move missing hints warnings from stdout to stderr so workflow_cli status keeps stdout parseable as a single JSON object
- Add regression coverage for missing hints readiness and clean stdout

## Validation
- pytest -q py/tests
- npm test

Fixes the review finding from the duplicate PR #129.